### PR TITLE
refactor: replace NULL -> nullptr where applicable

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,7 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- native/c: Enable `langlvl(extended0x)` for C++ code to support C++0x features (`auto`, `nullptr`, etc.) [#35](https://github.com/zowe/zowe-native-proto/pull/35)
+- `c`: Replace all applicable `NULL` references with `nullptr` in C++ code. [#36](https://github.com/zowe/zowe-native-proto/pull/36)
+- `c`: Enable `langlvl(extended0x)` for C++ code to support C++0x features (`auto`, `nullptr`, etc.) [#35](https://github.com/zowe/zowe-native-proto/pull/35)
 
 ## [Unreleased]
 

--- a/native/c/zcli.hpp
+++ b/native/c/zcli.hpp
@@ -245,7 +245,7 @@ bool ZCLI::validate()
       verb_map.insert(map<string, int>::value_type(iit->get_name(), 0));
 
       // ensure handler provided
-      if (NULL == iit->get_zcli_verb_handler())
+      if (iit->get_zcli_verb_handler() == nullptr)
       {
         cerr << "ZCLI Error: each verb must container a handler, " << iit->get_name() << " does not" << endl;
         return false;
@@ -492,7 +492,7 @@ int ZCLI::run(int argc, char *argv[])
   ZCLIVerb &verb = group.get_verb(argv[CLI_VERB_ARG]);
 
   // show group level help if unknwon verb
-  if (NULL == verb.get_zcli_verb_handler())
+  if (verb.get_zcli_verb_handler() == nullptr)
   {
     // delete command_group;
     cerr << "Unknown command verb: " << argv[CLI_VERB_ARG] << endl;

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -266,7 +266,7 @@ int zds_list_members(ZDS *zds, string dsn, vector<ZDSMem> &list)
 
   while (fread(&rec, sizeof *buffer, sizeof(RECORD), fp))
   {
-    unsigned char *data = NULL;
+    unsigned char *data = nullptr;
     data = (unsigned char *)&rec;
     data += sizeof(rec.count); // increment past halfword length
     int len = sizeof(RECORD_ENTRY);
@@ -521,7 +521,7 @@ int zds_list_data_sets(ZDS *zds, string dsn, vector<ZDSEntry> &attributes)
 
     int work_area_total = csi_work_area->header.used_size;
     unsigned char *p = (unsigned char *)&csi_work_area->entry;
-    ZDS_CSI_ENTRY *f = NULL;
+    ZDS_CSI_ENTRY *f = nullptr;
 
     work_area_total -= sizeof(ZDS_CSI_HEADER);
     work_area_total -= sizeof(ZDS_CSI_CATALOG);

--- a/native/c/zjb.cpp
+++ b/native/c/zjb.cpp
@@ -128,7 +128,7 @@ int zjb_read_job_jcl_by_jobid(ZJB *zjb, string jobid, string &response)
 int zjb_read_job_content_by_dsn(ZJB *zjb, string jobdsn, string &response)
 {
   int rc = 0;
-  unsigned char *p = NULL;
+  unsigned char *p = nullptr;
   ZDS zds = {0};
 
   // calculate total size needed, obtain, & clear
@@ -370,7 +370,7 @@ int zjb_submit(ZJB *zjb, string data_set, string &jobId)
 int zjb_list_dds_by_jobid(ZJB *zjb, string jobid, vector<ZJobDD> &jobDDs)
 {
   int rc = 0;
-  STATSEVB *PTR64 sysoutInfo = NULL;
+  STATSEVB *PTR64 sysoutInfo = nullptr;
   int entries = 0;
 
   if (0 == zjb->buffer_size)
@@ -431,7 +431,7 @@ int zjb_list_dds_by_jobid(ZJB *zjb, string jobid, vector<ZJobDD> &jobDDs)
 int zjb_view_by_jobid(ZJB *zjb, string jobid, ZJob &job)
 {
   int rc = 0;
-  STATJQTR *PTR64 jobInfo = NULL;
+  STATJQTR *PTR64 jobInfo = nullptr;
   int entries = 0;
 
   ///
@@ -550,7 +550,7 @@ int zjb_view_by_jobid(ZJB *zjb, string jobid, ZJob &job)
 int zjb_list_by_owner(ZJB *zjb, string owner_name, vector<ZJob> &jobs)
 {
   int rc = 0;
-  STATJQTR *PTR64 jobInfo = NULL;
+  STATJQTR *PTR64 jobInfo = nullptr;
   int entries = 0;
 
   if ("" == owner_name)

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -68,7 +68,7 @@ int zusf_create_uss_file_or_dir(ZUSF *zusf, string file, string mode, bool creat
   // TODO(zFernand0): `mkdirp` when creatnig a file in a directory that doesn't exist
   if (createDir)
   {
-    mkdir(file.c_str(), strtol(mode.c_str(), NULL, 8));
+    mkdir(file.c_str(), strtol(mode.c_str(), nullptr, 8));
     return RTNCD_SUCCESS;
   }
   else
@@ -77,7 +77,7 @@ int zusf_create_uss_file_or_dir(ZUSF *zusf, string file, string mode, bool creat
     if (out.is_open())
     {
       out.close();
-      chmod(file.c_str(), strtol(mode.c_str(), NULL, 8));
+      chmod(file.c_str(), strtol(mode.c_str(), nullptr, 8));
       return RTNCD_SUCCESS;
     }
   }
@@ -120,7 +120,7 @@ int zusf_list_uss_file_path(ZUSF *zusf, string file, string &response)
   }
 
   DIR *dir;
-  if ((dir = opendir(file.c_str())) == NULL)
+  if ((dir = opendir(file.c_str())) == nullptr)
   {
     zusf->diag.e_msg_len = sprintf(zusf->diag.e_msg, "Could not open directory '%s'", file.c_str());
     return RTNCD_FAILURE;
@@ -128,7 +128,7 @@ int zusf_list_uss_file_path(ZUSF *zusf, string file, string &response)
 
   struct dirent *entry;
   response.clear();
-  while ((entry = readdir(dir)) != NULL)
+  while ((entry = readdir(dir)) != nullptr)
   {
     // TODO(zFernand0): Skip hidden files
     if ((strcmp(entry->d_name, ".") != 0) && (strcmp(entry->d_name, "..") != 0))
@@ -253,6 +253,6 @@ int zusf_chmod_uss_file_or_dir(ZUSF *zusf, string file, string mode)
     zusf->diag.e_msg_len = sprintf(zusf->diag.e_msg, "Path '%s' does not exist", file.c_str());
     return RTNCD_FAILURE;
   }
-  chmod(file.c_str(), strtol(mode.c_str(), NULL, 8));
+  chmod(file.c_str(), strtol(mode.c_str(), nullptr, 8));
   return 0;
 }

--- a/native/c/zut.cpp
+++ b/native/c/zut.cpp
@@ -316,7 +316,7 @@ char *zut_encode_alloc(const string &bytes, const string &from_encoding, const s
   if (cd == (iconv_t)(-1))
   {
     diag.e_msg_len = sprintf(diag.e_msg, "Cannot open converter from %s to %s", from_encoding.c_str(), to_encoding.c_str());
-    return NULL;
+    return nullptr;
   }
 
   const size_t input_size = bytes.size();
@@ -334,7 +334,7 @@ char *zut_encode_alloc(const string &bytes, const string &from_encoding, const s
   {
     diag.e_msg_len = sprintf(diag.e_msg, "Error when converting characters");
     delete[] outbuf;
-    return NULL;
+    return nullptr;
   }
   *buf_end = outptr;
   iconv_close(cd);


### PR DESCRIPTION
**What It Does**

Now that `langlvl(extended0x)` is used for C++ code, we should use `nullptr` instead of `NULL` when assigning default values for pointers.

**How to Test**

Build this branch and notice the successful complication. Test the `zowex` binary (using the shell script or a few test commands) to verify behavior is still as expected.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
