### PR TITLE
refactor: support ds & uss write w/ encoding; cleanup encoding logic

### DIFF
--- a/native/c/zut.hpp
+++ b/native/c/zut.hpp
@@ -29,7 +29,7 @@ int zut_convert_dsect();
 bool zut_prepare_encoding(ZCLIResult &result, ZEncode *opts);
 void zut_print_string_as_bytes(std::string &input);
 
-char *zut_encode_alloc(const std::string &bytes, const std::string &from_encoding, const std::string &to_encoding, ZDIAG &diag, char **buf_end);
+std::string zut_encode_alloc(const string &bytes, const string &from_encoding, const string &to_encoding, ZDIAG &diag);
 std::string zut_format_as_csv(std::vector<std::string> &fields);
 std::string &zut_rtrim(std::string &s, const char *t = " ");
 std::string &zut_ltrim(std::string &s, const char *t = " ");


### PR DESCRIPTION
**What It Does**

Adds support for writing w/ encoding for data sets and USS files.
Currently dealing with an issue with piping bytes between Go and C++, but the logic works independent of the Go layer

**How to Test**

- Run this command in a shell on z/OS: `echo "\xc3\xb6\xc3\xb6\xc3\xb6" | ./zowe data-set write "USER.TESTPDS(MEMB)" --encoding ISO8859-1`
- Open the data set member in ZE using z/OSMF or ZNP using ISO8859-1 encoding
- Notice the contents are `ööö`
  - z/OSMF seems to have a bug where it inserts an NAK at the end of the data. This could be an issue with one of the Zowe SDKs.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
