### PR TITLE
Fix ioserver comms over non-Bash shell

### DIFF
--- a/native/golang/cmdutils.go
+++ b/native/golang/cmdutils.go
@@ -19,7 +19,7 @@ import (
 
 var exePath string
 
-func buildExecCommand(args []string) *exec.Cmd {
+func buildCommand(args []string) *exec.Cmd {
 	cmd := exec.Command(args[0], args[1:]...)
 	if exePath == "" {
 		path, err := os.Executable()

--- a/native/golang/cmdutils.go
+++ b/native/golang/cmdutils.go
@@ -17,11 +17,16 @@ import (
 	"path/filepath"
 )
 
+var exePath string
+
 func buildExecCommand(args []string) *exec.Cmd {
 	cmd := exec.Command(args[0], args[1:]...)
-	exePath, err := os.Executable()
-	if err != nil {
-		panic(err)
+	if exePath == "" {
+		path, err := os.Executable()
+		if err != nil {
+			panic(err)
+		}
+		exePath = path
 	}
 	cmd.Dir = filepath.Dir(exePath)
 	cmd.Env = append(os.Environ(), "_BPXK_AUTOCVT=ON")

--- a/native/golang/cmdutils.go
+++ b/native/golang/cmdutils.go
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func buildExecCommand(args []string) *exec.Cmd {
+	cmd := exec.Command(args[0], args[1:]...)
+	exePath, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	cmd.Dir = filepath.Dir(exePath)
+	cmd.Env = append(os.Environ(), "_BPXK_AUTOCVT=ON")
+	return cmd
+}

--- a/native/golang/ds.go
+++ b/native/golang/ds.go
@@ -33,7 +33,7 @@ func HandleReadDatasetRequest(jsonData []byte) {
 	if hasEncoding {
 		args = append(args, "--encoding", dsRequest.Encoding)
 	}
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -82,7 +82,7 @@ func HandleWriteDatasetRequest(jsonData []byte) {
 	if len(dsRequest.Encoding) > 0 {
 		args = append(args, "--encoding", dsRequest.Encoding)
 	}
-	cmd := buildExecCommand(args)
+	cmd := buildCommand(args)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		log.Println("Error opening stdin pipe:", err)
@@ -139,7 +139,7 @@ func HandleListDatasetsRequest(jsonData []byte) {
 	// 	args = append(args, "--start", listRequest.Start)
 	// }
 
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -182,7 +182,7 @@ func HandleListDsMembersRequest(jsonData []byte) {
 	// 	args = append(args, "--start", listRequest.Start)
 	// }
 
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -222,7 +222,7 @@ func HandleRestoreDatasetRequest(jsonData []byte) {
 
 	args := []string{"./zowex", "data-set", "restore", dsRequest.Dataset}
 
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		log.Println(string(out))

--- a/native/golang/ds.go
+++ b/native/golang/ds.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strings"
 )
 
@@ -34,7 +33,7 @@ func HandleReadDatasetRequest(jsonData []byte) {
 	if hasEncoding {
 		args = append(args, "--encoding", dsRequest.Encoding)
 	}
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -49,7 +48,7 @@ func HandleReadDatasetRequest(jsonData []byte) {
 	}
 	v, err := json.Marshal(dsResponse)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}
@@ -83,7 +82,7 @@ func HandleWriteDatasetRequest(jsonData []byte) {
 	if len(dsRequest.Encoding) > 0 {
 		args = append(args, "--encoding", dsRequest.Encoding)
 	}
-	cmd := exec.Command(args[0], args[1:]...)
+	cmd := buildExecCommand(args)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		log.Println("Error opening stdin pipe:", err)
@@ -119,7 +118,7 @@ func HandleWriteDatasetRequest(jsonData []byte) {
 	}
 	v, err := json.Marshal(dsResponse)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}
@@ -140,7 +139,7 @@ func HandleListDatasetsRequest(jsonData []byte) {
 	// 	args = append(args, "--start", listRequest.Start)
 	// }
 
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -164,7 +163,7 @@ func HandleListDatasetsRequest(jsonData []byte) {
 
 	v, err := json.Marshal(dsResponse)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}
@@ -183,7 +182,7 @@ func HandleListDsMembersRequest(jsonData []byte) {
 	// 	args = append(args, "--start", listRequest.Start)
 	// }
 
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -208,7 +207,7 @@ func HandleListDsMembersRequest(jsonData []byte) {
 
 	v, err := json.Marshal(dsResponse)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}
@@ -223,7 +222,7 @@ func HandleRestoreDatasetRequest(jsonData []byte) {
 
 	args := []string{"./zowex", "data-set", "restore", dsRequest.Dataset}
 
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		log.Println(string(out))
@@ -235,7 +234,7 @@ func HandleRestoreDatasetRequest(jsonData []byte) {
 	}
 	v, err := json.Marshal(dsResponse)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}

--- a/native/golang/issue.go
+++ b/native/golang/issue.go
@@ -25,7 +25,7 @@ func HandleConsoleCommandRequest(jsonData []byte) {
 		return
 	}
 	args := []string{"./zowexx", "console", "issue", request.Command, "--cn", request.Console}
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		log.Println(string(out))

--- a/native/golang/issue.go
+++ b/native/golang/issue.go
@@ -15,7 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os/exec"
+	"os"
 )
 
 func HandleConsoleCommandRequest(jsonData []byte) {
@@ -25,7 +25,7 @@ func HandleConsoleCommandRequest(jsonData []byte) {
 		return
 	}
 	args := []string{"./zowexx", "console", "issue", request.Command, "--cn", request.Console}
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		log.Println(string(out))
@@ -37,7 +37,7 @@ func HandleConsoleCommandRequest(jsonData []byte) {
 	}
 	v, err := json.Marshal(response)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}

--- a/native/golang/job.go
+++ b/native/golang/job.go
@@ -33,7 +33,7 @@ func HandleListJobsRequest(jsonData []byte) {
 		args = append(args, "--owner", listRequest.Owner)
 	}
 
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -76,7 +76,7 @@ func HandleListSpoolsRequest(jsonData []byte) {
 
 	args := []string{"./zowex", "job", "list-files", listRequest.JobId, "--rfc", "true"}
 
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -127,7 +127,7 @@ func HandleReadSpoolRequest(jsonData []byte) {
 	if hasEncoding {
 		args = append(args, "--encoding", request.Encoding)
 	}
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -158,7 +158,7 @@ func HandleGetJclRequest(jsonData []byte) {
 	}
 	// log.Println("GetJclRequest received:", ...)
 	args := []string{"./zowex", "job", "view-jcl", request.JobId}
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -183,7 +183,7 @@ func HandleGetStatusRequest(jsonData []byte) {
 		return
 	}
 	args := []string{"./zowex", "job", "view-status", request.JobId, "--rfc", "true"}
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return

--- a/native/golang/job.go
+++ b/native/golang/job.go
@@ -15,7 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os/exec"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -33,7 +33,7 @@ func HandleListJobsRequest(jsonData []byte) {
 		args = append(args, "--owner", listRequest.Owner)
 	}
 
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -60,7 +60,7 @@ func HandleListJobsRequest(jsonData []byte) {
 
 	v, err := json.Marshal(jobsResponse)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}
@@ -76,7 +76,7 @@ func HandleListSpoolsRequest(jsonData []byte) {
 
 	args := []string{"./zowex", "job", "list-files", listRequest.JobId, "--rfc", "true"}
 
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -108,7 +108,7 @@ func HandleListSpoolsRequest(jsonData []byte) {
 
 	v, err := json.Marshal(response)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}
@@ -127,7 +127,7 @@ func HandleReadSpoolRequest(jsonData []byte) {
 	if hasEncoding {
 		args = append(args, "--encoding", request.Encoding)
 	}
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -143,7 +143,7 @@ func HandleReadSpoolRequest(jsonData []byte) {
 	}
 	v, err := json.Marshal(response)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}
@@ -158,7 +158,7 @@ func HandleGetJclRequest(jsonData []byte) {
 	}
 	// log.Println("GetJclRequest received:", ...)
 	args := []string{"./zowex", "job", "view-jcl", request.JobId}
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -170,7 +170,7 @@ func HandleGetJclRequest(jsonData []byte) {
 	}
 	v, err := json.Marshal(response)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}
@@ -183,7 +183,7 @@ func HandleGetStatusRequest(jsonData []byte) {
 		return
 	}
 	args := []string{"./zowex", "job", "view-status", request.JobId, "--rfc", "true"}
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -210,7 +210,7 @@ func HandleGetStatusRequest(jsonData []byte) {
 
 	v, err := json.Marshal(jobsResponse)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}

--- a/native/golang/uss.go
+++ b/native/golang/uss.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 )
 
@@ -65,7 +64,7 @@ func HandleListFilesRequest(jsonData []byte) {
 
 	v, err := json.Marshal(ussResponse)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}
@@ -84,7 +83,7 @@ func HandleReadFileRequest(jsonData []byte) {
 	if hasEncoding {
 		args = append(args, "--encoding", request.Encoding)
 	}
-	out, err := exec.Command(args[0], args[1:]...).Output()
+	out, err := buildExecCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -99,7 +98,7 @@ func HandleReadFileRequest(jsonData []byte) {
 	}
 	v, err := json.Marshal(response)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}
@@ -133,7 +132,7 @@ func HandleWriteFileRequest(jsonData []byte) {
 	if len(request.Encoding) > 0 {
 		args = append(args, "--encoding", request.Encoding)
 	}
-	cmd := exec.Command(args[0], args[1:]...)
+	cmd := buildExecCommand(args)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		log.Println("Error opening stdin pipe:", err)
@@ -169,7 +168,7 @@ func HandleWriteFileRequest(jsonData []byte) {
 	}
 	v, err := json.Marshal(response)
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 	} else {
 		fmt.Println(string(v))
 	}

--- a/native/golang/uss.go
+++ b/native/golang/uss.go
@@ -83,7 +83,7 @@ func HandleReadFileRequest(jsonData []byte) {
 	if hasEncoding {
 		args = append(args, "--encoding", request.Encoding)
 	}
-	out, err := buildExecCommand(args).Output()
+	out, err := buildCommand(args).Output()
 	if err != nil {
 		log.Println("Error executing command:", err)
 		return
@@ -132,7 +132,7 @@ func HandleWriteFileRequest(jsonData []byte) {
 	if len(request.Encoding) > 0 {
 		args = append(args, "--encoding", request.Encoding)
 	}
-	cmd := buildExecCommand(args)
+	cmd := buildCommand(args)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		log.Println("Error opening stdin pipe:", err)

--- a/packages/sdk/src/ZSshClient.ts
+++ b/packages/sdk/src/ZSshClient.ts
@@ -13,15 +13,16 @@ import * as fs from "node:fs";
 import type { Writable } from "node:stream";
 import { DeferredPromise } from "@zowe/imperative";
 import type { SshSession } from "@zowe/zos-uss-for-zowe-sdk";
-import { Client, type ClientChannel, type ConnectConfig } from "ssh2";
+import { Client, type ClientChannel, type ConnectConfig, type PseudoTtyOptions } from "ssh2";
 import { AbstractRpcClient } from "./AbstractRpcClient";
 import type { IRpcRequest, IRpcResponse } from "./doc";
 
 export class ZSshClient extends AbstractRpcClient implements Disposable {
-    private static readonly SERVER_CMD = "cd zowe-native-proto/golang && ./ioserver";
+    private static readonly PTY_OPTIONS: PseudoTtyOptions = { modes: { ECHO: 0 } };
+    private static readonly SERVER_CMD = "./zowe-native-proto/golang/ioserver";
 
     private mSshClient: Client;
-    private mSshStream: ClientChannel | undefined;
+    private mSshStream: ClientChannel;
     private mResponse = "";
     private mResponseStream: Writable | undefined;
     private sshMutex: DeferredPromise<void> | undefined;
@@ -36,20 +37,13 @@ export class ZSshClient extends AbstractRpcClient implements Disposable {
         client.mSshClient.connect(ZSshClient.buildConnectConfig(session));
         client.mSshStream = await new Promise((resolve, reject) => {
             client.mSshClient.on("ready", () => {
-                client.mSshClient.shell(false, (err, stream) => {
+                client.mSshClient.exec(ZSshClient.SERVER_CMD, { pty: ZSshClient.PTY_OPTIONS }, (err, stream) => {
                     if (err) {
                         reject(err);
                     } else {
                         stream.stderr.on("data", (chunk: Buffer) => {
                             console.log("STDERR:", chunk.toString());
                         });
-                        // stream.stdin.on("data", (chunk: Buffer) => {
-                        //     console.log("STDIN:", chunk.toString());
-                        // });
-                        // stream.stdout.on("data", (chunk: Buffer) => {
-                        //     console.log("STDOUT:", chunk.toString());
-                        // });
-                        stream.write(`${ZSshClient.SERVER_CMD}\n`);
                         // console.log("client ready");
                         resolve(stream);
                     }
@@ -74,9 +68,9 @@ export class ZSshClient extends AbstractRpcClient implements Disposable {
         this.mResponseStream = stream;
 
         return new Promise((resolve, reject) => {
-            this.mSshStream!.stdin.write(`${JSON.stringify(request)}\n`);
-            this.mSshStream!.stderr.on("data", this.onErrData.bind(this, reject));
-            this.mSshStream!.stdout.on(
+            this.mSshStream.stdin.write(`${JSON.stringify(request)}\n`);
+            this.mSshStream.stderr.on("data", this.onErrData.bind(this, reject));
+            this.mSshStream.stdout.on(
                 "data",
                 this.onOutData.bind(this, (response: any) => resolve(JSON.parse(response))),
             );
@@ -111,15 +105,15 @@ export class ZSshClient extends AbstractRpcClient implements Disposable {
         } else {
             this.mResponse += chunk;
         }
-        if (endsWithNewLine) {
+        if (endsWithNewLine && this.mResponse.trim()) {
             this.requestEnd();
             resolve(this.mResponse);
         }
     }
 
     private requestEnd() {
-        this.mSshStream!.stderr.removeAllListeners();
-        this.mSshStream!.stdout.removeAllListeners();
+        this.mSshStream.stderr.removeAllListeners();
+        this.mSshStream.stdout.removeAllListeners();
         this.mResponseStream?.end();
         this.sshMutex?.resolve();
     }

--- a/packages/sdk/src/ZSshClient.ts
+++ b/packages/sdk/src/ZSshClient.ts
@@ -18,7 +18,8 @@ import { AbstractRpcClient } from "./AbstractRpcClient";
 import type { IRpcRequest, IRpcResponse } from "./doc";
 
 export class ZSshClient extends AbstractRpcClient implements Disposable {
-    private static readonly PTY_OPTIONS: PseudoTtyOptions = { modes: { ECHO: 0 } };
+    // https://github.com/mscdex/ssh2/blob/master/lib/protocol/constants.js#L252
+    private static readonly PTY_OPTIONS: PseudoTtyOptions = { modes: { ECHO: 0, ECHONL: 0 } };
     private static readonly SERVER_CMD = "./zowe-native-proto/golang/ioserver";
 
     private mSshClient: Client;
@@ -105,7 +106,7 @@ export class ZSshClient extends AbstractRpcClient implements Disposable {
         } else {
             this.mResponse += chunk;
         }
-        if (endsWithNewLine && this.mResponse.trim()) {
+        if (endsWithNewLine) {
             this.requestEnd();
             resolve(this.mResponse);
         }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes several limitations related to SSH and ioserver:
* Enables `pty` mode for SSH connection to support `sh`
  * Echo is disabled to prevent `stdin` being piped to `stdout`
  * Pty mode merges `stdout` and `stderr` into a single stream
* Fixes #9 
  * Using `exec` instead of `shell` bypasses user login script
* Fixes #42 
  * `ioserver` now invokes `zowex` in the executable directory

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
