### PR TITLE
prevent s0c4 if verb not found

### DIFF
--- a/native/c/zcli.hpp
+++ b/native/c/zcli.hpp
@@ -52,11 +52,11 @@ protected:
 
 public:
   ZCLIRequired() { required = false; }
-  void set_found(bool f) { found = f; }
-  bool is_found() { return found; }
+  virtual void set_found(bool f) { found = f; }
+  virtual bool is_found() { return found; }
 
-  void set_required(bool r) { required = r; }
-  bool get_required() { return required; }
+  virtual void set_required(bool r) { required = r; }
+  virtual bool get_required() { return required; }
 };
 
 class ZCLIDescription
@@ -492,7 +492,7 @@ int ZCLI::run(int argc, char *argv[])
   ZCLIVerb &verb = group.get_verb(argv[CLI_VERB_ARG]);
 
   // show group level help if unknwon verb
-  if (verb.get_zcli_verb_handler() == nullptr)
+  if (verb.get_name() == "not found")
   {
     // delete command_group;
     cerr << "Unknown command verb: " << argv[CLI_VERB_ARG] << endl;


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
`zowex job l` for example causes s0c4 abend. this is a quick fix to prevent that and surface an error message instead

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
