### PR TITLE
fix: pass binary as encoding value in VSCE

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "zowe-native-proto-vsce" extension will be documented
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- Fixed issue where `Open with Encoding: Binary` for MVS and USS files did not pass the correct encoding value to the server. [#61](https://github.com/zowe/zowe-native-proto/pull/61)
+
 ## [Unreleased]
 
 - Initial release

--- a/packages/vsce/src/api/SshMvsApi.ts
+++ b/packages/vsce/src/api/SshMvsApi.ts
@@ -42,7 +42,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
     ): Promise<zosfiles.IZosFilesResponse> {
         const response = await (await this.client).ds.readDataset({
             dataset: dataSetName,
-            encoding: options.encoding ?? "IBM-1047",
+            encoding: options.binary ? "binary" : (options.encoding ?? "IBM-1047"),
         });
         if (options.file != null) {
             imperative.IO.createDirsSyncFromFilePath(options.file);
@@ -64,7 +64,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         console.log(buf);
         const response = await (await this.client).ds.writeDataset({
             dataset: dataSetName,
-            encoding: options?.encoding ?? "IBM-1047",
+            encoding: options?.binary ? "binary" : (options?.encoding ?? "IBM-1047"),
             contents: ZSshUtils.encodeByteArray(buffer),
         });
         return this.buildZosFilesResponse({ etag: dataSetName });

--- a/packages/vsce/src/api/SshUssApi.ts
+++ b/packages/vsce/src/api/SshUssApi.ts
@@ -36,7 +36,7 @@ export class SshUssApi extends SshCommonApi implements MainframeInteraction.IUss
     ): Promise<zosfiles.IZosFilesResponse> {
         const response = await (await this.client).uss.readFile({
             path: ussFilePath,
-            encoding: options.encoding ?? "IBM-1047",
+            encoding: options.binary ? "binary" : (options.encoding ?? "IBM-1047"),
         });
         if (options.file != null) {
             imperative.IO.createDirsSyncFromFilePath(options.file);
@@ -55,7 +55,7 @@ export class SshUssApi extends SshCommonApi implements MainframeInteraction.IUss
     ): Promise<zosfiles.IZosFilesResponse> {
         const response = await (await this.client).uss.writeFile({
             path: filePath,
-            encoding: options?.encoding,
+            encoding: options?.binary ? "binary" : (options?.encoding ?? "IBM-1047"),
             contents: ZSshUtils.encodeByteArray(buffer),
         });
         return this.buildZosFilesResponse({ etag: filePath });


### PR DESCRIPTION
**What It Does**

Resolves comment about "Open w/ Encoding: Binary" in #34 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
