### PR TITLE
fix #58

### DIFF
--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -291,12 +291,12 @@ int zds_list_members(ZDS *zds, string dsn, vector<ZDSMem> &list)
         unsigned char info = entry.info;
         unsigned char pointer_count = entry.info;
         char name[9] = {0};
-        if (info & 0x80)
+        if (info & 0x80) // bit 0 indicates alias
         {
           // TODO(Kelosky): // member name is an alias
         }
         pointer_count & 0x60; // bits 1-2 contain number of user data TTRNs
-        pointer_count >>= 5;  // adjust to halfword boundary
+        pointer_count >>= 5;  // adjust to byte boundary
         info &= 0x1F;         // bits 3-7 contain the number of half words of user data
 
         memcpy(name, entry.name, sizeof(entry.name));


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Three things:
- If directory entry has less bytes remaining than the size of a specific entry, no more records can remain.  
- Defaults to returning maximum of 100 entries which can be overridden by a parm
- Truncation warning issued by default, may be disabled via `--warn false`

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

Number of members match ISPF display:

<img width="633" alt="image" src="https://github.com/user-attachments/assets/36ab5660-20d5-4b22-80d2-71aa6de17a5b" />

```
bash-4.3$ zowex data-set list-members sys1.maclib  --max-entries 2500 | wc -l
   2078 
```


**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
