### PR TITLE
refactor: Add watch tasks for `watch:native`, cleanup code & add JSDoc

### DIFF
--- a/scripts/watchNative.js
+++ b/scripts/watchNative.js
@@ -159,7 +159,7 @@ async function performActionOnFile(localPath, remotePath, action) {
             reject(err);
           });
 
-          writeStream.on("close", () => {
+          writeStream.on("finish", () => {
             resolve();
           });
 

--- a/scripts/watchNative.js
+++ b/scripts/watchNative.js
@@ -89,7 +89,7 @@ function invokeTaskAndPrintStatus(task, cmd, resolve) {
     }
 
     stream
-      .on("close", () => {
+      .on("end", () => {
         if (errText.length === 0) {
           console.log(`\n  [tasks -> ${task}] ${taskCmd} succeeded ✔`);
         } else {
@@ -100,7 +100,7 @@ function invokeTaskAndPrintStatus(task, cmd, resolve) {
         }
         resolve();
       })
-      .on("data", (data) => {
+      .stderr.on("data", (data) => {
         let str = data.toString().trim();
         if (
           str === "$" ||

--- a/tools/build/tasks.default.json
+++ b/tools/build/tasks.default.json
@@ -1,0 +1,4 @@
+{
+    "c": "make",
+    "golang": "go build"
+}


### PR DESCRIPTION
**What It Does**

- **Native watch tasks:** Makes the `watch:native` mode customizable by reading from a JSON tasks file
  - This helps for debugging, passing different build flags, different binary names/compilers, running commands before build, etc. 😋 
  - If `tasks.local.json` is not present in `tools/build`, the watch mode will use `tools/build/tasks.default.json`
- Fixes issue where deleting a file caused the script to crash
- Cleans up the code by adding comments and shared logic
- Adds JSDoc to help maintain the script

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
