### PR TITLE
Support compiling ioserver off z/OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
-name: client-build
+name: build
 
 on: [pull_request]
 
 jobs:
-  build:
+  build-client:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -41,3 +41,12 @@ jobs:
         with:
           name: zowe-native-proto-vsce
           path: dist/*.vsix
+
+  build-native:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: cd native/golang && go build

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ zowe-native-proto-package
 # Files
 .DS_Store
 config.*.json
+native/golang/ioserver*
 tsconfig.tsbuildinfo
 zowe.config.json
 zowe.schema.json

--- a/native/golang/utils/zos.go
+++ b/native/golang/utils/zos.go
@@ -1,3 +1,5 @@
+//go:build zos
+
 /**
  * This program and the accompanying materials are made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution, and is available at

--- a/native/golang/utils/zos_mock.go
+++ b/native/golang/utils/zos_mock.go
@@ -1,0 +1,16 @@
+//go:build !zos
+
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+package utils
+
+func SetAutoConvOnUntaggedStdio() {}

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -155,7 +155,8 @@ function getAllServerFiles() {
     for (const dir of dirs) {
         files.push(...getServerFiles(dir));
     }
-    return files;
+
+    return files.filter((file) => !file.startsWith("golang/ioserver"));
 }
 
 function getServerFiles(dir = "") {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Also restores local `go build` to GitHub workflow since it frequently fails on z/OS system.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
