### PR TITLE
fix(zusf): avoid use of append in recursive logic

### DIFF
--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -579,7 +579,7 @@ int handle_job_list(ZCLIResult result)
     return RTNCD_FAILURE;
   }
 
-  return rc;
+  return "false" == warn && rc == RTNCD_WARNING ? RTNCD_SUCCESS : rc;
 }
 
 int handle_job_list_files(ZCLIResult result)

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -311,7 +311,8 @@ int zusf_chmod_uss_file_or_dir(ZUSF *zusf, string file, string mode, bool recurs
     {
       if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0)
       {
-        const string child_path = file[file.length() - 1] == '/' ? file.append((const char *)entry->d_name) : file.append(string("/") + (const char *)entry->d_name);
+        const string child_path = file[file.length() - 1] == '/' ? file + string((const char *)entry->d_name)
+                                                                 : file + string("/") + string((const char *)entry->d_name);
         struct stat file_stats;
         stat(child_path.c_str(), &file_stats);
 
@@ -355,7 +356,8 @@ int zusf_delete_uss_item(ZUSF *zusf, string file, bool recursive)
     {
       if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0)
       {
-        const string child_path = file[file.length() - 1] == '/' ? file.append((const char *)entry->d_name) : file.append(string("/") + (const char *)entry->d_name);
+        const string child_path = file[file.length() - 1] == '/' ? file + string((const char *)entry->d_name)
+                                                                 : file + string("/") + string((const char *)entry->d_name);
         struct stat file_stats;
         stat(child_path.c_str(), &file_stats);
 
@@ -369,7 +371,14 @@ int zusf_delete_uss_item(ZUSF *zusf, string file, bool recursive)
     closedir(dir);
   }
 
-  return is_dir ? rmdir(file.c_str()) : remove(file.c_str());
+  const auto rc = is_dir ? rmdir(file.c_str()) : remove(file.c_str());
+  if (rc != 0)
+  {
+    zusf->diag.e_msg_len = sprintf(zusf->diag.e_msg, "Could not delete '%s', rc: %d", file.c_str(), errno);
+    return RTNCD_FAILURE;
+  }
+
+  return 0;
 }
 
 short zusf_get_id_from_user_or_group(string user_or_group, bool is_user)
@@ -429,7 +438,8 @@ int zusf_chown_uss_file_or_dir(ZUSF *zusf, string file, string owner, bool recur
     {
       if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0)
       {
-        const string child_path = file[file.length() - 1] == '/' ? file.append((const char *)entry->d_name) : file.append(string("/") + (const char *)entry->d_name);
+        const string child_path = file[file.length() - 1] == '/' ? file + string((const char *)entry->d_name)
+                                                                 : file + string("/") + string((const char *)entry->d_name);
         struct stat file_stats;
         stat(child_path.c_str(), &file_stats);
 
@@ -488,7 +498,8 @@ int zusf_chtag_uss_file_or_dir(ZUSF *zusf, string file, string tag, bool recursi
     {
       if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0)
       {
-        const string child_path = file[file.length() - 1] == '/' ? file.append((const char *)entry->d_name) : file.append(string("/") + (const char *)entry->d_name);
+        const string child_path = file[file.length() - 1] == '/' ? file + string((const char *)entry->d_name)
+                                                                 : file + string("/") + string((const char *)entry->d_name);
         struct stat file_stats;
         stat(child_path.c_str(), &file_stats);
 


### PR DESCRIPTION
**What It Does**

Using `std::string::append` caused the file path to be mangled as part of remaining recursive calls.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
