### PR TITLE
fix: CLI dangling pointers; read resource contents into vector

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -18,6 +18,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c,golang`: Added capability to submit JCL from stdin. [#143](https://github.com/zowe/zowe-native-proto/pull/143)
 - `c`: Add support for `mkdir -p` behavior when making a new USS directory. [#143](https://github.com/zowe/zowe-native-proto/pull/143)
 - `golang`: Refactored error handling in Go layer to forward errors to client as JSON. [#143](https://github.com/zowe/zowe-native-proto/pull/143)
+- `c`: Fixed dangling pointers in CLI code & refactored reading resource contents to avoid manual memory allocation. [#167](https://github.com/zowe/zowe-native-proto/pull/167)
 
 ## [Unreleased]
 

--- a/native/c/makefile
+++ b/native/c/makefile
@@ -95,6 +95,13 @@ MTL_FLAGS64+=-g1
 all: libzut.so libzut.a libzds.so libzds.a libzusf.so libzusf.a libzcn.so libzcn.a libzjb.so libzjb.a zowex zowexx extattr test
 
 #
+# CLI
+#
+zcli.o: zcli.cpp
+	@echo 'Building zcli.o'
+	$(CXX) $(DLL_CPP_FLAGS) -qlist=$*.cpp.lst -o $@ $^
+
+#
 # Utilities
 #
 zut.o: zut.cpp
@@ -247,13 +254,13 @@ libztso.a: ztso.o
 # Test CLI
 #
 # zowex: zowex.o zcn.o zcnm.o zcnm31.o zut.o zutm.o zutm31.o zjb.o zjbm.o zssi31.o zjbm31.o zds.o
-zowex: zowex.o libzcn.a libzut.a libzjb.a libzds.a libzusf.a libztso.a
+zowex: zowex.o zcli.o libzcn.a libzut.a libzjb.a libzds.a libzusf.a libztso.a
 	@echo 'Building zowex'
 	$(CXX) $(CPP_BND_FLAGS) -o $@ $^ > $*.bind.lst
 	ln -sf ../c/$@ ../golang/zowex
 	@echo 'Copied zowex to golang/'
 
-zowexx: zowex.o libzcn.a libzut.a libzjb.a libzds.a libzusf.a libztso.a
+zowexx: zowex.o zcli.o libzcn.a libzut.a libzjb.a libzds.a libzusf.a libztso.a
 	@echo 'Building zowexx'
 	$(CXX) $(CPP_BND_FLAGS_AUTH) -o $@ $^ > $*.bind.lst
 	ln -sf ../c/$@ ../golang/zowexx

--- a/native/c/zcli.cpp
+++ b/native/c/zcli.cpp
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+#include "zcli.hpp"
+
+ZCLIOption ZCLIOptionProvider::option_not_found = ZCLIOption("not found");
+ZCLIPositional ZCLIPositionalProvider::positional_not_found = ZCLIPositional("not found");
+ZCLIVerb ZCLIGroup::verb_not_found = ZCLIVerb("not found");
+ZCLIGroup ZCLI::group_not_found = ZCLIGroup("not found");

--- a/native/c/zcli.hpp
+++ b/native/c/zcli.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <iomanip>
 #include <sstream>
+#include <unistd.h>
 #include <map>
 
 using namespace std;
@@ -112,6 +113,8 @@ public:
 
 class ZCLIOptionProvider
 {
+  static ZCLIOption option_not_found;
+
 protected:
   vector<ZCLIOption> options;
 
@@ -142,6 +145,8 @@ public:
 
 class ZCLIPositionalProvider
 {
+  static ZCLIPositional positional_not_found;
+
 protected:
   vector<ZCLIPositional> positionals;
 
@@ -184,6 +189,8 @@ public:
 
 class ZCLIGroup : public ZCLIName, public ZCLIDescription, public ZCLIOptionProvider
 {
+  static ZCLIVerb verb_not_found;
+
 private:
   vector<ZCLIVerb> verbs;
   vector<string> aliases;
@@ -207,6 +214,8 @@ public:
 
 class ZCLI : public ZCLIName, public ZCLIOptionProvider
 {
+  static ZCLIGroup group_not_found;
+
 private:
   bool validate();
   void init();
@@ -456,8 +465,7 @@ ZCLIGroup &ZCLI::get_group(string group_name)
         return *it;
     }
   }
-  ZCLIGroup *not_found = new ZCLIGroup("not found");
-  return *not_found;
+  return ZCLI::group_not_found;
 }
 
 ZCLIVerb &ZCLIGroup::get_verb(string verb_name)
@@ -472,9 +480,7 @@ ZCLIVerb &ZCLIGroup::get_verb(string verb_name)
         return *it;
     }
   }
-  ZCLIVerb *not_found = new ZCLIVerb("not found");
-  not_found->set_zcli_verb_handler(nullptr);
-  return *not_found;
+  return ZCLIGroup::verb_not_found;
 }
 
 ZCLIOption &ZCLIOptionProvider::get_option(string option_name)
@@ -485,8 +491,7 @@ ZCLIOption &ZCLIOptionProvider::get_option(string option_name)
     if (option_name == it->get_flag_name() || std::find(aliases.begin(), aliases.end(), option_name) != it->get_aliases().end())
       return *it;
   }
-  ZCLIOption *not_found = new ZCLIOption("not found");
-  return *not_found;
+  return ZCLIOptionProvider::option_not_found;
 }
 
 ZCLIPositional &ZCLIPositionalProvider::get_positional(string positional_name)
@@ -496,8 +501,7 @@ ZCLIPositional &ZCLIPositionalProvider::get_positional(string positional_name)
     if (positional_name == it->get_name())
       return *it;
   }
-  ZCLIPositional *not_found = new ZCLIPositional("not found");
-  return *not_found;
+  return ZCLIPositionalProvider::positional_not_found;
 }
 
 bool ZCLI::should_quit(string arg)

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -91,13 +91,10 @@ int zds_read_from_dsn(ZDS *zds, string dsn, string &response)
   size_t size = in.tellg();
   in.seekg(0, ios::beg);
 
-  char *raw_data = new char[size];
-  std::fill(raw_data, raw_data + size, 0);
-  in.read(raw_data, size);
+  vector<char> raw_data(size);
+  in.read(&raw_data[0], size);
 
-  response.assign(raw_data);
-  delete[] raw_data;
-
+  response.assign(raw_data.begin(), raw_data.end());
   in.close();
 
   const auto encodingProvided = zds->encoding_opts.data_type == eDataTypeText && strlen(zds->encoding_opts.codepage) > 0;

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -192,13 +192,10 @@ int zusf_read_from_uss_file(ZUSF *zusf, string file, string &response)
   size_t size = in.tellg();
   in.seekg(0, ios::beg);
 
-  char *raw_data = new char[size];
-  std::fill(raw_data, raw_data + size, 0);
-  in.read(raw_data, size);
+  vector<char> raw_data(size);
+  in.read(&raw_data[0], size);
 
-  response.assign(raw_data);
-  delete[] raw_data;
-
+  response.assign(raw_data.begin(), raw_data.end());
   in.close();
 
   // TODO(traeok): Finish support for encoding auto-detection


### PR DESCRIPTION
**What It Does**

- Resolves a few dangling pointers in `zcli.hpp` by avoiding use of `new` & replacing the dereferenced pointers with static instances
- Fixes issue where response contents were appended with random junk data - replaced manual allocation with `vector<char>`

**How to Test**

- Open several files in the VSCE. Notice that the data is intact w/o any junk data at the end.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
