### PR TITLE
fix(ds): Use same read process as `zds_read_from_dd` in `zds_read_from_dsn`

### DIFF
--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -87,15 +87,24 @@ int zds_read_from_dsn(ZDS *zds, string dsn, string &response)
     return RTNCD_FAILURE;
   }
 
-  in.seekg(0, ios::end);
-  size_t size = in.tellg();
-  in.seekg(0, ios::beg);
+  int index = 0;
 
-  vector<char> raw_data(size);
-  in.read(&raw_data[0], size);
-
-  response.assign(raw_data.begin(), raw_data.end());
+  string line;
+  while (getline(in, line))
+  {
+    if (index > 0 || line.size() > 0)
+    {
+      response += line;
+      response.push_back('\n');
+      index++;
+    }
+  }
   in.close();
+
+  const size_t size = response.size() + 1;
+  string bytes;
+  bytes.reserve(size);
+  memcpy((char *)bytes.data(), response.c_str(), size);
 
   const auto encodingProvided = zds->encoding_opts.data_type == eDataTypeText && strlen(zds->encoding_opts.codepage) > 0;
 


### PR DESCRIPTION
**What It Does**

Updates the logic to be consistent with how we read from ddnames for jobs.
Doesn't really fix any issues, just wanted to be consistent instead of refactoring the read for data sets - and since we were already using this method, it makes sense to reuse the code we already have.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
