### PR TITLE
Fail make build for compiler and linker warnings

### DIFF
--- a/native/c/makefile
+++ b/native/c/makefile
@@ -8,14 +8,11 @@
 #
 #  Copyright Contributors to the Zowe Project.
 #
-CXX=xlc++
-CC=xlc
-ASM=as
-BIND = ld
 
-# https://www.ibm.com/docs/en/zos/3.1.0?topic=bor-binder-options
-# https://www.ibm.com/docs/en/zos/3.1.0?topic=descriptions-ld-link-object-files
-BIND_FLAGS = -bRMODE=ANY
+XLC_FLAGS=_CC_ACCEPTABLE_RC=0 _C89_ACCEPTABLE_RC=0 _CXX_ACCEPTABLE_RC=0
+CXX=$(XLC_FLAGS) xlc++
+CC=$(XLC_FLAGS) xlc
+ASM=as
 
 MTL_OPTS=metal,\
  langlvl(extended),\


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #178 - now the `zos-build` workflow is failing until the warnings are addressed in b3728f2596f5d0c5d45810cefc8b6567ce67ee2c and caac03033c37126ce30091c0f06e2f6b79704d11 😋 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
