### PR TITLE
fix(ds/list): Address inconsistent results (compared to z/OSMF) for DS search patterns

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -23,6 +23,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c,golang`: Added `createMember` function. [#95](https://github.com/zowe/zowe-native-proto/pull/95)
 - `c,golang`: Added `cancelJob` function. [#138](https://github.com/zowe/zowe-native-proto/pull/138)
 - `c,golang`: Added `holdJob` and `releaseJob` functions. [#182](https://github.com/zowe/zowe-native-proto/pull/182)
+- `c`: Fixed issue where data set search patterns did not return the same results as z/OSMF. [#74](https://github.com/zowe/zowe-native-proto/issues/74)
 
 ## [Unreleased]
 

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -24,6 +24,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c,golang`: Added `cancelJob` function. [#138](https://github.com/zowe/zowe-native-proto/pull/138)
 - `c,golang`: Added `holdJob` and `releaseJob` functions. [#182](https://github.com/zowe/zowe-native-proto/pull/182)
 - `c`: Fixed issue where data set search patterns did not return the same results as z/OSMF. [#74](https://github.com/zowe/zowe-native-proto/issues/74)
+- `c`: Added check for maximum data set pattern length before making a list request. Now, requests with patterns longer than 44 characters are rejected. [#185](https://github.com/zowe/zowe-native-proto/pull/185)
 
 ## [Unreleased]
 

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -365,7 +365,7 @@ typedef struct
 #define ERROR_CONDITION 0XF8       // all flags
   unsigned char type;
 #define CATALOG_TYPE 0xF0
-  char name[44];
+  char name[MAX_DS_LENGTH];
   ZDS_CSI_ERROR_INFO error_info;
 } ZDS_CSI_CATALOG;
 
@@ -396,7 +396,7 @@ typedef struct
 #define USER_CATALOG_CONNECTOR_ENTRY 'U'
 #define ATL_VOLUME_ENTRY 'W'
 #define ALIAS 'X'
-  char name[44];
+  char name[MAX_DS_LENGTH];
 
   union
   {

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -23,6 +23,8 @@
 #include "iefzb4d2.h"
 #include "zdsm.h"
 
+const size_t MAX_DS_LENGTH = 44u;
+
 using namespace std;
 
 int zds_read_from_dd(ZDS *zds, string ddname, string &response)

--- a/native/c/zds.hpp
+++ b/native/c/zds.hpp
@@ -15,8 +15,9 @@
 #include <iostream>
 #include <vector>
 #include <string>
-#include "zds.hpp"
 #include "zdstype.h"
+
+extern const size_t MAX_DS_LENGTH;
 
 struct ZDSMem
 {

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1129,13 +1129,15 @@ int handle_data_set_view_dsn(ZCLIResult result)
 int handle_data_set_list(ZCLIResult result)
 {
   int rc = 0;
-  string dsn = result.get_positional("dsn")->get_value() + ".**";
+  string dsn = result.get_positional("dsn")->get_value();
 
   if (dsn.length() > MAX_DS_LENGTH)
   {
     cerr << "Error: data set pattern exceeds 44 character length limit" << endl;
     return RTNCD_FAILURE;
   }
+
+  dsn += ".**";
 
   string max_entries = result.get_option("--max-entries")->get_value();
   string warn = result.get_option("--warn")->get_value();

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1131,7 +1131,7 @@ int handle_data_set_list(ZCLIResult result)
   int rc = 0;
   string dsn = result.get_positional("dsn")->get_value() + ".**";
 
-  if (dsn.length() > 44)
+  if (dsn.length() > MAX_DS_LENGTH)
   {
     cerr << "Error: data set pattern '" << dsn << "' exceeds 44 character length limit";
     return RTNCD_FAILURE;

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1133,7 +1133,7 @@ int handle_data_set_list(ZCLIResult result)
 
   if (dsn.length() > MAX_DS_LENGTH)
   {
-    cerr << "Error: data set pattern '" << dsn << "' exceeds 44 character length limit";
+    cerr << "Error: data set pattern exceeds 44 character length limit" << endl;
     return RTNCD_FAILURE;
   }
 

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1129,7 +1129,7 @@ int handle_data_set_view_dsn(ZCLIResult result)
 int handle_data_set_list(ZCLIResult result)
 {
   int rc = 0;
-  string dsn = result.get_positional("dsn")->get_value();
+  string dsn = result.get_positional("dsn")->get_value() + ".**";
   string max_entries = result.get_option("--max-entries")->get_value();
   string warn = result.get_option("--warn")->get_value();
   string attributes = result.get_option("--attributes")->get_value();

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1130,6 +1130,13 @@ int handle_data_set_list(ZCLIResult result)
 {
   int rc = 0;
   string dsn = result.get_positional("dsn")->get_value() + ".**";
+
+  if (dsn.length() > 44)
+  {
+    cerr << "Error: data set pattern '" << dsn << "' exceeds 44 character length limit";
+    return RTNCD_FAILURE;
+  }
+
   string max_entries = result.get_option("--max-entries")->get_value();
   string warn = result.get_option("--warn")->get_value();
   string attributes = result.get_option("--attributes")->get_value();

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -11,6 +11,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added `zssh list spool-files` command. [#38](https://github.com/zowe/zowe-native-proto/pull/38)
 - Added support for cancelling jobs. [#138](https://github.com/zowe/zowe-native-proto/pull/138)
 - Added support for holding and releasing jobs. [#182](https://github.com/zowe/zowe-native-proto/pull/182)
+- Updated error handling for listing data sets. [#185](https://github.com/zowe/zowe-native-proto/pull/185)
 
 ## [Unreleased]
 

--- a/packages/cli/src/list/data-set/DataSet.handler.ts
+++ b/packages/cli/src/list/data-set/DataSet.handler.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { type IHandlerParameters, ImperativeError } from "@zowe/imperative";
+import { type IHandlerParameters, ImperativeError, TextUtils } from "@zowe/imperative";
 import type { ZSshClient, ds } from "zowe-native-proto-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
@@ -21,8 +21,12 @@ export default class ListDataSetsHandler extends SshBaseHandler {
                 pattern: params.arguments.pattern,
             });
         } catch (err) {
-            const errText = err instanceof ImperativeError ? err.additionalDetails : err.toString();
+            const errText = (err instanceof ImperativeError ? err.additionalDetails : err.toString()).replace(
+                "Error: ",
+                "",
+            );
             params.response.data.setExitCode(1);
+            params.response.console.errorHeader(TextUtils.chalk.red("Response from Service"));
             params.response.console.error(errText);
             params.response.data.setMessage(errText);
             return { success: false, items: [], returnedRows: 0 };

--- a/packages/cli/src/list/data-set/DataSet.handler.ts
+++ b/packages/cli/src/list/data-set/DataSet.handler.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { ImperativeError, type IHandlerParameters } from "@zowe/imperative";
+import { type IHandlerParameters, ImperativeError } from "@zowe/imperative";
 import type { ZSshClient, ds } from "zowe-native-proto-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 

--- a/packages/cli/src/list/data-set/DataSet.handler.ts
+++ b/packages/cli/src/list/data-set/DataSet.handler.ts
@@ -9,15 +9,25 @@
  *
  */
 
-import type { IHandlerParameters } from "@zowe/imperative";
+import { ImperativeError, type IHandlerParameters } from "@zowe/imperative";
 import type { ZSshClient, ds } from "zowe-native-proto-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ListDataSetsHandler extends SshBaseHandler {
     public async processWithClient(params: IHandlerParameters, client: ZSshClient): Promise<ds.ListDatasetsResponse> {
-        const response = await client.ds.listDatasets({
-            pattern: params.arguments.pattern,
-        });
+        let response: ds.ListDatasetsResponse;
+        try {
+            response = await client.ds.listDatasets({
+                pattern: params.arguments.pattern,
+            });
+        } catch (err) {
+            const errText = err instanceof ImperativeError ? err.additionalDetails : err.toString();
+            params.response.data.setExitCode(1);
+            params.response.console.error(errText);
+            params.response.data.setMessage(errText);
+            return { success: false, items: [], returnedRows: 0 };
+        }
+
         params.response.data.setMessage(
             "Successfully listed %d matching data sets for pattern '%s'",
             response.returnedRows,

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Fixed issue where `Open with Encoding: Binary` for MVS and USS files did not pass the correct encoding value to the server. [#61](https://github.com/zowe/zowe-native-proto/pull/61)
 - Added support for cancelling jobs. [#138](https://github.com/zowe/zowe-native-proto/pull/138)
 - Added support for running MVS commands. [#138](https://github.com/zowe/zowe-native-proto/pull/138)
+- Updated error handling for listing data sets. [#185](https://github.com/zowe/zowe-native-proto/pull/185)
 
 ## [Unreleased]
 

--- a/packages/vsce/src/api/SshMvsApi.ts
+++ b/packages/vsce/src/api/SshMvsApi.ts
@@ -17,18 +17,31 @@ import { SshCommonApi } from "./SshCommonApi";
 
 export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs {
     public async dataSet(filter: string, options?: zosfiles.IListOptions): Promise<zosfiles.IZosFilesResponse> {
-        const response = await (await this.client).ds.listDatasets({
-            pattern: filter,
-        });
-        return this.buildZosFilesResponse({
-            items: response.items.map((item) => ({
-                dsname: item.name,
-                dsorg: item.dsorg,
-                vol: item.volser,
-                migr: item.migr ? "YES" : "NO",
-            })),
-            returnedRows: response.returnedRows,
-        });
+        try {
+            const response = await (await this.client).ds.listDatasets({
+                pattern: filter,
+            });
+            return this.buildZosFilesResponse({
+                items: response.items.map((item) => ({
+                    dsname: item.name,
+                    dsorg: item.dsorg,
+                    vol: item.volser,
+                    migr: item.migr ? "YES" : "NO",
+                })),
+                returnedRows: response.returnedRows,
+            });
+        } catch (err) {
+            if (err instanceof imperative.ImperativeError) {
+                Gui.errorMessage(`Failed to list data sets: ${err.additionalDetails.replace("Error: ", "")}`);
+            }
+            return this.buildZosFilesResponse(
+                {
+                    items: [],
+                    returnedRows: 0,
+                },
+                false,
+            );
+        }
     }
 
     public async allMembers(dataSetName: string, options?: zosfiles.IListOptions): Promise<zosfiles.IZosFilesResponse> {


### PR DESCRIPTION
**What It Does**

- Defines max data set length as constant `MAX_DS_LENGTH = 44`
  - Replace use of `44` with constant variable where applicable
- Performs length check for data set search pattern before performing list operation
- Appends `.**` to data set search pattern to match z/OSMF behavior

**How to Test**

- Open the VSCE, search for `SYS1.*` instead of `SYS1.**` using the build from this branch
- Notice that the results match z/OSMF this time
- Search for another pattern that has a wildcard in its qualifier, e.g.: `TRAE.ENC*`
  - Notice that this pattern now matches data sets starting with `TRAE.ENC`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
