### PR TITLE
fix: submit JCL from stdin

### DIFF
--- a/native/c/zjb.cpp
+++ b/native/c/zjb.cpp
@@ -561,7 +561,7 @@ void zjb_build_job_response(ZJB_JOB_INFO *PTR64 job_info, int entries, vector<ZJ
     zjob.full_status = string(job_info_next[i].phase_text);
     zut_rtrim(zjob.full_status);
 
-    zjob.retcode = ZJB_UNKNWON_RC;
+    zjob.retcode = ZJB_UNKNOWN_RC;
 
     if ("AWAIT MAIN SELECT" == zjob.full_status)
     {

--- a/native/c/zjbtype.h
+++ b/native/c/zjbtype.h
@@ -27,7 +27,7 @@
 #define ZJB_DEFAULT_MAX_JOBS 100
 #define ZJB_DEFAULT_MAX_DDS 100
 
-#define ZJB_UNKNWON_RC "------"
+#define ZJB_UNKNOWN_RC ""
 
 #if (defined(__IBMCPP__) || defined(__IBMC__))
 #pragma pack(packed)

--- a/native/golang/cmds/jobs.go
+++ b/native/golang/cmds/jobs.go
@@ -13,6 +13,7 @@ package cmds
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -275,28 +276,33 @@ func HandleSubmitJclRequest(conn *utils.StdioConn, params []byte) (result any, e
 
 	decodedBytes, err := base64.StdEncoding.DecodeString(request.Jcl)
 	if err != nil {
-		e = fmt.Errorf("Failed to decode JCL contents: %v", err)
+		e = fmt.Errorf("failed to decode JCL contents: %v", err)
 		return
 	}
 
-	cmd := utils.BuildCommandNoAutocvt([]string{"job", "submit-jcl", "--only-jobid", "true"})
+	byteString := hex.EncodeToString(decodedBytes)
+	if len(request.Encoding) == 0 {
+		request.Encoding = fmt.Sprintf("IBM-%d", utils.DefaultEncoding)
+	}
+
+	cmd := utils.BuildCommand([]string{"job", "submit-jcl", "--only-jobid", "true", "--encoding", request.Encoding})
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		e = fmt.Errorf("Failed to open stdin pipe to zowex: %v", err)
+		e = fmt.Errorf("failed to open stdin pipe to zowex: %v", err)
 		return
 	}
 
 	go func() {
 		defer stdin.Close()
-		_, err = stdin.Write(decodedBytes)
+		_, err = stdin.Write([]byte(byteString))
 		if err != nil {
-			e = fmt.Errorf("Failed to write to pipe: %v", err)
+			e = fmt.Errorf("failed to write to pipe: %v", err)
 		}
 	}()
 
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		e = fmt.Errorf("Failed to submit JCL: %v", err)
+		e = fmt.Errorf("failed to submit JCL: %v", err)
 		conn.LastExitCode = cmd.ProcessState.ExitCode()
 		return
 	}

--- a/native/golang/types/jobs/requests.go
+++ b/native/golang/types/jobs/requests.go
@@ -67,6 +67,8 @@ type SubmitJobRequest struct {
 type SubmitJclRequest struct {
 	common.CommandRequest `tstype:",extends"`
 	Command               string `json:"command" tstype:"\"submitJcl\""`
+	// Desired encoding for the spool file (optional)
+	Encoding string `json:"encoding,omitempty"`
 	// JCL contents to submit as a job
 	Jcl string `json:"jcl"`
 }

--- a/packages/cli/src/submit/stdin/Stdin.handler.ts
+++ b/packages/cli/src/submit/stdin/Stdin.handler.ts
@@ -9,14 +9,14 @@
  *
  */
 
-import { text } from "node:stream/consumers";
+import { buffer } from "node:stream/consumers";
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { ZSshClient, jobs } from "zowe-native-proto-sdk";
+import { type ZSshClient, ZSshUtils, type jobs } from "zowe-native-proto-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class SubmitJclHandler extends SshBaseHandler {
     public async processWithClient(params: IHandlerParameters, client: ZSshClient): Promise<jobs.DeleteJobResponse> {
-        const jcl = await text(params.stdin);
+        const jcl = ZSshUtils.encodeByteArray(await buffer(params.stdin));
         const response = await client.jobs.submitJcl({ jcl });
 
         const msg = `Job submitted: ${response.jobId}`;

--- a/packages/sdk/src/doc/gen/jobs.ts
+++ b/packages/sdk/src/doc/gen/jobs.ts
@@ -76,6 +76,10 @@ export interface SubmitJobRequest extends common.CommandRequest {
 export interface SubmitJclRequest extends common.CommandRequest {
   command: "submitJcl";
   /**
+   * Desired encoding for the spool file (optional)
+   */
+  encoding?: string;
+  /**
    * JCL contents to submit as a job
    */
   jcl: string;

--- a/packages/vsce/src/api/SshJesApi.ts
+++ b/packages/vsce/src/api/SshJesApi.ts
@@ -80,7 +80,7 @@ export class SshJesApi extends SshCommonApi implements MainframeInteraction.IJes
         internalReaderLrecl?: string,
     ): Promise<zosjobs.IJob> {
         const response = await (await this.client).jobs.submitJcl({
-            jcl,
+            jcl: ZSshUtils.encodeByteArray(Buffer.from(jcl)),
         });
         return { jobid: response.jobId } as zosjobs.IJob;
     }


### PR DESCRIPTION
**What It Does**

- Implement Timothy's change for CLI plug-in for submit job command
- `golang`: Fix `HandleSubmitJclRequest` function to allow passing JCL encoding
- `c`: Fix `handle_job_submit_jcl` function so it 
  - converts input data from UTF-8 to given encoding before submitting JCL
  - accepts raw bytes from `stdin` when `stdout` isn't a TTY (scenario: user invokes `zowex job submit-jcl` in a shell)
- `c`: Rename `ZJB_UNKNWON_RC` -> `ZJB_UNKNOWN_RC` and re-define constant as empty string (fixes bug in VSCE)

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)