### PR TITLE
fix: S0C4 when submitting JCL w/o encoding option

### DIFF
--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -812,7 +812,7 @@ int handle_job_submit_jcl(ZCLIResult result)
   raw_bytes.clear();
 
   ZEncode encoding_opts = {0};
-  const auto encoding_prepared = result.get_option("--encoding")->is_found() && zut_prepare_encoding(result.get_option("--encoding")->get_value(), &encoding_opts);
+  const auto encoding_prepared = result.get_option("--encoding") != nullptr && result.get_option("--encoding")->is_found() && zut_prepare_encoding(result.get_option("--encoding")->get_value(), &encoding_opts);
 
   if (encoding_prepared && encoding_opts.data_type != eDataTypeBinary)
   {


### PR DESCRIPTION
**What It Does**

- Fixes edge-case where submitting JCL without encoding results in a S0C4

**How to Test**

- Place the following contents in an IBM-1047 tagged file on USS:
```jcl
//DONOTHIN JOB (IZUACCT),'DONOTHIN',CLASS=A,MSGCLASS=A,MSGLEVEL=(1,1)
//STEP01    EXEC PGM=IEFBR14
//SYSPRINT  DD SYSOUT=*
//SYSOUT    DD SYSOUT=*
//SYSIN     DD DUMMY
```
- `cat JCL_CONTENTS.txt | ./zowex job submit-jcl` from a SSH shell

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] ~updated the changelog~ no changelog since fixes were just merged for submit JCL
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
