### PR TITLE
fix(sdk): Add error callback and request timeout to SSH client

### DIFF
--- a/packages/cli/src/SshBaseHandler.ts
+++ b/packages/cli/src/SshBaseHandler.ts
@@ -15,7 +15,7 @@ import { type CommandResponse, ZSshClient, ZSshUtils } from "zowe-native-proto-s
 export abstract class SshBaseHandler implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters) {
         const session = ZSshUtils.buildSession(commandParameters.arguments);
-        using client = await ZSshClient.create(session, commandParameters.arguments.serverPath);
+        using client = await ZSshClient.create(session, { serverPath: commandParameters.arguments.serverPath });
 
         const response = await this.processWithClient(commandParameters, client);
 

--- a/packages/sdk/src/ZSshClient.ts
+++ b/packages/sdk/src/ZSshClient.ts
@@ -126,14 +126,17 @@ export class ZSshClient extends AbstractRpcClient implements Disposable {
         } catch (err) {
             const errMsg = `Failed to parse response as JSON: ${err}`;
             Logger.getAppLogger().error(errMsg);
-            throw new Error(errMsg);
+            this.mErrHandler(new Error(errMsg));
+            return;
         }
         if (!this.mPromiseMap.has(response.id)) {
             const errMsg = `Missing promise for response ID: ${response.id}`;
             Logger.getAppLogger().error(errMsg);
-            throw new Error(errMsg);
+            this.mErrHandler(new Error(errMsg));
+            return;
         }
         if (response.error != null) {
+            Logger.getAppLogger().error(`Error for response ID: ${response.id}\n${JSON.stringify(response.error)}`);
             this.mPromiseMap.get(response.id).reject(
                 new ImperativeError({
                     msg: response.error.message,

--- a/packages/sdk/src/ZSshClient.ts
+++ b/packages/sdk/src/ZSshClient.ts
@@ -124,7 +124,9 @@ export class ZSshClient extends AbstractRpcClient implements Disposable {
     private processResponses(data: string): string {
         const responses = data.split("\n");
         for (let i = 0; i < responses.length - 1; i++) {
-            this.requestEnd(responses[i]);
+            if (responses[i].length > 0) {
+                this.requestEnd(responses[i]);
+            }
         }
         return responses[responses.length - 1];
     }
@@ -135,7 +137,7 @@ export class ZSshClient extends AbstractRpcClient implements Disposable {
         try {
             response = JSON.parse(data);
         } catch (err) {
-            const errMsg = `Failed to parse response as JSON: ${err}`;
+            const errMsg = `Failed to parse response as JSON: ${data}`;
             Logger.getAppLogger().error(errMsg);
             this.mErrHandler(new Error(errMsg));
             return;

--- a/packages/sdk/src/ZSshClient.ts
+++ b/packages/sdk/src/ZSshClient.ts
@@ -110,7 +110,7 @@ export class ZSshClient extends AbstractRpcClient implements Disposable {
 
     private onErrData(chunk: Buffer) {
         if (this.mRequestId === 0) {
-            const errMsg = Logger.getAppLogger().error("Message received on stderr: %s", chunk.toString());
+            const errMsg = Logger.getAppLogger().error("Error from server: %s", chunk.toString());
             this.mErrHandler(new Error(errMsg));
             return;
         }
@@ -137,7 +137,7 @@ export class ZSshClient extends AbstractRpcClient implements Disposable {
         try {
             response = JSON.parse(data);
         } catch (err) {
-            const errMsg = `Failed to parse response as JSON: ${data}`;
+            const errMsg = `Invalid JSON response: ${data}`;
             Logger.getAppLogger().error(errMsg);
             this.mErrHandler(new Error(errMsg));
             return;

--- a/packages/sdk/src/doc/client.ts
+++ b/packages/sdk/src/doc/client.ts
@@ -9,10 +9,8 @@
  *
  */
 
-export * from "./gen/common";
-export * as ds from "./gen/ds";
-export * as uss from "./gen/uss";
-export * as jobs from "./gen/jobs";
-export * as cmds from "./gen/cmds";
-export * from "./client";
-export * from "./types";
+export interface ClientOptions {
+    onClose?: () => void | Promise<void>;
+    onError?: (error: Error) => void | Promise<void>;
+    serverPath?: string;
+}

--- a/packages/sdk/src/doc/client.ts
+++ b/packages/sdk/src/doc/client.ts
@@ -10,7 +10,25 @@
  */
 
 export interface ClientOptions {
+    /**
+     * Function called when the connection is closed
+     */
     onClose?: () => void | Promise<void>;
+
+    /**
+     * Function called when there is a connection error
+     */
     onError?: (error: Error) => void | Promise<void>;
+
+    /**
+     * Number of seconds to wait for a response
+     * (default: 60)
+     */
+    responseTimeout?: number;
+
+    /**
+     * Remote path of the Zowe Native Proto server
+     * (default: `~/.zowe-server`)
+     */
     serverPath?: string;
 }

--- a/packages/vsce/src/SshClientCache.ts
+++ b/packages/vsce/src/SshClientCache.ts
@@ -43,8 +43,14 @@ export class SshClientCache extends vscode.Disposable {
             const serverPath = SshConfigUtils.getServerPath(profile.profile);
             this.mClientMap.set(
                 clientId,
-                await ZSshClient.create(session, serverPath, () => {
-                    this.end(clientId);
+                await ZSshClient.create(session, {
+                    serverPath,
+                    onClose: () => {
+                        this.end(clientId);
+                    },
+                    onError: (err: Error) => {
+                        vscode.window.showErrorMessage(err.toString());
+                    },
                 }),
             );
         }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Adds `onError` callback for improved handling of generic request errors. Now the VS Code extension will show these errors with `vscode.window.showErrorMessage` instead of silently writing them to the console.

Also adds a request timeout of 60 seconds - thanks @traeok for the idea! Hopefully our requests never take this long, but in case we do they shouldn't hang any more.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
