### PR TITLE
fix: No response from `zowed` when listing data sets w/ non-existent pattern 

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -28,6 +28,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c,golang`: Fixed issue where submit JCL handler did not convert input data from UTF-8 and did not support an `--encoding` option. [#198](https://github.com/zowe/zowe-native-proto/pull/198)
 - `c`: Fixed issue where submit JCL handler did not support raw bytes from stdin when the binary is directly invoked through a shell. [#198](https://github.com/zowe/zowe-native-proto/pull/198)
 - `c,golang`: Added `submitUss` function. [#184](https://github.com/zowe/zowe-native-proto/pull/184)
+- `golang`: Fixed issue where listing a non-existent data set pattern resulted in a panic and abrupt termination of `zowed`. [#200](https://github.com/zowe/zowe-native-proto/issues/200)
 
 ## [Unreleased]
 

--- a/native/golang/cmds/ds.go
+++ b/native/golang/cmds/ds.go
@@ -110,7 +110,14 @@ func HandleListDatasetsRequest(conn *utils.StdioConn, params []byte) (result any
 		return nil, fmt.Errorf("Error executing command: %v", err)
 	}
 
-	datasets := strings.Split(strings.TrimSpace(string(out)), "\n")
+	rawResponse := strings.TrimSpace(string(out))
+	if len(rawResponse) == 0 {
+		return ds.ListDatasetsResponse{
+			Items:        []t.Dataset{},
+			ReturnedRows: 0,
+		}, nil
+	}
+	datasets := strings.Split(rawResponse, "\n")
 	dsResponse := ds.ListDatasetsResponse{
 		Items:        make([]t.Dataset, len(datasets)),
 		ReturnedRows: len(datasets),
@@ -118,6 +125,9 @@ func HandleListDatasetsRequest(conn *utils.StdioConn, params []byte) (result any
 
 	for i, ds := range datasets {
 		vals := strings.Split(ds, ",")
+		if len(vals) < 4 {
+			continue
+		}
 		migr := false
 		if vals[3] == "true" {
 			migr = true


### PR DESCRIPTION
**What It Does**

Fixes an issue where listing data sets with a non-existent pattern causes `zowed` to hang with no response.

**How to Test**

- List a data set pattern in the VSCE that doesn't exist on the target system
- Notice "No data sets found" rather than infinitely hanging

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
