### PR TITLE
fix: newline in job ID after submit, use 1 worker for CLI plug-in

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -29,6 +29,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c`: Fixed issue where submit JCL handler did not support raw bytes from stdin when the binary is directly invoked through a shell. [#198](https://github.com/zowe/zowe-native-proto/pull/198)
 - `c,golang`: Added `submitUss` function. [#184](https://github.com/zowe/zowe-native-proto/pull/184)
 - `golang`: Fixed issue where listing a non-existent data set pattern resulted in a panic and abrupt termination of `zowed`. [#200](https://github.com/zowe/zowe-native-proto/issues/200)
+- `golang`: Fixed issue where a newline was present in the job ID when returning a response for the "submitJcl" command.
 
 ## [Unreleased]
 

--- a/native/golang/cmds/jobs.go
+++ b/native/golang/cmds/jobs.go
@@ -262,7 +262,7 @@ func HandleSubmitJobRequest(conn *utils.StdioConn, params []byte) (result any, e
 	result = jobs.SubmitJobResponse{
 		Success: true,
 		Dsname:  request.Dsname,
-		JobId:   string(out),
+		JobId:   strings.TrimRight(string(out), "\n"),
 	}
 	return
 }
@@ -284,7 +284,7 @@ func HandleSubmitUssRequest(conn *utils.StdioConn, params []byte) (result any, e
 	result = jobs.SubmitUssResponse{
 		Success: true,
 		Path:    request.Path,
-		JobId:   string(out),
+		JobId:   strings.TrimRight(string(out), "\n"),
 	}
 	return
 }

--- a/native/golang/cmds/jobs.go
+++ b/native/golang/cmds/jobs.go
@@ -331,7 +331,7 @@ func HandleSubmitJclRequest(conn *utils.StdioConn, params []byte) (result any, e
 
 	result = jobs.SubmitJclResponse{
 		Success: true,
-		JobId:   string(out),
+		JobId:   strings.TrimRight(string(out), "\n"),
 	}
 	return
 }

--- a/native/golang/utils/cmd.go
+++ b/native/golang/utils/cmd.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -52,28 +53,28 @@ func BuildArgString(args []string) string {
 
 // BuildCommandShared builds a command with the shared logic for command builder functions
 func BuildCommandShared(name string, args []string) *exec.Cmd {
-	cmd := exec.Command(name, args...)
-	cmd.Dir = GetExecDir()
+	execDir := GetExecDir()
+	cmd := exec.Command(path.Join(execDir, name), args...)
 	return cmd
 }
 
 // BuildCommand builds a command with _BPXK_AUTOCVT=ON
 func BuildCommand(args []string) *exec.Cmd {
-	cmd := BuildCommandShared("./zowex", args)
+	cmd := BuildCommandShared("zowex", args)
 	cmd.Env = append(os.Environ(), "_BPXK_AUTOCVT=ON")
 	return cmd
 }
 
 // BuildCommand builds a `zoweax` command to perform operations that require authorization
 func BuildCommandAuthorized(args []string) *exec.Cmd {
-	cmd := BuildCommandShared("./zoweax", args)
+	cmd := BuildCommandShared("zoweax", args)
 	cmd.Env = append(os.Environ(), "_BPXK_AUTOCVT=ON")
 	return cmd
 }
 
 // BuildCommandNoAutocvt builds a command with _BPXK_AUTOCVT=OFF
 func BuildCommandNoAutocvt(args []string) *exec.Cmd {
-	cmd := BuildCommandShared("./zowex", args)
+	cmd := BuildCommandShared("zowex", args)
 	cmd.Env = append(os.Environ(), "_BPXK_AUTOCVT=OFF")
 	return cmd
 }

--- a/native/golang/utils/stdio.go
+++ b/native/golang/utils/stdio.go
@@ -30,7 +30,7 @@ type StdioConn struct {
 }
 
 func (conn *StdioConn) ExecCmd(args []string) (stdout []byte, stderr error) {
-	_, err := conn.Stdin.Write([]byte("./zowex " + BuildArgString(args) + "\n"))
+	_, err := conn.Stdin.Write([]byte("zowex " + BuildArgString(args) + "\n"))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/cli/src/SshBaseHandler.ts
+++ b/packages/cli/src/SshBaseHandler.ts
@@ -15,7 +15,10 @@ import { type CommandResponse, ZSshClient, ZSshUtils } from "zowe-native-proto-s
 export abstract class SshBaseHandler implements ICommandHandler {
     public async process(commandParameters: IHandlerParameters) {
         const session = ZSshUtils.buildSession(commandParameters.arguments);
-        using client = await ZSshClient.create(session, { serverPath: commandParameters.arguments.serverPath });
+        using client = await ZSshClient.create(session, {
+            serverPath: commandParameters.arguments.serverPath,
+            numWorkers: 1,
+        });
 
         const response = await this.processWithClient(commandParameters, client);
 

--- a/packages/sdk/src/ZSshClient.ts
+++ b/packages/sdk/src/ZSshClient.ts
@@ -52,7 +52,10 @@ export class ZSshClient extends AbstractRpcClient implements Disposable {
                 })
                 .on("ready", () => {
                     client.mSshClient.exec(
-                        posix.join(opts.serverPath ?? ZSshClient.DEFAULT_SERVER_PATH, "zowed"),
+                        [
+                            posix.join(opts.serverPath ?? ZSshClient.DEFAULT_SERVER_PATH, "zowed"),
+                            `-num-workers ${opts.numWorkers ?? 10}`,
+                        ].join(" "),
                         (err, stream) => {
                             if (err) {
                                 Logger.getAppLogger().error("Error running SSH command: %s", err.toString());

--- a/packages/sdk/src/doc/client.ts
+++ b/packages/sdk/src/doc/client.ts
@@ -21,6 +21,11 @@ export interface ClientOptions {
     onError?: (error: Error) => void | Promise<void>;
 
     /**
+     * Number of workers to spawn
+     */
+    numWorkers?: number;
+
+    /**
      * Number of seconds to wait for a response
      * (default: 60)
      */


### PR DESCRIPTION
**What It Does**

- Removes newline from job IDs as part of output
- Use 1 worker for the CLI plug-in to avoid starting unnecessary workers

**How to Test**

- Try to submit a job through the VSCE (right click in editor -> "Submit as JCL") and click the hyperlink
- Use the CLI with a command, notice the successful response.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)