### PR TITLE
fix(vsce): pass prefix to request for list jobs

### DIFF
--- a/packages/vsce/src/api/SshJesApi.ts
+++ b/packages/vsce/src/api/SshJesApi.ts
@@ -18,6 +18,7 @@ export class SshJesApi extends SshCommonApi implements MainframeInteraction.IJes
     public async getJobsByParameters(params: zosjobs.IGetJobsParms): Promise<zosjobs.IJob[]> {
         const response = await (await this.client).jobs.listJobs({
             owner: params.owner?.toUpperCase(),
+            prefix: params.prefix,
         });
         return response.items.map(
             (item): Partial<zosjobs.IJob> => ({


### PR DESCRIPTION
**What It Does**

spotted while testing before release

**How to Test**

List jobs with a prefix through the VS Code extension. Notice that results are filtered to only match jobs starting with said prefix.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
