### PR TITLE
fix: s0c4 if `--etag-only` not specified on writes

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -33,6 +33,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c`: Added conflict detection for USS and Data Set write operations through use of the `--etag` option. [#144](https://github.com/zowe/zowe-native-proto/issues/144)
 - `golang`: Added `Etag` property to request and response types for both USS and Data Set write operations. [#144](https://github.com/zowe/zowe-native-proto/issues/144)
 - `c`: Fixed issue where running the `zowex uss write` or `zowex ds write` commands without the `--etag-only` parameter resulted in a S0C4 and abrupt termination. [#216](https://github.com/zowe/zowe-native-proto/pull/216)
+- `c`: Fixed issue where running the `zowex uss write` or `zowex ds write` commands without the `--encoding` parameter resulted in a no-op. [#216](https://github.com/zowe/zowe-native-proto/pull/216)
 
 ## [Unreleased]
 

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -32,6 +32,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `golang`: Fixed issue where a newline was present in the job ID when returning a response for the "submitJcl" command. [#211](https://github.com/zowe/zowe-native-proto/pull/211)
 - `c`: Added conflict detection for USS and Data Set write operations through use of the `--etag` option. [#144](https://github.com/zowe/zowe-native-proto/issues/144)
 - `golang`: Added `Etag` property to request and response types for both USS and Data Set write operations. [#144](https://github.com/zowe/zowe-native-proto/issues/144)
+- `c`: Fixed issue where running the `zowex uss write` or `zowex ds write` commands without the `--etag-only` parameter resulted in a S0C4 and abrupt termination. [#216](https://github.com/zowe/zowe-native-proto/pull/216)
 
 ## [Unreleased]
 

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -179,7 +179,7 @@ int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data, std::string e
 
   dsn = "//'" + dsn + "'";
 
-  if (!data.empty() && hasEncoding)
+  if (!data.empty())
   {
     auto *fp = fopen(dsn.c_str(), zds->encoding_opts.data_type == eDataTypeBinary ? "wb,recfm=U" : "w");
     if (fp == nullptr)
@@ -189,15 +189,18 @@ int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data, std::string e
     }
 
     std::string temp = data;
-    try
+    if (hasEncoding)
     {
-      const auto bytes_with_encoding = zut_encode(temp, "UTF-8", codepage, zds->diag);
-      temp = bytes_with_encoding;
-    }
-    catch (std::exception &e)
-    {
-      zds->diag.e_msg_len = sprintf(zds->diag.e_msg, "Failed to convert input data from UTF-8 to %s", codepage.c_str());
-      return RTNCD_FAILURE;
+      try
+      {
+        const auto bytes_with_encoding = zut_encode(temp, "UTF-8", codepage, zds->diag);
+        temp = bytes_with_encoding;
+      }
+      catch (std::exception &e)
+      {
+        zds->diag.e_msg_len = sprintf(zds->diag.e_msg, "Failed to convert input data from UTF-8 to %s", codepage.c_str());
+        return RTNCD_FAILURE;
+      }
     }
     if (!temp.empty())
     {

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1373,7 +1373,7 @@ int handle_data_set_write_to_dsn(ZCLIResult result)
     return RTNCD_FAILURE;
   }
 
-  if (result.get_option("--etag-only") == nullptr || !result.get_option("--etag-only")->is_found())
+  if (result.get_option("--etag-only") == nullptr && !result.get_option("--etag-only")->is_found())
   {
     cout << "Wrote data to '" << dsn << "'" << endl;
   }
@@ -1565,7 +1565,7 @@ int handle_uss_write(ZCLIResult result)
     cerr << "  Details: " << zusf.diag.e_msg << endl;
     return RTNCD_FAILURE;
   }
-  if (result.get_option("--etag-only") != nullptr || !result.get_option("--etag-only")->is_found())
+  if (result.get_option("--etag-only") != nullptr && !result.get_option("--etag-only")->is_found())
   {
     cout << "Wrote data to '" << file << "'" << endl;
   }

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -258,7 +258,7 @@ int zusf_write_to_uss_file(ZUSF *zusf, string file, string &data, std::string et
     }
   }
 
-  if (!data.empty() && hasEncoding)
+  if (!data.empty())
   {
     ofstream out(file.c_str(), zusf->encoding_opts.data_type == eDataTypeBinary ? ios::out | ios::binary : ios::out);
     if (!out.is_open())
@@ -268,15 +268,18 @@ int zusf_write_to_uss_file(ZUSF *zusf, string file, string &data, std::string et
     }
 
     std::string temp = data;
-    try
+    if (hasEncoding)
     {
-      const auto bytes_with_encoding = zut_encode(temp, "UTF-8", codepage, zusf->diag);
-      temp = bytes_with_encoding;
-    }
-    catch (std::exception &e)
-    {
-      zusf->diag.e_msg_len = sprintf(zusf->diag.e_msg, "Failed to convert input data from UTF-8 to %s", codepage.c_str());
-      return RTNCD_FAILURE;
+      try
+      {
+        const auto bytes_with_encoding = zut_encode(temp, "UTF-8", codepage, zusf->diag);
+        temp = bytes_with_encoding;
+      }
+      catch (std::exception &e)
+      {
+        zusf->diag.e_msg_len = sprintf(zusf->diag.e_msg, "Failed to convert input data from UTF-8 to %s", codepage.c_str());
+        return RTNCD_FAILURE;
+      }
     }
     if (!temp.empty())
     {


### PR DESCRIPTION
**What It Does**

- Fixes issue where a S0C4 is encountered when invoking `./zowex uss write` or `./zowex ds write` without using the `--etag-only` parameter.
  - Writes are still successful, but the exception is something that should be avoided
- Fixes issue where a no-op occurs when the `--encoding` flag is not provided to the USS write or DS write commands (more severe)

**How to Test**

- Test the current build on main when doing a USS write or DS write through a SSH shell. Don't pass the `--etag-only` parameter
  - Notice the S0C4 and abrupt termination
- Test the build on this branch and notice the S0C4 does not occur when `--etag-only` is not provided

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
