### PR TITLE
fix(ds): E-tag mismatch when data set saved with encoding specified

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c`: Fixed issue where running the `zowex uss write` or `zowex ds write` commands without the `--etag-only` parameter resulted in a S0C4 and abrupt termination. [#216](https://github.com/zowe/zowe-native-proto/pull/216)
 - `c`: Fixed issue where running the `zowex uss write` or `zowex ds write` commands without the `--encoding` parameter resulted in a no-op. [#216](https://github.com/zowe/zowe-native-proto/pull/216)
 - `golang`: Fixed issue where a jobs list request returns unexpected results whenever a search query does not match any jobs. [#217](https://github.com/zowe/zowe-native-proto/pull/217)
+- `c`: Fixed issue where e-tag calculation did not match when a data set was saved with the `--encoding` parameter provided. [#219](https://github.com/zowe/zowe-native-proto/pull/219)
 
 ## `0.1.0`
 

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -177,18 +177,18 @@ int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data, std::string e
     }
   }
 
-  dsn = "//'" + dsn + "'";
+  const string dsname = "//'" + dsn + "'";
 
+  std::string temp = data;
   if (!data.empty())
   {
-    auto *fp = fopen(dsn.c_str(), zds->encoding_opts.data_type == eDataTypeBinary ? "wb,recfm=U" : "w");
+    auto *fp = fopen(dsname.c_str(), zds->encoding_opts.data_type == eDataTypeBinary ? "wb,recfm=U" : "w");
     if (fp == nullptr)
     {
-      zds->diag.e_msg_len = sprintf(zds->diag.e_msg, "Could not open '%s'", dsn.c_str());
+      zds->diag.e_msg_len = sprintf(zds->diag.e_msg, "Could not open '%s'", dsname.c_str());
       return RTNCD_FAILURE;
     }
 
-    std::string temp = data;
     if (hasEncoding)
     {
       try
@@ -210,8 +210,14 @@ int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data, std::string e
   }
 
   // Print new e-tag to stdout as response
-  cout << std::hex << zut_calc_adler32_checksum(data) << std::dec << endl;
+  string saved_contents = "";
+  const auto read_rc = zds_read_from_dsn(zds, dsn, saved_contents);
+  if (read_rc != 0)
+  {
+    return RTNCD_FAILURE;
+  }
 
+  cout << std::hex << zut_calc_adler32_checksum(saved_contents) << std::dec << endl;
   return 0;
 }
 

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## TBD Release
 
 - Fixed issue where a jobs list request returns unexpected results whenever a search query does not match any jobs. [#217](https://github.com/zowe/zowe-native-proto/pull/217)
+- Fixed issue where data set save requests sometimes resulted in an unexpected conflict error. [#219](https://github.com/zowe/zowe-native-proto/pull/219)
 
 ## `0.1.0`
 


### PR DESCRIPTION
**What It Does**

Fixes issue where the e-tag did not match the e-tag for the saved contents when a data set was saved with encoding.

**How to Test**

- Open a data set in an editor from the VSCE, with either the default encoding (just click on it) or a custom one (right-click -> "Open with Encoding")
- In the same window, make a conflict using `zowex` from a terminal, e.g.:
  - `echo "test changes" | ./zowex ds write "TEST.DATASET(MEM1)"`
- Make a change in the data set and try to save it to trigger a conflict
- Notice a conflict is detected and both Overwrite / Compare works as expected

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)