### PR TITLE
validate ssh profiles when used on vsce

### DIFF
--- a/packages/vsce/src/SshConfigUtils.ts
+++ b/packages/vsce/src/SshConfigUtils.ts
@@ -12,7 +12,6 @@
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { ProfileConstants } from "@zowe/core-for-zowe-sdk";
-import { ImperativeError } from "@zowe/imperative";
 import {
     FileManagement,
     Gui,
@@ -21,7 +20,6 @@ import {
     ZoweVsCodeExtension,
     imperative,
 } from "@zowe/zowe-explorer-api";
-import { all } from "axios";
 import { Client, type ClientChannel } from "ssh2";
 import * as vscode from "vscode";
 import { type ISshConfigExt, ZClientUtils, ZSshClient } from "zowe-native-proto-sdk";

--- a/packages/vsce/src/SshConfigUtils.ts
+++ b/packages/vsce/src/SshConfigUtils.ts
@@ -473,10 +473,7 @@ export class SshConfigUtils {
         return selectedProfile;
     }
 
-    private static async setProfile(
-        selectedConfig: Partial<ISshConfigExt> | undefined,
-        updatedProfile?: string,
-    ): Promise<void> {
+    private static async setProfile(selectedConfig: ISshConfigExt | undefined, updatedProfile?: string): Promise<void> {
         // Profile information
         const zoweExplorerApi = ZoweVsCodeExtension.getZoweExplorerApi();
         const profCache = zoweExplorerApi.getExplorerExtenderApi().getProfilesCache();

--- a/packages/vsce/src/SshConfigUtils.ts
+++ b/packages/vsce/src/SshConfigUtils.ts
@@ -598,7 +598,7 @@ export class SshConfigUtils {
             await config.save(false);
         } catch (err) {}
     }
-    private static async validateConfig(newConfig: ISshConfigExt): Promise<Partial<ISshConfigExt> | undefined> {
+    private static async validateConfig(newConfig: ISshConfigExt): Promise<ISshConfigExt | undefined> {
         const attemptConnection = async (config: ISshConfigExt): Promise<boolean> => {
             return new Promise((resolve, reject) => {
                 const sshClient = new Client();
@@ -630,7 +630,7 @@ export class SshConfigUtils {
             });
         };
 
-        const promptForPassword = async (config: ISshConfigExt): Promise<Partial<ISshConfigExt> | undefined> => {
+        const promptForPassword = async (config: ISshConfigExt): Promise<ISshConfigExt | undefined> => {
             let passwordAttempts = 0;
             while (passwordAttempts < 3) {
                 config.password = await vscode.window.showInputBox({

--- a/packages/vsce/src/SshConfigUtils.ts
+++ b/packages/vsce/src/SshConfigUtils.ts
@@ -12,6 +12,7 @@
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { ProfileConstants } from "@zowe/core-for-zowe-sdk";
+import { ImperativeError } from "@zowe/imperative";
 import {
     FileManagement,
     Gui,
@@ -23,7 +24,6 @@ import {
 import { Client, type ClientChannel } from "ssh2";
 import * as vscode from "vscode";
 import { type ISshConfigExt, ZClientUtils, ZSshClient } from "zowe-native-proto-sdk";
-import { ImperativeError } from "@zowe/imperative";
 
 // biome-ignore lint/complexity/noStaticOnlyClass: Utilities class has static methods
 export class SshConfigUtils {

--- a/packages/vsce/src/Utilities.ts
+++ b/packages/vsce/src/Utilities.ts
@@ -41,6 +41,7 @@ export function registerCommands(context: vscode.ExtensionContext): vscode.Dispo
         vscode.commands.registerCommand("zowe-native-proto-vsce.connect", async (profName?: string) => {
             imperative.Logger.getAppLogger().trace("Running connect command for profile %s", profName);
             const profile = await SshConfigUtils.promptForProfile(profName);
+            console.debug();
             if (!profile?.profile) return;
 
             const sshSession = ZSshUtils.buildSession(profile.profile);

--- a/packages/vsce/src/Utilities.ts
+++ b/packages/vsce/src/Utilities.ts
@@ -41,7 +41,6 @@ export function registerCommands(context: vscode.ExtensionContext): vscode.Dispo
         vscode.commands.registerCommand("zowe-native-proto-vsce.connect", async (profName?: string) => {
             imperative.Logger.getAppLogger().trace("Running connect command for profile %s", profName);
             const profile = await SshConfigUtils.promptForProfile(profName);
-            console.debug();
             if (!profile?.profile) return;
 
             const sshSession = ZSshUtils.buildSession(profile.profile);


### PR DESCRIPTION
**What It Does**
Validates keyPassphrases and passwords on existing ssh profiles and prompts for corrections if necessary 

**How to Test**
- Create an ssh profile with an incorrect password or keypassphrase and attempt to utilize that ssh profile.
- enter the correct credential when the text input appears.
- Check the config file for a corrected credential, if it was previously in plaintext, it will now be in the secure array assuming isSecure() returns true for your context

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
