### PR TITLE
async init for workers, remove WaitGroup

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the native code for "zowe-native-proto" are documented in
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- `golang`: Reduced startup time for `zowed` by initializing workers in the background. [#237](https://github.com/zowe/zowe-native-proto/pull/237)
+- `golang`: Added verbose option to enable debug logging. [#237](https://github.com/zowe/zowe-native-proto/pull/237)
+
 ## `0.1.1`
 
 - `c`: Fixed issue where running the `zowex uss write` or `zowex ds write` commands without the `--etag-only` parameter resulted in a S0C4 and abrupt termination. [#216](https://github.com/zowe/zowe-native-proto/pull/216)

--- a/native/golang/main.go
+++ b/native/golang/main.go
@@ -55,7 +55,7 @@ func main() {
 	dispatcher := cmds.NewDispatcher()
 	cmds.InitializeCoreHandlers(dispatcher)
 
-	// Create the worker pool - workers are now initialized asynchronously
+	// Initialize workers in background
 	workerPool := CreateWorkerPool(options.NumWorkers, requestQueue, dispatcher)
 
 	// Log available worker count at initialization when verbose is enabled

--- a/native/golang/main.go
+++ b/native/golang/main.go
@@ -16,6 +16,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"time"
 
 	"zowe-native-proto/zowed/cmds"
 	t "zowe-native-proto/zowed/types/common"
@@ -25,6 +26,7 @@ import (
 // parseOptions parses command-line flags and returns the parsed options
 func parseOptions() t.IoserverOptions {
 	numWorkersFlag := flag.Int("num-workers", 10, "Number of worker threads for concurrent processing")
+	verboseFlag := flag.Bool("verbose", false, "Enable verbose logging")
 
 	flag.Parse()
 
@@ -34,12 +36,13 @@ func parseOptions() t.IoserverOptions {
 
 	return t.IoserverOptions{
 		NumWorkers: *numWorkersFlag,
+		Verbose:    *verboseFlag,
 	}
 }
 
 func main() {
 	options := parseOptions()
-	utils.InitLogger(false)
+	utils.InitLogger(false, options.Verbose)
 	utils.SetAutoConvOnUntaggedStdio()
 
 	// Channel for receiving input from stdin
@@ -52,7 +55,22 @@ func main() {
 	dispatcher := cmds.NewDispatcher()
 	cmds.InitializeCoreHandlers(dispatcher)
 
-	wg, _ := CreateWorkerPool(options.NumWorkers, requestQueue, dispatcher)
+	// Create the worker pool - workers are now initialized asynchronously
+	workerPool := CreateWorkerPool(options.NumWorkers, requestQueue, dispatcher)
+
+	// Log available worker count at initialization when verbose is enabled
+	if utils.IsVerboseLogging() {
+		go func() {
+			for {
+				count := workerPool.GetAvailableWorkersCount()
+				utils.LogDebug("Available workers: %d/%d", count, options.NumWorkers)
+				time.Sleep(500 * time.Millisecond)
+				if count == int32(options.NumWorkers) {
+					break
+				}
+			}
+		}()
+	}
 
 	// Start goroutine to read from stdin
 	go func() {
@@ -62,15 +80,14 @@ func main() {
 			// Process each line (it should be a complete JSON request)
 			input <- []byte(line)
 		}
-		close(requestQueue)
+		// Close the input channel once stdin is closed
+		close(input)
 	}()
 
-	// Distribute incoming requests to the queue
+	// Distribute incoming requests to available workers
 	for data := range input {
-		requestQueue <- data
+		workerPool.DistributeRequest(data)
 	}
 
-	// If stdin is closed (process likely terminated), close the request queue and wait for all workers to finish
-	close(requestQueue)
-	wg.Wait()
+	// `zowed` exits after stdin is closed and all pending requests are processed
 }

--- a/native/golang/types/common/options.go
+++ b/native/golang/types/common/options.go
@@ -12,7 +12,8 @@
 package types
 
 type IoserverOptions struct {
-	NumWorkers int `json:"numWorkers,omitempty"`
+	NumWorkers int  `json:"numWorkers,omitempty"`
+	Verbose    bool `json:"verbose,omitempty"`
 }
 
 type ListOptions struct {

--- a/native/golang/utils/log.go
+++ b/native/golang/utils/log.go
@@ -20,6 +20,23 @@ import (
 )
 
 var logFile *os.File
+var verboseLogging bool
+
+// IsVerboseLogging returns whether verbose logging is enabled
+func IsVerboseLogging() bool {
+	return verboseLogging
+}
+
+// LogDebug logs a debug message to the log file if verbose logging is enabled
+func LogDebug(format string, args ...any) {
+	if !verboseLogging {
+		return
+	}
+	_, err := logFile.WriteString(fmt.Sprintf("[DEBUG] "+format, args...) + "\n")
+	if err != nil {
+		log.Fatalln("Failed to write to log file:", err)
+	}
+}
 
 // LogError logs an error to the log file
 func LogError(format string, args ...any) {
@@ -37,7 +54,7 @@ func LogError(format string, args ...any) {
 	// If log file size exceeds 10MB, truncate and reopen the file
 	if info.Size() > 10*1024*1024 {
 		logFile.Close()
-		InitLogger(true)
+		InitLogger(true, verboseLogging)
 		_, _ = logFile.WriteString("Log file truncated due to size limit\n")
 	}
 }
@@ -56,7 +73,8 @@ func PrintErrorResponse(details t.ErrorDetails, rpcId *int) {
 }
 
 // InitLogger initializes the logger
-func InitLogger(truncate bool) {
+func InitLogger(truncate bool, verbose bool) {
+	verboseLogging = verbose
 	access := os.O_APPEND
 	if truncate {
 		access = os.O_TRUNC
@@ -68,4 +86,7 @@ func InitLogger(truncate bool) {
 	}
 
 	logFile = file
+	if verbose {
+		LogDebug("Verbose logging enabled")
+	}
 }

--- a/native/golang/worker.go
+++ b/native/golang/worker.go
@@ -169,7 +169,7 @@ func CreateWorkerPool(numWorkers int, requestQueue chan []byte, dispatcher *cmds
 		Queue:      requestQueue,
 	}
 
-	// Create all workers but initialize them asynchronously
+	// Create each worker
 	for i := 0; i < numWorkers; i++ {
 		worker := &Worker{
 			ID:           i,
@@ -187,7 +187,7 @@ func CreateWorkerPool(numWorkers int, requestQueue chan []byte, dispatcher *cmds
 	return pool
 }
 
-// initializeWorker initializes a worker asynchronously
+// initializeWorker initializes a worker for forwarding `zowex` requests/responses
 func initializeWorker(worker *Worker, pool *WorkerPool) {
 	// Create a separate `zowex` process in interactive mode for each worker
 	workerCmd := utils.BuildCommand([]string{"--it"})

--- a/packages/sdk/src/doc/gen/common.ts
+++ b/packages/sdk/src/doc/gen/common.ts
@@ -123,6 +123,7 @@ export interface Spool {
 
 export interface IoserverOptions {
   numWorkers?: number /* int */;
+  verbose?: boolean;
 }
 export interface ListOptions {
   /**

--- a/packages/sdk/src/doc/gen/common.ts
+++ b/packages/sdk/src/doc/gen/common.ts
@@ -117,6 +117,13 @@ export interface Spool {
    */
   procstep: string;
 }
+/**
+ * StatusMessage represents the status of `zowed` and serves as a health check
+ */
+export interface StatusMessage {
+  status: string;
+  message: string;
+}
 
 //////////
 // source: options.go


### PR DESCRIPTION
**What It Does**

- No longer wait for all workers to be available and remove use of WaitGroup
- Asynchronously initializes workers to reduce time-to-input for `zowed` once started by the client
  - Allows server to start accepting requests as soon as the first worker is available
  - Balances requests in the same fashion as before, but prioritizes available workers in the event that requests are more immediate
- Adds verbose logging to `zowed` for debugging purposes
- Moves request queue into worker pool for more explicit code separation

**How to Test**

- Start the server from the VSCE or CLI and notice that the client does not take as long to validate/wait to send input

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)