### PR TITLE
vsce: Refactor `promptForProfile()`

### DIFF
--- a/packages/vsce/src/SshConfigUtils.ts
+++ b/packages/vsce/src/SshConfigUtils.ts
@@ -27,7 +27,10 @@ import { type ISshConfigExt, ZClientUtils, ZSshClient } from "zowe-native-proto-
 // biome-ignore lint/complexity/noStaticOnlyClass: Utilities class has static methods
 export class SshConfigUtils {
     public static migratedConfigs: ISshConfigExt[];
+    public static filteredMigratedConfigs: ISshConfigExt[];
     public static validationResult: ISshConfigExt | undefined;
+    public static selectedProfile: ISshConfigExt | undefined;
+    public static sshProfiles: imperative.IProfileLoaded[];
 
     public static getServerPath(profile?: imperative.IProfile): string {
         const serverPathMap: Record<string, string> =
@@ -49,94 +52,46 @@ export class SshConfigUtils {
             return profCache.getLoadedProfConfig(profileName, "ssh");
         }
 
-        const sshProfiles = (await profCache.fetchAllProfilesByType("ssh")).filter(
+        SshConfigUtils.sshProfiles = (await profCache.fetchAllProfilesByType("ssh")).filter(
             ({ name, profile }) => name && profile?.host,
         );
 
         // Get configs from ~/.ssh/config
         SshConfigUtils.migratedConfigs = await ZClientUtils.migrateSshConfig();
 
+        console.debug();
         // Parse to remove migratable configs that already exist on the team config
-        const filteredMigratedConfigs = SshConfigUtils.migratedConfigs.filter(
-            (migratedConfig) => !sshProfiles.some((sshProfile) => sshProfile.profile?.host === migratedConfig.hostname),
+        SshConfigUtils.filteredMigratedConfigs = SshConfigUtils.migratedConfigs.filter(
+            (migratedConfig) =>
+                !SshConfigUtils.sshProfiles.some((sshProfile) => sshProfile.profile?.host === migratedConfig.hostname),
         );
 
-        // Choose between adding a new SSH host, an existing team config profile, and migrating from config.
-        const qpItems: vscode.QuickPickItem[] = [
-            { label: "$(plus) Add New SSH Host..." },
-            ...sshProfiles.map(({ name, profile }) => ({
-                label: name!,
-                description: profile!.host!,
-            })),
-            {
-                label: "Migrate From SSH Config",
-                kind: vscode.QuickPickItemKind.Separator,
-            },
-            ...filteredMigratedConfigs.map(({ name, hostname }) => ({
-                label: name!,
-                description: hostname,
-            })),
-        ];
+        console.debug();
+        // If result is add new SSH host then create a new config, if not use migrated configs
+        SshConfigUtils.selectedProfile = SshConfigUtils.filteredMigratedConfigs.find(
+            ({ name, hostname }) => result?.label === name && result?.description === hostname,
+        );
 
-        // Function to show the QuickPick with dynamic top option
-        async function showQuickPickWithCustomInput(): Promise<vscode.QuickPickItem | undefined> {
-            const quickPick = vscode.window.createQuickPick();
-            quickPick.items = qpItems;
-            quickPick.placeholder = "Select configured SSH host or enter user@host";
+        console.debug();
+        // Prompt for a new profile name with the hostname (for adding a new config) or host value (for migrating from a config)
+        SshConfigUtils.selectedProfile = await SshConfigUtils.getNewProfileName(
+            SshConfigUtils.selectedProfile!,
+            profInfo.getTeamConfig(),
+        );
 
-            let value: undefined;
-
-            // Add the custom entry
-            const customItem = {
-                label: `> ${value}`, // Using ">" as a visual cue for custom input
-                description: "Custom SSH Host",
-                alwaysShow: true,
-            };
-            quickPick.onDidChangeValue((value) => {
-                if (value) {
-                    // Update custom entry when something is typed in search bar
-                    customItem.label = `> ${value}`;
-                    // Update the QuickPick items with the custom entry at the top, if not already added
-                    quickPick.items = [customItem, ...qpItems.filter((item) => item.label !== customItem.label)];
-                } else {
-                    // Remove the custom entry if the search bar is cleared
-                    quickPick.items = [...qpItems];
-                }
-            });
-
-            // Show the QuickPick
-            quickPick.show();
-
-            // Wait for selection
-            const result = await new Promise<vscode.QuickPickItem | undefined>((resolve) => {
-                quickPick.onDidAccept(() => {
-                    resolve(quickPick.selectedItems[0]);
-                    quickPick.hide();
-                });
-            });
-
-            if (result?.label.startsWith(">")) result.label = result.label.replace(">", "").trim();
-
-            return result;
-        }
-        const result = await showQuickPickWithCustomInput();
+        const result = await SshConfigUtils.showQuickPickWithCustomInput();
 
         // If nothing selected, return
         if (!result) return;
 
-        // If result is add new SSH host then create a new config, if not use migrated configs
-        let selectedProfile = filteredMigratedConfigs.find(
-            ({ name, hostname }) => result.label === name && result.description === hostname,
-        );
-
         if (result.description === "Custom SSH Host") {
-            selectedProfile = await SshConfigUtils.createNewConfig(result.label, false);
+            SshConfigUtils.selectedProfile = await SshConfigUtils.createNewConfig(result.label, false);
         } else if (result.label === "$(plus) Add New SSH Host...") {
-            selectedProfile = await SshConfigUtils.createNewConfig();
+            SshConfigUtils.selectedProfile = await SshConfigUtils.createNewConfig();
         }
 
-        if (!selectedProfile) {
-            const foundProfile = sshProfiles.find(({ name }) => name === result.label);
+        if (!SshConfigUtils.selectedProfile) {
+            const foundProfile = SshConfigUtils.sshProfiles.find(({ name }) => name === result.label);
             if (foundProfile) {
                 const validConfig = await SshConfigUtils.validateConfig({
                     hostname: foundProfile?.profile?.host,
@@ -165,152 +120,47 @@ export class SshConfigUtils {
         }
         ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        // Prompt for a new profile name with the hostname (for adding a new config) or host value (for migrating from a config)
-
-        selectedProfile = await SshConfigUtils.getNewProfileName(selectedProfile!, profInfo.getTeamConfig());
-        if (!selectedProfile?.name) {
+        if (!SshConfigUtils.selectedProfile?.name) {
             vscode.window.showWarningMessage("SSH setup cancelled.");
             return;
         }
 
         // Attempt to validate with given URL/creds
-        SshConfigUtils.validationResult = await SshConfigUtils.validateConfig(selectedProfile);
+        SshConfigUtils.validationResult = await SshConfigUtils.validateConfig(SshConfigUtils.selectedProfile);
 
         // If validateConfig returns a string, that string is the correct keyPassphrase
         if (SshConfigUtils.validationResult && Object.keys(SshConfigUtils.validationResult).length >= 1) {
-            selectedProfile = { ...selectedProfile, ...SshConfigUtils.validationResult };
+            SshConfigUtils.selectedProfile = { ...SshConfigUtils.selectedProfile, ...SshConfigUtils.validationResult };
         }
+
         if (SshConfigUtils.validationResult === undefined) {
-            // Create a progress bar using the custom Gui.withProgress
-            await Gui.withProgress(
-                {
-                    location: vscode.ProgressLocation.Notification,
-                    title: "Validating SSH Configurations...",
-                    cancellable: false,
-                },
-                async (progress, token) => {
-                    let validationAttempts = SshConfigUtils.migratedConfigs.filter(
-                        (config) => config.hostname === selectedProfile?.hostname,
-                    );
-
-                    // If multiple matches exist, narrow down by user
-                    if (validationAttempts.length > 1 && selectedProfile?.user) {
-                        validationAttempts = validationAttempts.filter(
-                            (config) => config.user === selectedProfile?.user,
-                        );
-                    } else {
-                        // If no user is specified, allow all configs where the hostname matches
-                        validationAttempts = validationAttempts.filter(
-                            (config) => !selectedProfile?.user || config.user === selectedProfile?.user,
-                        );
-                    }
-
-                    // Iterate over filtered validation attempts
-                    let step = 0;
-                    for (const profile of validationAttempts) {
-                        const testValidation: ISshConfigExt = profile;
-
-                        const result = await SshConfigUtils.validateConfig(testValidation);
-                        step++;
-                        progress.report({ increment: 100 / validationAttempts.length });
-
-                        if (result) {
-                            SshConfigUtils.validationResult = {};
-                            if (typeof result === "string") {
-                                testValidation.keyPassphrase = result;
-                            }
-                            selectedProfile = testValidation;
-                            break;
-                        }
-                    }
-
-                    // Find private keys located at ~/.ssh/ and attempt to connect with them
-                    if (!SshConfigUtils.validationResult) {
-                        const foundPrivateKeys = await ZClientUtils.findPrivateKeys();
-                        for (const privateKey of foundPrivateKeys) {
-                            const testValidation: ISshConfigExt = selectedProfile!;
-                            testValidation.privateKey = privateKey;
-
-                            const result = await SshConfigUtils.validateConfig(testValidation);
-                            step++;
-                            progress.report({ increment: 100 / foundPrivateKeys.length });
-
-                            if (result) {
-                                SshConfigUtils.validationResult = {};
-                                if (typeof result === "string") {
-                                    testValidation.keyPassphrase = result;
-                                    selectedProfile = testValidation;
-                                }
-                                break;
-                            }
-                        }
-                    }
-                },
-            );
+            await SshConfigUtils.validateFoundPrivateKeys();
         }
 
-        // Password loading bar
-        await Gui.withProgress(
-            {
-                location: vscode.ProgressLocation.Notification,
-                title: "Validating Password...",
-                cancellable: false,
-            },
-            async (progress) => {
-                // If not validated, remove private key from profile and get the password
-                if (SshConfigUtils.validationResult === undefined) {
-                    selectedProfile!.privateKey = undefined;
-
-                    // Show the password input prompt
-                    const passwordPrompt = await vscode.window.showInputBox({
-                        title: `${selectedProfile?.user}@${selectedProfile?.hostname}'s password:`,
-                        password: true,
-                        placeHolder: "Enter your password",
-                        ignoreFocusOut: true,
-                    });
-
-                    if (!passwordPrompt || !selectedProfile) return;
-
-                    // Validate the password
-                    const validatePassword = await SshConfigUtils.validateConfig({
-                        ...selectedProfile,
-                        password: passwordPrompt,
-                    });
-
-                    if (validatePassword && Object.keys(validatePassword).length === 0) {
-                        selectedProfile.password = passwordPrompt;
-                    } else if (validatePassword && Object.keys(validatePassword).length >= 1) {
-                        selectedProfile = { ...selectedProfile, ...validatePassword };
-                    } else {
-                        // vscode.window.showWarningMessage("Password Authentication Failed");
-                        return;
-                    }
-                }
-            },
-        );
+        await SshConfigUtils.validatePassword();
 
         // If no private key or password is on the profile then there is no possible validation combination, thus return
-        if (!selectedProfile?.privateKey && !selectedProfile?.password) {
+        if (!SshConfigUtils.selectedProfile?.privateKey && !SshConfigUtils.selectedProfile?.password) {
             vscode.window.showWarningMessage("SSH setup cancelled.");
             return;
         }
 
-        await SshConfigUtils.setProfile(selectedProfile);
+        await SshConfigUtils.setProfile(SshConfigUtils.selectedProfile);
 
         return {
-            name: selectedProfile.name,
+            name: SshConfigUtils.selectedProfile.name,
             message: "",
             failNotFound: false,
             type: "ssh",
             profile: {
-                host: selectedProfile.hostname,
-                name: selectedProfile.name,
-                password: selectedProfile.password,
-                user: selectedProfile.user,
-                privateKey: selectedProfile.privateKey,
-                handshakeTimeout: selectedProfile.handshakeTimeout,
-                port: selectedProfile.port,
-                keyPassphrase: selectedProfile.keyPassphrase,
+                host: SshConfigUtils.selectedProfile.hostname,
+                name: SshConfigUtils.selectedProfile.name,
+                password: SshConfigUtils.selectedProfile.password,
+                user: SshConfigUtils.selectedProfile.user,
+                privateKey: SshConfigUtils.selectedProfile.privateKey,
+                handshakeTimeout: SshConfigUtils.selectedProfile.handshakeTimeout,
+                port: SshConfigUtils.selectedProfile.port,
+                keyPassphrase: SshConfigUtils.selectedProfile.keyPassphrase,
             },
         };
     }
@@ -731,5 +581,178 @@ export class SshConfigUtils {
             }
         }
         return configModifications;
+    }
+
+    private static async validateFoundPrivateKeys() {
+        // Create a progress bar using the custom Gui.withProgress
+        await Gui.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: "Validating SSH Configurations...",
+                cancellable: false,
+            },
+            async (progress, token) => {
+                let validationAttempts = SshConfigUtils.migratedConfigs.filter(
+                    (config) => config.hostname === SshConfigUtils.selectedProfile?.hostname,
+                );
+
+                // If multiple matches exist, narrow down by user
+                if (validationAttempts.length > 1 && SshConfigUtils.selectedProfile?.user) {
+                    validationAttempts = validationAttempts.filter(
+                        (config) => config.user === SshConfigUtils.selectedProfile?.user,
+                    );
+                } else {
+                    // If no user is specified, allow all configs where the hostname matches
+                    validationAttempts = validationAttempts.filter(
+                        (config) =>
+                            !SshConfigUtils.selectedProfile?.user ||
+                            config.user === SshConfigUtils.selectedProfile?.user,
+                    );
+                }
+
+                // Iterate over filtered validation attempts
+                let step = 0;
+                for (const profile of validationAttempts) {
+                    const testValidation: ISshConfigExt = profile;
+
+                    const result = await SshConfigUtils.validateConfig(testValidation);
+                    step++;
+                    progress.report({ increment: 100 / validationAttempts.length });
+
+                    if (result) {
+                        SshConfigUtils.validationResult = {};
+                        if (typeof result === "string") {
+                            testValidation.keyPassphrase = result;
+                        }
+                        SshConfigUtils.selectedProfile = testValidation;
+                        break;
+                    }
+                }
+
+                // Find private keys located at ~/.ssh/ and attempt to connect with them
+                if (!SshConfigUtils.validationResult) {
+                    const foundPrivateKeys = await ZClientUtils.findPrivateKeys();
+                    for (const privateKey of foundPrivateKeys) {
+                        const testValidation: ISshConfigExt = SshConfigUtils.selectedProfile!;
+                        testValidation.privateKey = privateKey;
+
+                        const result = await SshConfigUtils.validateConfig(testValidation);
+                        step++;
+                        progress.report({ increment: 100 / foundPrivateKeys.length });
+
+                        if (result) {
+                            SshConfigUtils.validationResult = {};
+                            if (typeof result === "string") {
+                                testValidation.keyPassphrase = result;
+                                SshConfigUtils.selectedProfile = testValidation;
+                            }
+                            break;
+                        }
+                    }
+                }
+            },
+        );
+    }
+
+    private static async validatePassword() {
+        // Password loading bar
+        await Gui.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: "Validating Password...",
+                cancellable: false,
+            },
+            async (progress) => {
+                // If not validated, remove private key from profile and get the password
+                if (SshConfigUtils.validationResult === undefined) {
+                    SshConfigUtils.selectedProfile!.privateKey = undefined;
+
+                    // Show the password input prompt
+                    const passwordPrompt = await vscode.window.showInputBox({
+                        title: `${SshConfigUtils.selectedProfile?.user}@${SshConfigUtils.selectedProfile?.hostname}'s password:`,
+                        password: true,
+                        placeHolder: "Enter your password",
+                        ignoreFocusOut: true,
+                    });
+
+                    if (!passwordPrompt || !SshConfigUtils.selectedProfile) return;
+
+                    // Validate the password
+                    const validatePassword = await SshConfigUtils.validateConfig({
+                        ...SshConfigUtils.selectedProfile,
+                        password: passwordPrompt,
+                    });
+
+                    if (validatePassword && Object.keys(validatePassword).length === 0) {
+                        SshConfigUtils.selectedProfile.password = passwordPrompt;
+                    } else if (validatePassword && Object.keys(validatePassword).length >= 1) {
+                        SshConfigUtils.selectedProfile = { ...SshConfigUtils.selectedProfile, ...validatePassword };
+                    } else {
+                        // vscode.window.showWarningMessage("Password Authentication Failed");
+                        return;
+                    }
+                }
+            },
+        );
+    }
+
+    // Function to show the QuickPick with dynamic top option
+    private static async showQuickPickWithCustomInput(): Promise<vscode.QuickPickItem | undefined> {
+        // Choose between adding a new SSH host, an existing team config profile, and migrating from config.
+        const qpItems: vscode.QuickPickItem[] = [
+            { label: "$(plus) Add New SSH Host..." },
+            ...SshConfigUtils.sshProfiles.map(({ name, profile }) => ({
+                label: name!,
+                description: profile!.host!,
+            })),
+            {
+                label: "Migrate From SSH Config",
+                kind: vscode.QuickPickItemKind.Separator,
+            },
+            ...SshConfigUtils.filteredMigratedConfigs.map(({ name, hostname }) => ({
+                label: name!,
+                description: hostname,
+            })),
+        ];
+
+        const quickPick = vscode.window.createQuickPick();
+        quickPick.items = qpItems;
+        quickPick.placeholder = "Select configured SSH host or enter user@host";
+
+        let value: undefined;
+
+        // Add the custom entry
+        const customItem = {
+            label: `> ${value}`, // Using ">" as a visual cue for custom input
+            description: "Custom SSH Host",
+            alwaysShow: true,
+        };
+
+        quickPick.onDidChangeValue((value) => {
+            if (value) {
+                // Update custom entry when something is typed in search bar
+                customItem.label = `> ${value}`;
+                // Update the QuickPick items with the custom entry at the top, if not already added
+                quickPick.items = [customItem, ...qpItems.filter((item) => item.label !== customItem.label)];
+            } else {
+                // Remove the custom entry if the search bar is cleared
+                quickPick.items = [...qpItems];
+            }
+        });
+
+        // Show the QuickPick
+        quickPick.show();
+
+        // Wait for selection
+        const result = await new Promise<vscode.QuickPickItem | undefined>((resolve) => {
+            quickPick.onDidAccept(() => {
+                resolve(quickPick.selectedItems[0]);
+                quickPick.hide();
+            });
+        });
+
+        if (result?.label.startsWith(">")) result.label = result.label.replace(">", "").trim();
+
+        return result;
     }
 }


### PR DESCRIPTION
**What It Does**
- Refactor `promptForProfile()` in SshConfigUtils.ts to have logic broken up
- Remove unused methods now that `validateConfig()` handles prompting and returning passwords
- Fix regression in regards to using found private keys within `~/.ssh/config`
- Improved regex validation for a custom/new ssh connection via an ssh command ex `ssh example@user` or `example@user`

**How to test**

**Cases**
1.
- a. Within your ssh config file `(~/.ssh/config)` create a profile that has an `IdentityFile` that is valid for an existing ssh connection with a corresponding `hostname`
Ex:
```
Host Example
  HostName Example.net
  user TestUser
  Port 22
  IdentityFile /Users/Test/.ssh/id_test
```
Note: IdentityFile should **NOT** have one of the automatically detected algorithm names - "id_ed25519","id_rsa","id_ecdsa", "id_dsa"

- b. Create a configuration via an ssh command where the IdentityFile previously set is a valid form of authentication
Ex: `ssh TestUser@Example.net`
- c. You will either be prompted for a key passphrase if required or it will automatically deploy to the server.

2. a. Similar to the previous test case but the IdenitityFile is one of the automatically detected names ex: `/Users/Test/.ssh/id_rsa`
b. if this is a valid private key, the server will be deployed

3. Connect via a migrated config (similar to above, minus private key) and enter password.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
