### PR TITLE
Fix error handling for server deploy

### DIFF
--- a/native/golang/utils/bytes.go
+++ b/native/golang/utils/bytes.go
@@ -15,6 +15,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -48,7 +49,7 @@ func CollectContentsAsBytes(input string, isByteString bool) (data []byte, err e
 }
 
 func LoadChecksums() map[string]string {
-	checksumsFile := "checksums.asc"
+	checksumsFile := filepath.Dir(os.Args[0]) + "/checksums.asc"
 	file, err := os.Open(checksumsFile)
 	if os.IsNotExist(err) {
 		// Checksums file does not exist for dev builds


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes regressions introduced in #236:
* SSH profile validation hangs when server binary not found
* Checksums file not found by `zowed` and missing ASCII tag
* Checksums did not match when listed in different order

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Same as #236

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
