### PR TITLE
Add zoweax to server PAX release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           gh run download $RUN_ID --name zowe-server
           mkdir packages/cli/bin && cp server.pax.Z packages/cli/bin/
           mkdir packages/vsce/bin && cp server.pax.Z packages/vsce/bin/
+          gh run download $RUN_ID --name zowe-server-full
           mkdir dist && mv server.pax.Z dist/zowe-server-${NEW_VERSION}.pax.Z
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/zos-build.yml
+++ b/.github/workflows/zos-build.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           command: npm run z:all
           max_attempts: 3
-          new_command_on_retry: npm run z:build && npm run z:artifacts
+          new_command_on_retry: npm run z:build && npm run z:artifacts:all
           retry_on_exit_code: 11 # Ignore transient SIGSEGV error on Go build
           timeout_minutes: 10
 
@@ -52,6 +52,11 @@ jobs:
         with:
           name: zowe-server
           path: packages/cli/bin/server.pax.Z
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: zowe-server-full
+          path: dist/server.pax.Z
 
       - name: Clean up on z/OS
         if: always()

--- a/package.json
+++ b/package.json
@@ -17,14 +17,16 @@
     "watch": "npm run watch:native & npm run watch:client",
     "watch:client": "npm run watch --workspaces",
     "watch:native": "node scripts/watchNative.js",
-    "z:all": "npm run z:init && npm run z:deploy:build && npm run z:artifacts",
+    "z:all": "npm run z:init && npm run z:deploy:build && npm run z:artifacts:all",
     "z:artifacts": "npm run tools -- artifacts",
+    "z:artifacts:all": "npm run z:artifacts && npm run z:package",
     "z:build": "npm run tools -- build",
     "z:clean": "npm run tools -- clean",
     "z:delete": "npm run tools -- delete",
     "z:deploy": "npm run tools -- deploy",
     "z:deploy:build": "npm run tools -- deploy:build",
-    "z:init": "npm run tools -- init"
+    "z:init": "npm run tools -- init",
+    "z:package": "npm run tools -- package"
   },
   "keywords": [],
   "author": "",

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -94,7 +94,10 @@ connection.on("ready", async () => {
                 await getDumps(connection);
                 break;
             case "artifacts":
-                await artifacts(connection);
+                await artifacts(connection, false);
+                break;
+            case "package":
+                await artifacts(connection, true);
                 break;
             case "clean":
                 await clean(connection);
@@ -286,10 +289,13 @@ async function getDumps(connection: Client) {
     await retrieve(connection, resp, "dumps");
 }
 
-async function artifacts(connection: Client) {
+async function artifacts(connection: Client, packageApf: boolean) {
     const artifactPaths = ["c/zowex", "golang/zowed"];
+    if (packageApf) {
+        artifactPaths.push("c/zoweax");
+    }
     const artifactNames = artifactPaths.map((file) => basename(file)).sort();
-    const localDirs = ["packages/cli/bin", "packages/vsce/bin"];
+    const localDirs = packageApf ? ["dist"] : ["packages/cli/bin", "packages/vsce/bin"];
     const localFiles = ["server.pax.Z", "checksums.asc"];
     const [paxFile, checksumFile] = localFiles;
     const prePaxCmds = artifactPaths.map((file) => `cp ${file} ${basename(file)} && chmod 700 ${basename(file)}`);


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Adds `zoweax` binary to the server PAX that we publish to GitHub releases 😋 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run `npm run z:artifacts:all` and verify that there are 2 different server PAX files generated: one in `dist` with `zoweax` and another in `packages/*/bin` without `zoweax`.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
