### PR TITLE
Add Parms to Run

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -144,6 +144,5 @@
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "files.eol": "\n",
-  "cmake.sourceDirectory": "/Users/dk635460/dev/c/zowe-native-proto/node_modules/cpu-features/deps/cpu_features/cmake/ci/sample"
+  "files.eol": "\n"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -144,5 +144,6 @@
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "files.eol": "\n"
+  "files.eol": "\n",
+  "cmake.sourceDirectory": "/Users/dk635460/dev/c/zowe-native-proto/node_modules/cpu-features/deps/cpu_features/cmake/ci/sample"
 }

--- a/native/c/zadata.hpp
+++ b/native/c/zadata.hpp
@@ -1,0 +1,70 @@
+#ifndef ZADATA_HPP
+#define ZADATA_HPP
+
+#include <string>
+
+typedef struct
+{
+  unsigned char language;
+  unsigned short record_type;
+  unsigned char arch_level;
+  unsigned char flag;
+  unsigned char edition;
+  unsigned char reserved[4];
+  unsigned short len;
+} ADATA_HEADER;
+
+typedef struct
+{
+  unsigned char esid[4];
+  int statement_number;
+  int location_counter;
+  unsigned char reserved[8];
+  int instruction_offset;
+  int instruction_length;
+  unsigned char instruction_value[3];
+} MACHINE_RECORD;
+
+typedef struct
+{
+  unsigned char esid[4];
+  int statement_number;
+  int input_record_number;
+  int parent_record_number;
+  int input_assigned_file_number;
+  int parent_assigned_file_number;
+  int location_counter;
+  unsigned char input_record_origin;
+  unsigned char parent_record_origin;
+  unsigned char print_flags;
+  unsigned char reserved0[2];
+  unsigned char source_record_type;
+  unsigned char assembler_operation_code;
+  unsigned char flags;
+  unsigned char reserved1[4];
+  unsigned char address1[4];
+  unsigned char reserved2[4];
+  unsigned char address2[4];
+  int offset_name_entry;
+  int length_name_entry;
+  int offset_operation;
+  int length_operation;
+  int offset_operand;
+  int length_operand;
+  int offset_remarks;
+  int length_remarks;
+  int offset_continuation_char;
+  unsigned char reserved3[4];
+  int input_macro_offset;
+  int input_macro_length;
+  int parent_macro_offset;
+  int parent_macro_length;
+  int source_record_offset;
+  int source_record_length;
+  unsigned char reserved4[8];
+  char input_macro_name[1];
+  char parent_macro_name[1];
+  char source_record[1];
+} SOURCE_ANALYSIS_RECORD;
+
+#endif

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -604,7 +604,7 @@ int main(int argc, char *argv[])
   tool_run.get_options().push_back(input);
 
   ZCLIOption outdd("out-dd");
-  outdd.set_description("input ddname");
+  outdd.set_description("output ddname");
   outdd.get_aliases().push_back("--odd");
   tool_run.get_options().push_back(outdd);
 

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <algorithm>
+#include <fstream>
 #include "zcn.hpp"
 #include "zut.hpp"
 #include "zcli.hpp"
@@ -581,6 +582,32 @@ int main(int argc, char *argv[])
   tool_group.get_verbs().push_back(tool_search);
 
   ZCLIVerb tool_run("run");
+
+  ZCLIOption dynalloc_pre("dynalloc-pre");
+  dynalloc_pre.set_description("dynalloc pre run statements");
+  dynalloc_pre.get_aliases().push_back("--dp");
+  tool_run.get_options().push_back(dynalloc_pre);
+
+  ZCLIOption dynalloc_post("dynalloc-post");
+  dynalloc_post.set_description("dynalloc post run statements");
+  dynalloc_post.get_aliases().push_back("--dt");
+  tool_run.get_options().push_back(dynalloc_post);
+
+  ZCLIOption indd("in-dd");
+  indd.set_description("input ddname");
+  indd.get_aliases().push_back("--idd");
+  tool_run.get_options().push_back(indd);
+
+  ZCLIOption input("input");
+  input.set_description("input");
+  input.get_aliases().push_back("--in");
+  tool_run.get_options().push_back(input);
+
+  ZCLIOption outdd("out-dd");
+  outdd.set_description("input ddname");
+  outdd.get_aliases().push_back("--odd");
+  tool_run.get_options().push_back(outdd);
+
   tool_run.set_description("run a program");
   tool_run.set_zcli_verb_handler(handle_tool_run);
   ZCLIPositional run_name("program");
@@ -1778,6 +1805,55 @@ int handle_tool_run(ZCLIResult result)
 {
   int rc = 0;
   string program(result.get_positional("program")->get_value());
+  string dynalloc_pre(result.get_option_value("--dynalloc-pre"));
+  string dynalloc_post(result.get_option_value("--dynalloc-post"));
+
+  // allocate anything that was requested
+  if (result.get_option("--dynalloc-pre"))
+  {
+    vector<string> dds;
+
+    ifstream in(dynalloc_pre.c_str());
+    if (!in.is_open())
+    {
+      cerr << "Error: could not open '" << dynalloc_pre << "'" << endl;
+      return RTNCD_FAILURE;
+    }
+
+    string line;
+    while (getline(in, line))
+    {
+      dds.push_back(line);
+    }
+    in.close();
+
+    rc = loop_dynalloc(dds);
+    if (RTNCD_SUCCESS != rc)
+    {
+      return RTNCD_FAILURE;
+    }
+  }
+
+  string indd(result.get_option_value("--in-dd"));
+  if (result.get_option("--in-dd"))
+  {
+    string ddname = "DD:" + indd;
+    ofstream out(ddname.c_str());
+    if (!out.is_open())
+    {
+      cerr << "Error: could not open input '" << ddname << "'" << endl;
+      return RTNCD_FAILURE;
+    }
+
+    string input(result.get_option_value("--input"));
+    if (result.get_option("--input"))
+    {
+      out << input << endl;
+    }
+
+    out.close();
+  }
+
   transform(program.begin(), program.end(), program.begin(), ::toupper); // upper case
 
   rc = zut_run(program);
@@ -1785,10 +1861,50 @@ int handle_tool_run(ZCLIResult result)
   if (0 != rc)
   {
     cerr << "Error: program '" << program << "' ended with rc: '" << rc << "'" << endl;
-    return RTNCD_FAILURE;
+    rc = RTNCD_FAILURE; // continue to obtain output
   }
 
-  return RTNCD_SUCCESS;
+  string outdd(result.get_option_value("--out-dd"));
+  if (result.get_option("--out-dd"))
+  {
+    string ddname = "DD:" + outdd;
+    ifstream in(ddname.c_str());
+    if (!in.is_open())
+    {
+      cerr << "Error: could not open output '" << ddname << "'" << endl;
+      return RTNCD_FAILURE;
+    }
+
+    string line;
+    while (getline(in, line))
+    {
+      cout << line << endl;
+    }
+    in.close();
+  }
+
+  // optionally free everything that was allocated
+  if (result.get_option("--dynalloc-post"))
+  {
+    vector<string> dds;
+
+    ifstream in(dynalloc_post.c_str());
+    if (!in.is_open())
+    {
+      cerr << "Error: could not open '" << dynalloc_post << "'" << endl;
+    }
+
+    string line;
+    while (getline(in, line))
+    {
+      dds.push_back(line);
+    }
+    in.close();
+
+    loop_dynalloc(dds);
+  }
+
+  return rc;
 }
 
 int handle_tool_search(ZCLIResult result)


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

`zowex tool run <pgm>` did not accept input.  For now, this adds a few options:

```
Options:
  --dynalloc-pre,--dp         dynalloc pre run statements
  --dynalloc-post,--dt        dynalloc post run statements
  --in-dd,--idd               input ddname
  --input,--in                input
  --out-dd,--odd              input ddname
```

This allows a user to specify files for dynallocation performed before and after the program is run to `alloc` and `free`.  You can also specify an `out-dd` to echo results of a specific dd upon completion as well as provide `--input` on the command line to an `--in-dd`.

Assuming you have `amblist_pre.txt`:

```
alloc dd(syslib) da('dkelosky.loadlib') shr
alloc dd(sysin) 
alloc dd(sysprint) 
```

And `amblist_post.txt`

```
free dd(syslib) 
free dd(sysin) 
free dd(sysprint) 
```

You could run something like `zowex tool run amblist --dynalloc-pre amblist_pre.txt --idd sysin --input " LISTLOAD OUTPUT=MAP,MEMBER=TESTASM1" --out-dd sysprint --dynalloc-post amblist_post.txt`

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
