### PR TITLE
Add `--return-etag` flag so displaying etag is optional

### DIFF
--- a/native/c/zadata.hpp
+++ b/native/c/zadata.hpp
@@ -1,3 +1,14 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
 #ifndef ZADATA_HPP
 #define ZADATA_HPP
 

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -140,12 +140,12 @@ int zds_write_to_dd(ZDS *zds, string ddname, string &data)
   return 0;
 }
 
-int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data, std::string etag_value)
+int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data)
 {
   const auto hasEncoding = zds->encoding_opts.data_type == eDataTypeText && strlen(zds->encoding_opts.codepage) > 0;
   const auto codepage = string(zds->encoding_opts.codepage);
 
-  if (!etag_value.empty())
+  if (zds->etag != nullptr)
   {
     ZDS read_ds = {0};
     string current_contents = "";
@@ -160,7 +160,7 @@ int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data, std::string e
       return RTNCD_FAILURE;
     }
 
-    const auto given_etag = strtoul(etag_value.c_str(), nullptr, 16);
+    const auto given_etag = strtoul(zds->etag, nullptr, 16);
     const auto new_etag = zut_calc_adler32_checksum(current_contents);
 
     if (given_etag != new_etag)
@@ -217,7 +217,12 @@ int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data, std::string e
     return RTNCD_FAILURE;
   }
 
-  cout << std::hex << zut_calc_adler32_checksum(saved_contents) << std::dec << endl;
+  stringstream etag_ss;
+  etag_ss << std::hex << zut_calc_adler32_checksum(saved_contents);
+  string etag_str = etag_ss.str();
+  std::vector<char> etag(etag_str.begin(), etag_str.end());
+  zds->etag = etag.data();
+
   return 0;
 }
 

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -217,11 +217,9 @@ int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data)
     return RTNCD_FAILURE;
   }
 
-  stringstream etag_ss;
-  etag_ss << std::hex << zut_calc_adler32_checksum(saved_contents);
-  string etag_str = etag_ss.str();
-  std::vector<char> etag(etag_str.begin(), etag_str.end());
-  zds->etag = etag.data();
+  stringstream etag_stream;
+  etag_stream << std::hex << zut_calc_adler32_checksum(saved_contents);
+  strcpy(zds->etag, etag_stream.str().c_str());
 
   return 0;
 }

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -145,7 +145,7 @@ int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data)
   const auto hasEncoding = zds->encoding_opts.data_type == eDataTypeText && strlen(zds->encoding_opts.codepage) > 0;
   const auto codepage = string(zds->encoding_opts.codepage);
 
-  if (zds->etag != nullptr)
+  if (strlen(zds->etag) > 0)
   {
     ZDS read_ds = {0};
     string current_contents = "";

--- a/native/c/zds.hpp
+++ b/native/c/zds.hpp
@@ -72,7 +72,7 @@ int zds_write_to_dd(ZDS *zds, std::string ddname, std::string &data);
  * @param data data to write
  * @return int 0 for success; non zero otherwise
  */
-int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data, std::string etag_value = "");
+int zds_write_to_dsn(ZDS *zds, std::string dsn, std::string &data);
 
 /**
  * @brief Create a data set

--- a/native/c/zdstype.h
+++ b/native/c/zdstype.h
@@ -55,7 +55,7 @@ typedef struct
   int32_t len;              // future use
 
   ZEncode encoding_opts;
-  char *etag;
+  char etag[8];
 
   int32_t max_entries;
   int32_t buffer_size;

--- a/native/c/zdstype.h
+++ b/native/c/zdstype.h
@@ -55,6 +55,7 @@ typedef struct
   int32_t len;              // future use
 
   ZEncode encoding_opts;
+  char *etag;
 
   int32_t max_entries;
   int32_t buffer_size;

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1345,9 +1345,12 @@ int handle_data_set_view_dsn(ZCLIResult result)
     return RTNCD_FAILURE;
   }
 
-  const auto etag = zut_calc_adler32_checksum(response);
-  cout << "etag: " << std::hex << etag << endl;
-  cout << "data: ";
+  if (result.get_option_value("--return-etag") == "true")
+  {
+    const auto etag = zut_calc_adler32_checksum(response);
+    cout << "etag: " << std::hex << etag << endl;
+    cout << "data: ";
+  }
   if (hasEncoding && result.get_option_value("--response-format-bytes") == "true")
   {
     zut_print_string_as_bytes(response);
@@ -1667,8 +1670,11 @@ int handle_uss_view(ZCLIResult result)
     return RTNCD_FAILURE;
   }
 
-  cout << "etag: " << zut_build_etag(file_stats.st_mtime, file_stats.st_size) << endl;
-  cout << "data: ";
+  if (result.get_option_value("--return-etag") == "true")
+  {
+    cout << "etag: " << zut_build_etag(file_stats.st_mtime, file_stats.st_size) << endl;
+    cout << "data: ";
+  }
   if (hasEncoding && result.get_option_value("--response-format-bytes") == "true")
   {
     zut_print_string_as_bytes(response);

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1534,7 +1534,8 @@ int handle_data_set_write_to_dsn(ZCLIResult result)
     return RTNCD_FAILURE;
   }
 
-  if (result.get_option("--etag-only") != nullptr && result.get_option("--etag-only")->is_found())
+  auto *etag_opt2 = result.get_option("--etag-only");
+  if (etag_opt2 != nullptr && etag_opt2->get_value() == "true")
   {
     cout << zds.etag << endl;
   }
@@ -1739,7 +1740,8 @@ int handle_uss_write(ZCLIResult result)
     return RTNCD_FAILURE;
   }
 
-  if (result.get_option("--etag-only") != nullptr && result.get_option("--etag-only")->is_found())
+  auto *etag_opt2 = result.get_option("--etag-only");
+  if (etag_opt2 != nullptr && etag_opt2->get_value() == "true")
   {
     cout << zusf.etag << endl;
   }

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1519,9 +1519,7 @@ int handle_data_set_write_to_dsn(ZCLIResult result)
   auto *etag_opt = result.get_option("--etag");
   if (etag_opt != nullptr && etag_opt->is_found())
   {
-    string etag_str = etag_opt->get_value();
-    std::vector<char> etag(etag_str.begin(), etag_str.end());
-    zds.etag = etag.data();
+    strcpy(zds.etag, etag_opt->get_value().c_str());
   }
 
   rc = zds_write_to_dsn(&zds, dsn, data);
@@ -1724,9 +1722,7 @@ int handle_uss_write(ZCLIResult result)
   auto *etag_opt = result.get_option("--etag");
   if (etag_opt != nullptr && etag_opt->is_found())
   {
-    string etag_str = etag_opt->get_value();
-    std::vector<char> etag(etag_str.begin(), etag_str.end());
-    zusf.etag = etag.data();
+    strcpy(zusf.etag, etag_opt->get_value().c_str());
   }
 
   rc = zusf_write_to_uss_file(&zusf, file, data);

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -296,8 +296,7 @@ int zusf_write_to_uss_file(ZUSF *zusf, string file, string &data)
 
     // Print new e-tag to stdout as response
     string etag_str = zut_build_etag(file_stats.st_mtime, file_stats.st_size);
-    std::vector<char> etag(etag_str.begin(), etag_str.end());
-    zusf->etag = etag.data();
+    strcpy(zusf->etag, etag_str.c_str());
   }
 
   return 0;

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -248,7 +248,7 @@ int zusf_write_to_uss_file(ZUSF *zusf, string file, string &data)
   const auto hasEncoding = zusf->encoding_opts.data_type == eDataTypeText && strlen(zusf->encoding_opts.codepage) > 0;
   const auto codepage = string(zusf->encoding_opts.codepage);
 
-  if (zusf->etag != nullptr)
+  if (strlen(zusf->etag) > 0)
   {
     const auto current_etag = zut_build_etag(file_stats.st_mtime, file_stats.st_size);
     if (current_etag != zusf->etag)

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -235,7 +235,7 @@ int zusf_read_from_uss_file(ZUSF *zusf, string file, string &response)
  *
  * @return RTNCD_SUCCESS on success, RTNCD_FAILURE on failure
  */
-int zusf_write_to_uss_file(ZUSF *zusf, string file, string &data, std::string etag)
+int zusf_write_to_uss_file(ZUSF *zusf, string file, string &data)
 {
   struct stat file_stats;
   if (stat(file.c_str(), &file_stats) == -1)
@@ -248,12 +248,12 @@ int zusf_write_to_uss_file(ZUSF *zusf, string file, string &data, std::string et
   const auto hasEncoding = zusf->encoding_opts.data_type == eDataTypeText && strlen(zusf->encoding_opts.codepage) > 0;
   const auto codepage = string(zusf->encoding_opts.codepage);
 
-  if (!etag.empty())
+  if (zusf->etag != nullptr)
   {
     const auto current_etag = zut_build_etag(file_stats.st_mtime, file_stats.st_size);
-    if (current_etag != etag)
+    if (current_etag != zusf->etag)
     {
-      zusf->diag.e_msg_len = sprintf(zusf->diag.e_msg, "Etag mismatch: expected %s, actual %s", etag.c_str(), current_etag.c_str());
+      zusf->diag.e_msg_len = sprintf(zusf->diag.e_msg, "Etag mismatch: expected %s, actual %s", zusf->etag, current_etag.c_str());
       return RTNCD_FAILURE;
     }
   }
@@ -295,7 +295,9 @@ int zusf_write_to_uss_file(ZUSF *zusf, string file, string &data, std::string et
     }
 
     // Print new e-tag to stdout as response
-    cout << zut_build_etag(file_stats.st_mtime, file_stats.st_size) << endl;
+    string etag_str = zut_build_etag(file_stats.st_mtime, file_stats.st_size);
+    std::vector<char> etag(etag_str.begin(), etag_str.end());
+    zusf->etag = etag.data();
   }
 
   return 0;

--- a/native/c/zusf.hpp
+++ b/native/c/zusf.hpp
@@ -25,7 +25,7 @@
 int zusf_create_uss_file_or_dir(ZUSF *zusf, std::string file, std::string mode, bool createDir);
 int zusf_list_uss_file_path(ZUSF *zusf, std::string file, std::string &response);
 int zusf_read_from_uss_file(ZUSF *zusf, std::string file, std::string &response);
-int zusf_write_to_uss_file(ZUSF *zusf, std::string file, std::string &response, std::string etag = "");
+int zusf_write_to_uss_file(ZUSF *zusf, std::string file, std::string &response);
 int zusf_chmod_uss_file_or_dir(ZUSF *zusf, std::string file, std::string mode, bool recursive);
 int zusf_delete_uss_item(ZUSF *zusf, std::string file, bool recursive);
 int zusf_chown_uss_file_or_dir(ZUSF *zusf, std::string file, std::string owner, bool recursive);

--- a/native/c/zusftype.h
+++ b/native/c/zusftype.h
@@ -41,7 +41,7 @@ typedef struct
   char file_name[1024]; // filename
 
   ZEncode encoding_opts;
-  char *etag;
+  char etag[16];
 
   ZDIAG diag;
 

--- a/native/c/zusftype.h
+++ b/native/c/zusftype.h
@@ -41,6 +41,7 @@ typedef struct
   char file_name[1024]; // filename
 
   ZEncode encoding_opts;
+  char *etag;
 
   ZDIAG diag;
 

--- a/native/golang/cmds/ds.go
+++ b/native/golang/cmds/ds.go
@@ -34,7 +34,7 @@ func HandleReadDatasetRequest(conn *utils.StdioConn, params []byte) (result any,
 	if len(request.Encoding) == 0 {
 		request.Encoding = fmt.Sprintf("IBM-%d", utils.DefaultEncoding)
 	}
-	args := []string{"data-set", "view", request.Dsname, "--encoding", request.Encoding, "--rfb", "true"}
+	args := []string{"data-set", "view", request.Dsname, "--encoding", request.Encoding, "--rfb", "true", "--return-etag", "true"}
 	out, err := conn.ExecCmd(args)
 	if err != nil {
 		return nil, fmt.Errorf("Error executing command: %v", err)

--- a/native/golang/cmds/uss.go
+++ b/native/golang/cmds/uss.go
@@ -82,7 +82,7 @@ func HandleReadFileRequest(conn *utils.StdioConn, params []byte) (result any, e 
 	if len(request.Encoding) == 0 {
 		request.Encoding = fmt.Sprintf("IBM-%d", utils.DefaultEncoding)
 	}
-	args := []string{"uss", "view", request.Path, "--encoding", request.Encoding, "--rfb", "true"}
+	args := []string{"uss", "view", request.Path, "--encoding", request.Encoding, "--rfb", "true", "--return-etag", "true"}
 	out, err := conn.ExecCmd(args)
 	if err != nil {
 		e = fmt.Errorf("Error executing command: %v", err)


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Adds `--return-etag` option to the `zowex ds view` and `zowex uss view` commands. The default value is false. When true it will print the etag.

Updates the `zowex ds write` and `zowex uss write` commands so that they don't print the etag unless `--etag-only` option is specified.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Test the following commands:
* `zowex ds|uss view` with and without `--return-etag` option
* `zowex ds|uss write` with and without `--etag-only` option
* `zowex ds|uss write` with the `--etag` option to test mismatch

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
