### PR TITLE
Fix/found private key cancel

### DIFF
--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -469,9 +469,7 @@ export abstract class AbstractConfigManager {
 
                     if (result) {
                         this.validationResult = {};
-                        if (Object.keys(result).length >= 1) {
-                            this.selectedProfile = { ...this.selectedProfile, ...result };
-                        }
+                        this.selectedProfile = { ...this.selectedProfile, ...result, privateKey };
                         return;
                     }
                 }

--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -100,12 +100,10 @@ export abstract class AbstractConfigManager {
         );
 
         if (result.description === "Custom SSH Host") {
-            console.log("test")
             const createNewConfig = await this.createNewProfile(result.label);
             if (!createNewConfig) return undefined;
             this.selectedProfile = createNewConfig;
         } else if (result.label === "$(plus) Add New SSH Host...") {
-            console.log("test")
             const createNewConfig = await this.createNewProfile();
             if (!createNewConfig) return undefined;
             this.selectedProfile = createNewConfig;
@@ -303,7 +301,6 @@ export abstract class AbstractConfigManager {
             const newConfig: IConfig = await ConfigBuilder.build(impConfig, global, opts);
             config.api.layers.merge(newConfig);
             await config.save(false);
-            console.log("test1")
         } catch (err) {}
     }
 
@@ -573,7 +570,7 @@ export abstract class AbstractConfigManager {
                 });
             }
         } else {
-            if (!configApi.profiles.defaultGet("ssh")) configApi.profiles.defaultSet("ssh", selectedConfig?.name!);
+            if (!configApi.profiles.defaultGet("ssh") || !configApi.layers.get().properties.defaults["ssh"]) configApi.profiles.defaultSet("ssh", selectedConfig?.name!);
             configApi.profiles.set(selectedConfig?.name!, config);
         }
 

--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -570,7 +570,7 @@ export abstract class AbstractConfigManager {
                 });
             }
         } else {
-            if (!configApi.profiles.defaultGet("ssh") || !configApi.layers.get().properties.defaults["ssh"])
+            if (!configApi.profiles.defaultGet("ssh") || !configApi.layers.get().properties.defaults.ssh)
                 configApi.profiles.defaultSet("ssh", selectedConfig?.name!);
             configApi.profiles.set(selectedConfig?.name!, config);
         }

--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -100,11 +100,13 @@ export abstract class AbstractConfigManager {
         );
 
         if (result.description === "Custom SSH Host") {
-            const createNewConfig = await this.createNewConfig(result.label);
+            console.log("test")
+            const createNewConfig = await this.createNewProfile(result.label);
             if (!createNewConfig) return undefined;
             this.selectedProfile = createNewConfig;
         } else if (result.label === "$(plus) Add New SSH Host...") {
-            const createNewConfig = await this.createNewConfig();
+            console.log("test")
+            const createNewConfig = await this.createNewProfile();
             if (!createNewConfig) return undefined;
             this.selectedProfile = createNewConfig;
         }
@@ -192,15 +194,8 @@ export abstract class AbstractConfigManager {
         };
     }
 
-    private async createNewConfig(knownConfigOpts?: string): Promise<ISshConfigExt | undefined> {
+    private async createNewProfile(knownConfigOpts?: string): Promise<ISshConfigExt | undefined> {
         const SshProfile: ISshConfigExt = {};
-
-        //check if project layer exists, if it doesnt create one, but if no workspace then create it as global
-
-        const workspaceDirPath = this.getCurrentDir();
-        if (workspaceDirPath !== undefined && !this.mProfilesCache.getTeamConfig().layerExists(workspaceDirPath)) {
-            await this.createZoweSchema(false);
-        }
 
         let sshResponse: string | undefined;
 
@@ -281,13 +276,14 @@ export abstract class AbstractConfigManager {
     // Cloned method
     private async createZoweSchema(global: boolean): Promise<void> {
         try {
+            const homeDir = ConfigUtils.getZoweDir()
+
             const user = false;
             const workspaceDir = this.getCurrentDir();
 
-            const config = await Config.load("zowe", {
-                homeDir: ConfigUtils.getZoweDir(),
-                projectDir: workspaceDir,
-            });
+            const config = this.mProfilesCache.getTeamConfig();
+
+            if(config.layerExists(global ? homeDir : workspaceDir)) return;
 
             config.api.layers.activate(user, global);
 
@@ -307,6 +303,7 @@ export abstract class AbstractConfigManager {
             const newConfig: IConfig = await ConfigBuilder.build(impConfig, global, opts);
             config.api.layers.merge(newConfig);
             await config.save(false);
+            console.log("test1")
         } catch (err) {}
     }
 

--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -13,7 +13,7 @@ import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { ProfileConstants } from "@zowe/core-for-zowe-sdk";
 import {
-    Config,
+    type Config,
     ConfigBuilder,
     ConfigSchema,
     ConfigUtils,
@@ -274,14 +274,14 @@ export abstract class AbstractConfigManager {
     // Cloned method
     private async createZoweSchema(global: boolean): Promise<void> {
         try {
-            const homeDir = ConfigUtils.getZoweDir()
+            const homeDir = ConfigUtils.getZoweDir();
 
             const user = false;
             const workspaceDir = this.getCurrentDir();
 
             const config = this.mProfilesCache.getTeamConfig();
 
-            if(config.layerExists(global ? homeDir : workspaceDir)) return;
+            if (config.layerExists(global ? homeDir : workspaceDir)) return;
 
             config.api.layers.activate(user, global);
 
@@ -570,7 +570,8 @@ export abstract class AbstractConfigManager {
                 });
             }
         } else {
-            if (!configApi.profiles.defaultGet("ssh") || !configApi.layers.get().properties.defaults["ssh"]) configApi.profiles.defaultSet("ssh", selectedConfig?.name!);
+            if (!configApi.profiles.defaultGet("ssh") || !configApi.layers.get().properties.defaults["ssh"])
+                configApi.profiles.defaultSet("ssh", selectedConfig?.name!);
             configApi.profiles.set(selectedConfig?.name!, config);
         }
 


### PR DESCRIPTION
**What It Does**
Fixes multiple issues regarding authenticating private keys

1. Fixes an issue where authenticating via found private key i.e id_rsa, id_dsa, etc will cancel out early
2. Fixes an issue where creating a profile in a project config will also create a global config when not needed
3. Fixes an issue where creating a profile with no work space and no zowe global config will force the user to run the command twice before functioning

**How to Test**

1. 
a. Attempt to connect to a lpar where you have a local private key setup matching one of the keywords `["id_ed25519", "id_rsa", "id_ecdsa", "id_dsa"]`. 
b. `ssh user@example.com` where `id_rsa` is stored in ~/.ssh

3.
 a. Open ZNP with a workspace (folder) open.
 b. Have no global or project configs
 c. Connect to target system
 d. No global config should be created (only project config)

4.
 a. Open ZNP with no workspace (no open folder)
 b. Have no global configs
 c. Connect to target system
 d. Connection should succeed on the first attempt

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
