### PR TITLE
feat: Support streaming for read/write DS

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -11,7 +11,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `golang`: Added verbose option to enable debug logging. [#237](https://github.com/zowe/zowe-native-proto/pull/237)
 - `golang`: Added SHA256 checksums to the ready message to allow checks for outdated server. [#236](https://github.com/zowe/zowe-native-proto/pull/236)
 - `c,golang`: Added support for streaming USS file contents for read and write operations (`zusf_read_from_uss_file_streamed`, `zusf_write_to_uss_file_streamed`). [#311](https://github.com/zowe/zowe-native-proto/pull/311)
-- `c`: Added support for streaming data set contents for read and write operations (`zds_read_from_dsn_streamed`, `zds_write_to_dsn_streamed`). [#326](https://github.com/zowe/zowe-native-proto/pull/326)
+- `c,golang`: Added support for streaming data set contents for read and write operations (`zds_read_from_dsn_streamed`, `zds_write_to_dsn_streamed`). [#326](https://github.com/zowe/zowe-native-proto/pull/326)
 
 ## `0.1.1`
 

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -11,6 +11,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `golang`: Added verbose option to enable debug logging. [#237](https://github.com/zowe/zowe-native-proto/pull/237)
 - `golang`: Added SHA256 checksums to the ready message to allow checks for outdated server. [#236](https://github.com/zowe/zowe-native-proto/pull/236)
 - `c,golang`: Added support for streaming USS file contents for read and write operations (`zusf_read_from_uss_file_streamed`, `zusf_write_to_uss_file_streamed`). [#311](https://github.com/zowe/zowe-native-proto/pull/311)
+- `c`: Added support for streaming data set contents for read and write operations (`zds_read_from_dsn_streamed`, `zds_write_to_dsn_streamed`). [#326](https://github.com/zowe/zowe-native-proto/pull/326)
 
 ## `0.1.1`
 

--- a/native/c/extern/zb64.h
+++ b/native/c/extern/zb64.h
@@ -345,7 +345,7 @@ const static unsigned char unb64[] = {
 // this function, if you want your C string to be fully encoded,
 // you have to pass strlen(str)+1 to as binaryData as I have in the
 // examples.
-char *base64(const void *binaryData, int len, int *flen)
+inline char *base64(const void *binaryData, int len, int *flen)
 {
    // printf("Base64 encoding %d bytes of binary data\n", len);
 
@@ -524,7 +524,7 @@ char *base64(const void *binaryData, int len, int *flen)
    return base64String;
 }
 
-unsigned char *unbase64(const char *ascii, int len, int *flen)
+inline unsigned char *unbase64(const char *ascii, int len, int *flen)
 {
 #ifdef SAFEBASE64
    if (!base64integrity(ascii, len))
@@ -646,7 +646,7 @@ unsigned char *unbase64(const char *ascii, int len, int *flen)
 // piece of data that says it is padded by 2 bytes at the end. Well, you
 // only need to pad by 2 bytes if the number of bits in the original data
 // was not evenly divisible by 6. 0%6==0, so something's clearly wrong here.
-int base64integrity(const char *ascii, int len)
+inline int base64integrity(const char *ascii, int len)
 {
    // The base64 string is somewhat inflated, since each ASCII character
    // represents only a 6-bit value (a sextet). That leaves 2 bits wasted per 8 bits used.

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -28,7 +28,6 @@
 #include "extern/zb64.h"
 
 const size_t MAX_DS_LENGTH = 44u;
-const size_t FIFO_CHUNK_SIZE = 4096u;
 
 using namespace std;
 

--- a/native/c/zds.hpp
+++ b/native/c/zds.hpp
@@ -18,6 +18,7 @@
 #include "zdstype.h"
 
 extern const size_t MAX_DS_LENGTH;
+extern const size_t FIFO_CHUNK_SIZE;
 
 struct ZDSMem
 {
@@ -136,5 +137,25 @@ int zds_list_members(ZDS *zds, std::string dsn, std::vector<ZDSMem> &members);
 int zds_list_data_sets(ZDS *zds, std::string dsn, std::vector<ZDSEntry> &attributes);
 
 int zdsReadDynalloc(std::string, std::string, std::string, std::string &); // NOTE(Kelosky): testing only
+
+/**
+ * @brief Read data from a z/OS data set in streaming mode
+ *
+ * @param zds data set returned attributes and error information
+ * @param dsn data set name from which to read
+ * @param pipe name of the output pipe
+ * @return int 0 for success; non zero otherwise
+ */
+int zds_read_from_dsn_streamed(ZDS *zds, std::string dsn, std::string pipe);
+
+/**
+ * @brief Write data to a z/OS data set in streaming mode
+ *
+ * @param zds data set returned attributes and error information
+ * @param dsn data set name to write to
+ * @param pipe name of the input pipe
+ * @return int 0 for success; non zero otherwise
+ */
+int zds_write_to_dsn_streamed(ZDS *zds, std::string dsn, std::string pipe);
 
 #endif

--- a/native/c/zds.hpp
+++ b/native/c/zds.hpp
@@ -18,7 +18,6 @@
 #include "zdstype.h"
 
 extern const size_t MAX_DS_LENGTH;
-extern const size_t FIFO_CHUNK_SIZE;
 
 struct ZDSMem
 {

--- a/native/golang/types/ds/requests.go
+++ b/native/golang/types/ds/requests.go
@@ -42,8 +42,8 @@ type ReadDatasetRequest struct {
 	Encoding string `json:"encoding,omitempty"`
 	// Dataset name
 	Dsname string `json:"dsname"`
-	// Path to a FIFO pipe for streaming data (optional)
-	PipePath string `json:"pipePath,omitempty"`
+	// Stream to write contents to
+	StreamId int `json:"stream,omitempty" tstype:"Writable"`
 }
 
 type WriteDatasetRequest struct {
@@ -57,8 +57,8 @@ type WriteDatasetRequest struct {
 	Dsname string `json:"dsname"`
 	// Dataset contents
 	Data string `json:"data" tstype:"B64String"`
-	// Path to a FIFO pipe for streaming data (optional)
-	PipePath string `json:"pipePath,omitempty"`
+	// Stream to read contents from
+	StreamId int `json:"stream,omitempty" tstype:"Readable"`
 }
 
 type DeleteDatasetRequest struct {

--- a/native/golang/types/ds/requests.go
+++ b/native/golang/types/ds/requests.go
@@ -42,6 +42,8 @@ type ReadDatasetRequest struct {
 	Encoding string `json:"encoding,omitempty"`
 	// Dataset name
 	Dsname string `json:"dsname"`
+	// Path to a FIFO pipe for streaming data (optional)
+	PipePath string `json:"pipePath,omitempty"`
 }
 
 type WriteDatasetRequest struct {
@@ -55,6 +57,8 @@ type WriteDatasetRequest struct {
 	Dsname string `json:"dsname"`
 	// Dataset contents
 	Data string `json:"data" tstype:"B64String"`
+	// Path to a FIFO pipe for streaming data (optional)
+	PipePath string `json:"pipePath,omitempty"`
 }
 
 type DeleteDatasetRequest struct {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -9,7 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Improved error handling when SSH client connects to throw `ENOTFOUND` if server binary is missing. [#44](https://github.com/zowe/zowe-native-proto/issues/44)
 - Added `ZSshUtils.checkIfOutdated` method to check if deployed server is out of date. [#44](https://github.com/zowe/zowe-native-proto/issues/44)
 - Added `keepAliveInterval` option when creating an instance of the `ZSshClient` class that defaults to 30 seconds. [#260](https://github.com/zowe/zowe-native-proto/issues/260)
-- Added support for streaming data in chunks to handle large requests and responses in the `ZSshClient` class. This allows streaming USS file contents for read and write operations (`ReadFileRequest`, `WriteFileRequest`). [#311](https://github.com/zowe/zowe-native-proto/pull/311)
+- Added support for streaming data in chunks to handle large requests and responses in the `ZSshClient` class. This allows streaming USS file contents for read and write operations (`ReadDatasetRequest`, `ReadFileRequest`, `WriteDatasetRequest`, `WriteFileRequest`). [#311](https://github.com/zowe/zowe-native-proto/pull/311)
 
 ## `0.1.1`
 

--- a/packages/sdk/src/doc/gen/ds.ts
+++ b/packages/sdk/src/doc/gen/ds.ts
@@ -49,6 +49,10 @@ export interface ReadDatasetRequest extends common.CommandRequest {
    * Dataset name
    */
   dsname: string;
+  /**
+   * Path to a FIFO pipe for streaming data (optional)
+   */
+  pipePath?: string;
 }
 export interface WriteDatasetRequest extends common.CommandRequest {
   command: "writeDataset";
@@ -68,6 +72,10 @@ export interface WriteDatasetRequest extends common.CommandRequest {
    * Dataset contents
    */
   data: B64String;
+  /**
+   * Path to a FIFO pipe for streaming data (optional)
+   */
+  pipePath?: string;
 }
 export interface DeleteDatasetRequest extends common.CommandRequest {
   command: "deleteDataset";

--- a/packages/sdk/src/doc/gen/ds.ts
+++ b/packages/sdk/src/doc/gen/ds.ts
@@ -50,9 +50,9 @@ export interface ReadDatasetRequest extends common.CommandRequest {
    */
   dsname: string;
   /**
-   * Path to a FIFO pipe for streaming data (optional)
+   * Stream to write contents to
    */
-  pipePath?: string;
+  stream?: Writable;
 }
 export interface WriteDatasetRequest extends common.CommandRequest {
   command: "writeDataset";
@@ -73,9 +73,9 @@ export interface WriteDatasetRequest extends common.CommandRequest {
    */
   data: B64String;
   /**
-   * Path to a FIFO pipe for streaming data (optional)
+   * Stream to read contents from
    */
-  pipePath?: string;
+  stream?: Readable;
 }
 export interface DeleteDatasetRequest extends common.CommandRequest {
   command: "deleteDataset";


### PR DESCRIPTION
**What It Does**

Kudos to @t1m0thyj for all his work in #311 as without it this wouldn't be possible 🙏 
Let's get to streaming ⏯️ 

**How to Test**

Build the artifacts & SDK for this branch (`npm install && npm run build && npm run z:all`), then deploy the actual server using the VSCE or CLI. Then run the following script: `node test.js <localFile> <dsname> <encoding>`

e.g. `node test.js 10mb_local_file.dat "TRAE.TESTDS(MEMB)" binary`
note that the data set or member must exist

```js
const fs = require("fs");
const { ProfileInfo } = require("@zowe/imperative");
const { SshSession } = require("@zowe/zos-uss-for-zowe-sdk");
const { ZSshClient } = require("./packages/sdk");
let client;

async function main(localFile, dsname, encoding) {
    const profInfo = new ProfileInfo("zowe");
    await profInfo.readProfilesFromDisk();
    const sshProfAttrs = profInfo.getDefaultProfile("ssh");
    const sshMergedArgs = profInfo.mergeArgsForProfile(sshProfAttrs, { getSecureVals: true });
    const session = new SshSession(ProfileInfo.initSessCfg(sshMergedArgs.knownArgs));
    const serverPathArg = sshMergedArgs.knownArgs.find((arg) => arg.argName === "serverPath");
    client = await ZSshClient.create(session, { serverPath: serverPathArg?.argValue });
    
    console.time("uploadTime");
    await client.ds.writeDataset({
        dsname: dsname,
        stream: fs.createReadStream(localFile),
        encoding,
    });
    console.timeEnd("uploadTime");
    console.log("uploadSize:", fs.statSync(localFile).size.toLocaleString());
    
    console.time("downloadTime");
    await client.ds.readDataset({
        dsname: dsname,
        stream: fs.createWriteStream(`${localFile}.tmp`),
        encoding,
    });
    console.timeEnd("downloadTime");
    console.log("downloadSize:", fs.statSync(`${localFile}.tmp`).size.toLocaleString());
    
    fs.unlinkSync(`${localFile}.tmp`);
}

main(...process.argv.slice(2)).catch(console.error).finally(() => client?.dispose()); 
```

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
