### PR TITLE
Fix watch script exceeding max session limit

### DIFF
--- a/scripts/watchNative.js
+++ b/scripts/watchNative.js
@@ -41,6 +41,7 @@ const conn = new Client()
       ? fs.readFileSync(config.privateKey)
       : undefined,
     password: config.password,
+    keepaliveInterval: 30e3,
   });
 
 function cTask(err, remotePath, stream, resolve) {
@@ -130,6 +131,7 @@ async function deleteFile(remotePath) {
           return reject(err);
         }
 
+        sftp.end();
         resolve();
       });
     });
@@ -171,6 +173,7 @@ async function uploadFile(localPath, remotePath) {
             resolve();
           }
         });
+        sftp.end();
       });
 
       writeStream.on("error", (err) => {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
This should make the watch script more reliable 😋 
* Terminate SFTP sessions to avoid hitting max session limit of 10
* Add keep alive interval of 30s to match the ZNP SSH client

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
