### PR TITLE
Fix artifact download in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,7 @@ jobs:
           RUN_ID=$(gh run list --branch=${{ github.ref }} --workflow=zos-build.yml --limit=1 --json=databaseId --jq='.[0].databaseId')
           NEW_VERSION=$([ -z "${{ inputs.version }}" ] && jq -r '.version' package.json || echo "${{ inputs.version }}")
           gh run download $RUN_ID --name zowe-server-bin
-          mkdir packages/cli/bin && cp checksums.asc server.pax.Z packages/cli/bin/
-          mkdir packages/vsce/bin && cp checksums.asc server.pax.Z packages/vsce/bin/
+          node scripts/moveArtifacts.js
           gh run download $RUN_ID --name zowe-server-release
           mkdir dist && mv server.pax.Z dist/zowe-server-${NEW_VERSION}.pax.Z
         env:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build:all": "npm run build:types && npm run build",
     "build:types": "cd native/golang && go run github.com/gzuidhof/tygo generate && npm run license",
     "clean": "npm run clean --workspaces",
+    "download": "gh run download --name zowe-server-bin && node scripts/moveArtifacts.js",
     "license": "node scripts/updateLicenses.js",
     "lint": "npm run lint --workspaces",
     "lint:go": "cd native/golang && golangci-lint run",

--- a/scripts/moveArtifacts.js
+++ b/scripts/moveArtifacts.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+const srcDir = path.resolve(__dirname, "..");
+const srcFiles = ["checksums.asc", "server.pax.Z"];
+const destDirs = [path.join(srcDir, "packages/cli/bin"), path.join(srcDir, "packages/vsce/bin")];
+for (const destDir of destDirs) {
+    fs.mkdirSync(destDir, { recursive: true });
+    for (const srcFile of srcFiles) {
+        fs.copyFileSync(path.join(srcDir, srcFile), path.join(destDir, srcFile));
+    }
+}
+srcFiles.forEach(fs.unlinkSync);


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes error in the release workflow where downloading second PAX fails because it would overwrite the first one.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
