### PR TITLE
fix: swap recfm bitmasks for fixed and variable

### DIFF
--- a/native/c/zdsm.c
+++ b/native/c/zdsm.c
@@ -155,12 +155,12 @@ int ZDSRECFM(ZDS *zds, const char *dsn, const char *volser, char *recfm_buf,
     int len = 0;
     char main_fmt = 0;
 
-    if ((dscb->ds1recfm & 0xC0) == 0x40)
+    if ((dscb->ds1recfm & 0xC0) == 0x80)
     {
       temp_recfm[len++] = 'F';
       main_fmt = 'F';
     }
-    else if ((dscb->ds1recfm & 0xC0) == 0x80)
+    else if ((dscb->ds1recfm & 0xC0) == 0x40)
     {
       temp_recfm[len++] = 'V';
       main_fmt = 'V';

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -96,7 +96,7 @@ int run_interactive_mode(ArgumentParser &arg_parser, const std::string &program_
 
 int main(int argc, char *argv[])
 {
-  ArgumentParser arg_parser(argv[0], "Zowe Native Protocol CLI - Modernizing mainframe access");
+  ArgumentParser arg_parser(argv[0], "Zowe Native Protocol CLI");
 
   // Add interactive mode flag to root command
   arg_parser.get_root_command().add_keyword_arg("interactive",


### PR DESCRIPTION
**What It Does**

- Swaps the fixed and variable bitmasks for RECFM calculation

**How to Test**

- Do a data set list and notice that RECFMs now match expected result from z/OSMF.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog - no changelog update 
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
