### PR TITLE
refactor: remove --n alias for "negated flag" generation 

### DIFF
--- a/native/c/parser.hpp
+++ b/native/c/parser.hpp
@@ -462,7 +462,6 @@ namespace parser
       if (type == ArgType_Flag && default_bool && *default_bool == true)
       {
         std::string no_flag_name = "no-" + name;
-        std::string no_flag_long_alias = "--n" + name;
         std::string no_flag_help = "disable the --" + name + " flag.";
 
         // ensure the generated --no- name/alias doesn't conflict
@@ -478,25 +477,9 @@ namespace parser
                                       no_flag_name +
                                       "' conflicts with an existing argument.");
         }
-        for (std::vector<ArgumentDef>::const_iterator it2 = m_kw_args.begin();
-             it2 != m_kw_args.end(); ++it2)
-        {
-          const ArgumentDef &existing_arg = *it2;
-          for (size_t j = 0; j < existing_arg.aliases.size(); ++j)
-          {
-            if (existing_arg.aliases[j] == no_flag_long_alias)
-            {
-              throw std::invalid_argument(
-                  "automatic negation flag alias '" + no_flag_long_alias +
-                  "' conflicts with an existing argument.");
-            }
-          }
-        }
 
         // add the negation argument definition
-        std::vector<std::string> no_flag_aliases;
-        no_flag_aliases.push_back(no_flag_long_alias);
-        m_kw_args.push_back(ArgumentDef(no_flag_name, no_flag_aliases,
+        m_kw_args.push_back(ArgumentDef(no_flag_name, make_aliases(),
                                         no_flag_help, ArgType_Flag, false,
                                         ArgValue(false), false));
       }

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1005,7 +1005,7 @@ int handle_data_set_list(const ParseResult &result)
   dsn += ".**";
 
   string max_entries = result.find_kw_arg_string("max-entries");
-  bool warn = result.find_kw_arg_bool("warn");
+  bool warn = result.find_kw_arg_bool("warn") && !result.find_kw_arg_bool("no-warn");
   bool attributes = result.find_kw_arg_bool("attributes");
 
   ZDS zds = {0};
@@ -2015,7 +2015,7 @@ int handle_job_list(const ParseResult &result)
   string owner_name = result.find_kw_arg_string("owner");
   string prefix_name = result.find_kw_arg_string("prefix");
   string max_entries = result.find_kw_arg_string("max-entries");
-  bool warn = result.find_kw_arg_bool("warn");
+  bool warn = result.find_kw_arg_bool("warn") && !result.find_kw_arg_bool("no-warn");
 
   if (!max_entries.empty())
   {


### PR DESCRIPTION
**What It Does**

There was some back and forth on whether we want a `--n` alias for auto-negated flags. For example, if a `--warn` flag is added to a command with default value of `true`, a negated flag is available with following aliases: `--nwarn, --no-warn`

This changes the behavior so only `--no-warn` is available. It establishes consistency with yargs (Zowe CLI command interpreter) and avoids extra logic for the alias checks.

**How to Test**

Run `./zowex ds list -h` and see that the "no-warn" option no longer has the `--nwarn` alias

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog - no changelog needed since recent related changes are not yet released
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)