### PR TITLE
Support capturing lambdas in `ztest`, fix mode parsing for `zusf_chmod_uss_file_or_dir`

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -18,7 +18,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c`: Fixed issue where the record format (`recfm` attribute) was listed as unknown for a Partitioned Data Set (PDS) with no members. Now, the record format for all data sets is retrieved through the Volume Table of Contents. [#351](https://github.com/zowe/zowe-native-proto/pull/351)
 - `c`: Added CLI parser and lexer library for use in `zowex`. For an example of how to use the new CLI parser library, refer to the sample CLI code in `examples/native-cli/testcli.cpp`.
 - `c`: Fixed an issue where the zowex `ds list` command always printed data set attributes when passing the argument `--response-format-csv`, even if the attributes argument was `false`.
-- `c`: Fixed an issue where the `zusf_chmod_uss_file_or_dir` function did not pass the correct mode flags for the `chmod` C standard library function. [#399](https://github.com/zowe/zowe-native-proto/pull/399)
+- `c`: Fixed an issue where the `zusf_chmod_uss_file_or_dir` function did not handle invalid input before passing the mode to the `chmod` C standard library function. [#399](https://github.com/zowe/zowe-native-proto/pull/399)
 
 ## `0.1.2`
 

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -18,6 +18,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c`: Fixed issue where the record format (`recfm` attribute) was listed as unknown for a Partitioned Data Set (PDS) with no members. Now, the record format for all data sets is retrieved through the Volume Table of Contents. [#351](https://github.com/zowe/zowe-native-proto/pull/351)
 - `c`: Added CLI parser and lexer library for use in `zowex`. For an example of how to use the new CLI parser library, refer to the sample CLI code in `examples/native-cli/testcli.cpp`.
 - `c`: Fixed an issue where the zowex `ds list` command always printed data set attributes when passing the argument `--response-format-csv`, even if the attributes argument was `false`.
+- `c`: Fixed an issue where the `zusf_chmod_uss_file_or_dir` function did not pass the correct mode flags for the `chmod` C standard library function. [#399](https://github.com/zowe/zowe-native-proto/pull/399)
 
 ## `0.1.2`
 

--- a/native/c/makefile
+++ b/native/c/makefile
@@ -276,6 +276,10 @@ $(OUT_DIR)/zusf.o: zusf.cpp
 	@echo 'Building $(OUT_DIR)/zusf.o'
 	$(CXX) $(DLL_CPP_FLAGS) -qlist=$*.cpp.lst -o $@ $^
 
+$(OUT_DIR_CXXLANG)/zusf.o: $(OUT_DIRS) zusf.cpp
+	@echo '$(OUT_DIR_CXXLANG)/zusf.o'
+	$(CXXLANG) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -o $@ $^
+
 $(OUT_DIR)/libzusf.so: $(OUT_DIR)/zusf.o $(OUT_DIR)/libzut.a
 	@echo 'Building $(OUT_DIR)/libzusf.so'
 	$(CXX) $(DLL_BND_FLAGS) -o $@ $^ > $*.bind.lst

--- a/native/c/makefile
+++ b/native/c/makefile
@@ -99,7 +99,7 @@ MTL_FLAGS64+=-g1
 .END
 
 all: libzut.so libzut.a libzds.so libzds.a libzusf.so libzusf.a libzcn.so libzcn.a libzjb.so libzjb.a zowex zoweax extattr xlclang-extenders tests
-xlclang-extenders: $(OUT_DIR_CXXLANG)/zut.o $(OUT_DIR_CXXLANG)/zds.o $(OUT_DIR_CXXLANG)/zjb.o $(OUT_DIR_CXXLANG)/zcn.o
+xlclang-extenders: $(OUT_DIR_CXXLANG)/zut.o $(OUT_DIR_CXXLANG)/zds.o $(OUT_DIR_CXXLANG)/zjb.o $(OUT_DIR_CXXLANG)/zcn.o $(OUT_DIR_CXXLANG)/zusf.o
 tests:
 	 $(MAKE) -c test
 

--- a/native/c/test/makefile
+++ b/native/c/test/makefile
@@ -147,7 +147,9 @@ build-out/zcnm31.o \
 build-out/zrecovery.test.o \
 build-out/zrecovery.metal.test.o \
 build-out/zmetal.test.o \
-build-out/zmetal.metal.test.o
+build-out/zmetal.metal.test.o \
+build-out/zusf.test.o \
+build-out/zusf.o
 	$(OCXX) $(CXXLANG_BND_FLAGS) -o $@ $^ > $*.bind.lst
 
 build-out/zut.o:
@@ -227,6 +229,12 @@ build-out/zmetal.metal.test.s: zmetal.metal.test.c
 
 build-out/zmetal.metal.test.o: build-out/zmetal.metal.test.s
 	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+
+build-out/zusf.test.o: zusf.test.cpp
+	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+
+build-out/zusf.o:
+	cp ../build-out/xlclang/zusf.o build-out/zusf.o
 
 # build-out/testrcvy.s: testrcvy.c
 # 	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^

--- a/native/c/test/makefile
+++ b/native/c/test/makefile
@@ -191,6 +191,9 @@ build-out/zcnm.o:
 build-out/zcnm31.o:
 	cp ../build-out/zcnm31.o build-out/zcnm31.o
 
+build-out/zusf.o:
+	cp ../build-out/xlclang/zusf.o build-out/zusf.o
+
 build-out/zstorage.test.o: zstorage.test.cpp
 	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
 
@@ -232,9 +235,6 @@ build-out/zmetal.metal.test.o: build-out/zmetal.metal.test.s
 
 build-out/zusf.test.o: zusf.test.cpp
 	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
-
-build-out/zusf.o:
-	cp ../build-out/xlclang/zusf.o build-out/zusf.o
 
 # build-out/testrcvy.s: testrcvy.c
 # 	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^

--- a/native/c/test/ztest.cpp
+++ b/native/c/test/ztest.cpp
@@ -134,30 +134,18 @@ ztst::RESULT_CHECK ztst::RESULT_CHECK::Not()
   return copy;
 }
 
-struct TEST_CASE
-{
-  bool success;
-  string description;
-  string fail_message;
-};
 
-struct TEST_SUITE
-{
-  string description;
-  vector<TEST_CASE> tests;
-};
 
-vector<TEST_SUITE>
-    ztst_suites;
-int ztst_suite_index = -1;
-jmp_buf ztst_jmp_buf = {0};
+vector<ztst::TEST_SUITE> ztst::ztst_suites;
+int ztst::ztst_suite_index = -1;
+jmp_buf ztst::ztst_jmp_buf = {0};
 
 void ztst::describe(std::string description, ztst::cb suite)
 {
   TEST_SUITE ts = {0};
   ts.description = description;
-  ztst_suites.push_back(ts);
-  ztst_suite_index++;
+  ztst::ztst_suites.push_back(ts);
+  ztst::ztst_suite_index++;
   cout << description << endl;
   suite();
 }
@@ -170,14 +158,19 @@ extern "C"
 {
 #endif
 
-  static void SIGHAND(int code, siginfo_t *info, void *context)
+  static void SIGHAND(int code, void *info, void *context)
   {
-    longjmp(ztst_jmp_buf, 1);
+    longjmp(ztst::ztst_jmp_buf, 1);
   }
 
 #if defined(__cplusplus)
 }
 #endif
+
+void ztst::signal_handler(int code, siginfo_t *info, void *context)
+{
+  longjmp(ztst::ztst_jmp_buf, 1);
+}
 
 void ztst::it(string description, ztst::cb test)
 {
@@ -250,7 +243,7 @@ void ztst::it(string description, ztst::cb test, TEST_OPTIONS &opts)
     cout << "    " << tc.fail_message << endl;
   }
 
-  ztst_suites[ztst_suite_index].tests.push_back(tc);
+  ztst::ztst_suites[ztst::ztst_suite_index].tests.push_back(tc);
 }
 
 ztst::RESULT_CHECK ztst::expect(int val)
@@ -307,7 +300,7 @@ int ztst::report()
 
   cout << "======== TESTS SUMMARY ========" << endl;
 
-  for (vector<TEST_SUITE>::iterator it = ztst_suites.begin(); it != ztst_suites.end(); it++)
+  for (vector<TEST_SUITE>::iterator it = ztst::ztst_suites.begin(); it != ztst::ztst_suites.end(); it++)
   {
     for (vector<TEST_CASE>::iterator iit = it->tests.begin(); iit != it->tests.end(); iit++)
     {
@@ -320,7 +313,7 @@ int ztst::report()
     }
   }
 
-  cout << "Total Suites: " << ztst_suites.size() - suite_fail << " passed, " << suite_fail << " failed, " << ztst_suites.size() << " total" << endl;
+  cout << "Total Suites: " << ztst::ztst_suites.size() - suite_fail << " passed, " << suite_fail << " failed, " << ztst::ztst_suites.size() << " total" << endl;
   cout << "Tests:      : " << tests_total - tests_fail << " passed, " << tests_fail << " failed, " << tests_total << " total" << endl;
   return tests_fail > 0 ? 1 : 0;
 }

--- a/native/c/test/ztest.cpp
+++ b/native/c/test/ztest.cpp
@@ -134,8 +134,6 @@ ztst::RESULT_CHECK ztst::RESULT_CHECK::Not()
   return copy;
 }
 
-
-
 vector<ztst::TEST_SUITE> ztst::ztst_suites;
 int ztst::ztst_suite_index = -1;
 jmp_buf ztst::ztst_jmp_buf = {0};
@@ -158,7 +156,7 @@ extern "C"
 {
 #endif
 
-  static void SIGHAND(int code, void *info, void *context)
+  static void SIGHAND(int code, siginfo_t *info, void *context)
   {
     longjmp(ztst::ztst_jmp_buf, 1);
   }

--- a/native/c/test/ztest_runner.cpp
+++ b/native/c/test/ztest_runner.cpp
@@ -17,6 +17,7 @@
 #include "zcn.test.hpp"
 #include "zrecovery.test.hpp"
 #include "zmetal.test.hpp"
+#include "zusf.test.hpp"
 #include "ztest.hpp"
 
 using namespace std;
@@ -43,6 +44,7 @@ int main(int argc, char *argv[])
         zcn_tests();
         zrecovery_tests();
         zmetal_tests();
+        zusf_tests();
       });
 
   return rc;

--- a/native/c/test/zusf.test.cpp
+++ b/native/c/test/zusf.test.cpp
@@ -1,0 +1,153 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+#include <iostream>
+#include <stdexcept>
+#include <fstream>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "ztest.hpp"
+#include "zusf.hpp"
+#include "ztype.h"
+
+using namespace std;
+using namespace ztst;
+
+void zusf_tests()
+{
+  describe("zusf_chmod_uss_file_or_dir tests",
+           []() -> void
+           {
+             // Setup test environment
+             ZUSF zusf;
+             memset(&zusf, 0, sizeof(zusf));
+             
+             const string test_file = "/tmp/zusf_test_file.txt";
+             const string test_dir = "/tmp/zusf_test_dir";
+             const string nonexistent_file = "/tmp/nonexistent_file.txt";
+             
+             it("should fail when file does not exist",
+                [&]() -> void
+                {
+                  // Ensure the file doesn't exist
+                  unlink(nonexistent_file.c_str());
+                  
+                  int result = zusf_chmod_uss_file_or_dir(&zusf, nonexistent_file, 0644, false);
+                  expect(result).ToBe(RTNCD_FAILURE);
+                  expect(string(zusf.diag.e_msg)).ToBe("Path '/tmp/nonexistent_file.txt' does not exist");
+                });
+
+             it("should fail when trying to chmod directory without recursive flag",
+                [&]() -> void
+                {
+                  // Create test directory
+                  rmdir(test_dir.c_str());  // Remove if exists
+                  mkdir(test_dir.c_str(), 0755);
+                  
+                  int result = zusf_chmod_uss_file_or_dir(&zusf, test_dir, 0644, false);
+                  expect(result).ToBe(RTNCD_FAILURE);
+                  expect(string(zusf.diag.e_msg)).ToBe("Path '/tmp/zusf_test_dir' is a folder and recursive is false");
+                  
+                  // Cleanup
+                  rmdir(test_dir.c_str());
+                });
+
+             it("should successfully chmod a regular file",
+                [&]() -> void
+                {
+                  // Create test file
+                  unlink(test_file.c_str());  // Remove if exists
+                  ofstream file(test_file);
+                  file << "test content";
+                  file.close();
+                  
+                  // Set initial permissions
+                  chmod(test_file.c_str(), 0600);
+                  
+                  // Test chmod function
+                  int result = zusf_chmod_uss_file_or_dir(&zusf, test_file, 0644, false);
+                  expect(result).ToBe(RTNCD_SUCCESS);
+                  
+                  // Verify permissions were changed
+                  struct stat file_stat;
+                  stat(test_file.c_str(), &file_stat);
+                  mode_t actual_mode = file_stat.st_mode & 0777;  // Mask to get only permission bits
+                  expect((int)actual_mode).ToBe(0644);
+                  
+                  // Cleanup
+                  unlink(test_file.c_str());
+                });
+
+             it("should successfully chmod a directory with recursive flag",
+                [&]() -> void
+                {
+                  // Create test directory structure
+                  rmdir(test_dir.c_str());  // Remove if exists
+                  mkdir(test_dir.c_str(), 0700);
+                  
+                  // Create a file inside the directory to test recursive behavior
+                  string inner_file = test_dir + "/inner_file.txt";
+                  ofstream file(inner_file);
+                  file << "inner content";
+                  file.close();
+                  chmod(inner_file.c_str(), 0600);
+                  
+                  // Test chmod function with recursive flag
+                  int result = zusf_chmod_uss_file_or_dir(&zusf, test_dir, 0755, true);
+                  expect(result).ToBe(RTNCD_SUCCESS);
+                  
+                  // Verify directory permissions were changed
+                  struct stat dir_stat;
+                  stat(test_dir.c_str(), &dir_stat);
+                  mode_t actual_dir_mode = dir_stat.st_mode & 0777;
+                  expect((int)actual_dir_mode).ToBe(0755);
+                  
+                  // Verify file permissions were also changed (recursive)
+                  struct stat file_stat;
+                  stat(inner_file.c_str(), &file_stat);
+                  mode_t actual_file_mode = file_stat.st_mode & 0777;
+                  expect((int)actual_file_mode).ToBe(0755);
+                  
+                  // Cleanup
+                  unlink(inner_file.c_str());
+                  rmdir(test_dir.c_str());
+                });
+
+             it("should handle different permission modes correctly",
+                [&]() -> void
+                {
+                  // Create test file
+                  unlink(test_file.c_str());
+                  ofstream file(test_file);
+                  file << "test content";
+                  file.close();
+                  
+                  // Test different permission modes
+                  mode_t test_modes[] = {0600, 0644, 0755, 0777};
+                  
+                  for (mode_t mode : test_modes) {
+                    int result = zusf_chmod_uss_file_or_dir(&zusf, test_file, mode, false);
+                    expect(result).ToBe(RTNCD_SUCCESS);
+                    
+                    struct stat file_stat;
+                    stat(test_file.c_str(), &file_stat);
+                    mode_t actual_mode = file_stat.st_mode & 0777;
+                    expect((int)actual_mode).ToBe((int)mode);
+                  }
+                  
+                  // Cleanup
+                  unlink(test_file.c_str());
+                });
+           });
+} 

--- a/native/c/test/zusf.test.cpp
+++ b/native/c/test/zusf.test.cpp
@@ -27,7 +27,7 @@ using namespace ztst;
 void zusf_tests()
 {
   describe("zusf_chmod_uss_file_or_dir tests",
-           []() -> void
+           [&]() -> void
            {
              // Setup test environment
              ZUSF zusf;

--- a/native/c/test/zusf.test.cpp
+++ b/native/c/test/zusf.test.cpp
@@ -10,7 +10,6 @@
  */
 
 #include <iostream>
-#include <stdexcept>
 #include <fstream>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -32,33 +31,33 @@ void zusf_tests()
              // Setup test environment
              ZUSF zusf;
              memset(&zusf, 0, sizeof(zusf));
-             
+
              const string test_file = "/tmp/zusf_test_file.txt";
              const string test_dir = "/tmp/zusf_test_dir";
              const string nonexistent_file = "/tmp/nonexistent_file.txt";
-             
+
              it("should fail when file does not exist",
                 [&]() -> void
                 {
                   // Ensure the file doesn't exist
                   unlink(nonexistent_file.c_str());
-                  
+
                   int result = zusf_chmod_uss_file_or_dir(&zusf, nonexistent_file, 0644, false);
-                  expect(result).ToBe(RTNCD_FAILURE);
-                  expect(string(zusf.diag.e_msg)).ToBe("Path '/tmp/nonexistent_file.txt' does not exist");
+                  Expect(result).ToBe(RTNCD_FAILURE);
+                  Expect(string(zusf.diag.e_msg)).ToBe("Path '/tmp/nonexistent_file.txt' does not exist");
                 });
 
              it("should fail when trying to chmod directory without recursive flag",
                 [&]() -> void
                 {
                   // Create test directory
-                  rmdir(test_dir.c_str());  // Remove if exists
+                  rmdir(test_dir.c_str()); // Remove if exists
                   mkdir(test_dir.c_str(), 0755);
-                  
+
                   int result = zusf_chmod_uss_file_or_dir(&zusf, test_dir, 0644, false);
-                  expect(result).ToBe(RTNCD_FAILURE);
-                  expect(string(zusf.diag.e_msg)).ToBe("Path '/tmp/zusf_test_dir' is a folder and recursive is false");
-                  
+                  Expect(result).ToBe(RTNCD_FAILURE);
+                  Expect(string(zusf.diag.e_msg)).ToBe("Path '/tmp/zusf_test_dir' is a folder and recursive is false");
+
                   // Cleanup
                   rmdir(test_dir.c_str());
                 });
@@ -67,24 +66,24 @@ void zusf_tests()
                 [&]() -> void
                 {
                   // Create test file
-                  unlink(test_file.c_str());  // Remove if exists
+                  unlink(test_file.c_str()); // Remove if exists
                   ofstream file(test_file);
                   file << "test content";
                   file.close();
-                  
+
                   // Set initial permissions
                   chmod(test_file.c_str(), 0600);
-                  
+
                   // Test chmod function
                   int result = zusf_chmod_uss_file_or_dir(&zusf, test_file, 0644, false);
-                  expect(result).ToBe(RTNCD_SUCCESS);
-                  
+                  Expect(result).ToBe(RTNCD_SUCCESS);
+
                   // Verify permissions were changed
                   struct stat file_stat;
                   stat(test_file.c_str(), &file_stat);
-                  mode_t actual_mode = file_stat.st_mode & 0777;  // Mask to get only permission bits
-                  expect((int)actual_mode).ToBe(0644);
-                  
+                  mode_t actual_mode = file_stat.st_mode & 0777; // Mask to get only permission bits
+                  Expect((int)actual_mode).ToBe(0644);
+
                   // Cleanup
                   unlink(test_file.c_str());
                 });
@@ -93,32 +92,32 @@ void zusf_tests()
                 [&]() -> void
                 {
                   // Create test directory structure
-                  rmdir(test_dir.c_str());  // Remove if exists
+                  rmdir(test_dir.c_str()); // Remove if exists
                   mkdir(test_dir.c_str(), 0700);
-                  
+
                   // Create a file inside the directory to test recursive behavior
                   string inner_file = test_dir + "/inner_file.txt";
                   ofstream file(inner_file);
                   file << "inner content";
                   file.close();
                   chmod(inner_file.c_str(), 0600);
-                  
+
                   // Test chmod function with recursive flag
                   int result = zusf_chmod_uss_file_or_dir(&zusf, test_dir, 0755, true);
-                  expect(result).ToBe(RTNCD_SUCCESS);
-                  
+                  Expect(result).ToBe(RTNCD_SUCCESS);
+
                   // Verify directory permissions were changed
                   struct stat dir_stat;
                   stat(test_dir.c_str(), &dir_stat);
                   mode_t actual_dir_mode = dir_stat.st_mode & 0777;
-                  expect((int)actual_dir_mode).ToBe(0755);
-                  
+                  Expect((int)actual_dir_mode).ToBe(0755);
+
                   // Verify file permissions were also changed (recursive)
                   struct stat file_stat;
                   stat(inner_file.c_str(), &file_stat);
                   mode_t actual_file_mode = file_stat.st_mode & 0777;
-                  expect((int)actual_file_mode).ToBe(0755);
-                  
+                  Expect((int)actual_file_mode).ToBe(0755);
+
                   // Cleanup
                   unlink(inner_file.c_str());
                   rmdir(test_dir.c_str());
@@ -132,22 +131,23 @@ void zusf_tests()
                   ofstream file(test_file);
                   file << "test content";
                   file.close();
-                  
+
                   // Test different permission modes
                   mode_t test_modes[] = {0600, 0644, 0755, 0777};
-                  
-                  for (mode_t mode : test_modes) {
+
+                  for (mode_t mode : test_modes)
+                  {
                     int result = zusf_chmod_uss_file_or_dir(&zusf, test_file, mode, false);
-                    expect(result).ToBe(RTNCD_SUCCESS);
-                    
+                    Expect(result).ToBe(RTNCD_SUCCESS);
+
                     struct stat file_stat;
                     stat(test_file.c_str(), &file_stat);
                     mode_t actual_mode = file_stat.st_mode & 0777;
-                    expect((int)actual_mode).ToBe((int)mode);
+                    Expect((int)actual_mode).ToBe((int)mode);
                   }
-                  
+
                   // Cleanup
                   unlink(test_file.c_str());
                 });
            });
-} 
+}

--- a/native/c/test/zusf.test.hpp
+++ b/native/c/test/zusf.test.hpp
@@ -1,0 +1,15 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+#ifndef ZUSF_TEST_HPP
+#define ZUSF_TEST_HPP
+void zusf_tests();
+#endif 

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -712,13 +712,13 @@ int zusf_chtag_uss_file_or_dir(ZUSF *zusf, string file, string tag, bool recursi
   const auto is_dir = S_ISDIR(file_stats.st_mode);
   if (!is_dir)
   {
-    attrib64_t attr;
+    attrib_t attr;
     memset(&attr, 0, sizeof(attr));
     attr.att_filetagchg = 1;
     attr.att_filetag.ft_ccsid = ccsid;
     attr.att_filetag.ft_txtflag = int(ccsid != 65535);
 
-    const auto rc = __chattr64((char *)file.c_str(), &attr, sizeof(attr));
+    const auto rc = __chattr((char *)file.c_str(), &attr, sizeof(attr));
     if (rc != 0)
     {
       zusf->diag.e_msg_len = sprintf(zusf->diag.e_msg, "Failed to update attributes for path '%s'", file.c_str());

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -186,13 +186,15 @@ int zusf_list_uss_file_path(ZUSF *zusf, string file, string &response, ListOptio
       stat(child_path.c_str(), &child_stats);
 
       vector<string> fields;
-      string name =entry->d_name;
-      if (name.at(0) == '.' && !options.all_files) {
+      string name = entry->d_name;
+      if (name.at(0) == '.' && !options.all_files)
+      {
         continue;
       }
 
       fields.push_back(entry->d_name);
-      if (options.long_format) {
+      if (options.long_format)
+      {
         string mode;
         mode += (S_ISDIR(child_stats.st_mode) ? "d" : "-");
         mode += (child_stats.st_mode & S_IRUSR ? "r" : "-");
@@ -519,7 +521,7 @@ int zusf_write_to_uss_file_streamed(ZUSF *zusf, string file, string pipe)
  *
  * @return RTNCD_SUCCESS on success, RTNCD_FAILURE on failure
  */
-int zusf_chmod_uss_file_or_dir(ZUSF *zusf, string file, string mode, bool recursive)
+int zusf_chmod_uss_file_or_dir(ZUSF *zusf, string file, mode_t mode, bool recursive)
 {
   // TODO(zFernand0): Add recursive option for directories
   struct stat file_stats;
@@ -535,7 +537,7 @@ int zusf_chmod_uss_file_or_dir(ZUSF *zusf, string file, string mode, bool recurs
     return RTNCD_FAILURE;
   }
 
-  chmod(file.c_str(), strtol(mode.c_str(), nullptr, 8));
+  chmod(file.c_str(), mode);
   if (recursive && S_ISDIR(file_stats.st_mode))
   {
     DIR *dir;

--- a/native/c/zusf.hpp
+++ b/native/c/zusf.hpp
@@ -19,12 +19,14 @@
 #include <vector>
 #include <string>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include "zusf.hpp"
 #include "zusftype.h"
 
-typedef struct _ListOptions {
-    bool all_files;
-    bool long_format;
+typedef struct _ListOptions
+{
+  bool all_files;
+  bool long_format;
 } ListOptions;
 
 int zusf_create_uss_file_or_dir(ZUSF *zusf, std::string file, std::string mode, bool createDir);
@@ -33,7 +35,7 @@ int zusf_read_from_uss_file(ZUSF *zusf, std::string file, std::string &response)
 int zusf_read_from_uss_file_streamed(ZUSF *zusf, std::string file, std::string pipe);
 int zusf_write_to_uss_file(ZUSF *zusf, std::string file, std::string &data);
 int zusf_write_to_uss_file_streamed(ZUSF *zusf, std::string file, std::string pipe);
-int zusf_chmod_uss_file_or_dir(ZUSF *zusf, std::string file, std::string mode, bool recursive);
+int zusf_chmod_uss_file_or_dir(ZUSF *zusf, std::string file, mode_t mode, bool recursive);
 int zusf_delete_uss_item(ZUSF *zusf, std::string file, bool recursive);
 int zusf_chown_uss_file_or_dir(ZUSF *zusf, std::string file, std::string owner, bool recursive);
 short zusf_get_id_from_user_or_group(std::string user_or_group, bool is_user);


### PR DESCRIPTION
**What It Does**

- Fixes handling cases where `strtol` fails to parse the given mode in the `zusf_chmod_uss_file_or_dir` function. I've removed the `strtol` logic altogether, and the command handler now passes the octal value into the function to save the overhead of converting to string for recursive calls.
- Added support for capturing lambdas so we can declare common variables outside of lambdas for tests 😋 should help with avoiding code duplication and now the callables behave like "arrow functions" (akin to Jest) where you can capture variables outside of the function's scope.

**How to Test**

Run the command: `./zowex uss chmod 777 /u/users/<username>/<some_file_here>`
Notice that the command was successful, and the permissions are now accurately set.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)