### PR TITLE
fix mode parsing for `zusf_create_uss_file_or_dir`

### DIFF
--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1669,12 +1669,34 @@ int handle_uss_create_file(const ParseResult &result)
 {
   int rc = 0;
   string file_path = result.find_pos_arg_string("file-path");
-  string mode = result.find_kw_arg_string("mode");
-  if (mode.empty())
-    mode = "644";
+
+  int mode = result.find_kw_arg_int("mode");
+  if (result.find_kw_arg_string("mode").empty())
+  {
+    mode = 644;
+  }
+  else if (mode == 0 && result.find_kw_arg_string("mode") != "0")
+  {
+    cerr << "Error: invalid mode provided.\nExamples of valid modes: 777, 0644" << endl;
+    return RTNCD_FAILURE;
+  }
+
+  // Convert mode from decimal to octal
+  mode_t cf_mode = 0;
+  int temp_mode = mode;
+  int multiplier = 1;
+
+  // Convert decimal representation of octal to actual octal value
+  // e.g. user inputs 777 -> converted to correct value for chmod
+  while (temp_mode > 0)
+  {
+    cf_mode += (temp_mode % 10) * multiplier;
+    temp_mode /= 10;
+    multiplier *= 8;
+  }
 
   ZUSF zusf = {0};
-  rc = zusf_create_uss_file_or_dir(&zusf, file_path, mode, false);
+  rc = zusf_create_uss_file_or_dir(&zusf, file_path, cf_mode, false);
   if (0 != rc)
   {
     cerr << "Error: could not create USS file: '" << file_path << "' rc: '" << rc << "'" << endl;
@@ -1692,12 +1714,34 @@ int handle_uss_create_dir(const ParseResult &result)
 {
   int rc = 0;
   string file_path = result.find_pos_arg_string("file-path");
-  string mode = result.find_kw_arg_string("mode");
-  if (mode.empty())
-    mode = "755";
+
+  int mode = result.find_kw_arg_int("mode");
+  if (result.find_kw_arg_string("mode").empty()) 
+  {
+    mode = 755;
+  } 
+  else if (mode == 0 && result.find_kw_arg_string("mode") != "0")
+  {
+    cerr << "Error: invalid mode provided.\nExamples of valid modes: 777, 0644" << endl;
+    return RTNCD_FAILURE;
+  }
+
+  // Convert mode from decimal to octal
+  mode_t cf_mode = 0;
+  int temp_mode = mode;
+  int multiplier = 1;
+
+  // Convert decimal representation of octal to actual octal value
+  // e.g. user inputs 777 -> converted to correct value for chmod
+  while (temp_mode > 0)
+  {
+    cf_mode += (temp_mode % 10) * multiplier;
+    temp_mode /= 10;
+    multiplier *= 8;
+  }
 
   ZUSF zusf = {0};
-  rc = zusf_create_uss_file_or_dir(&zusf, file_path, mode, true);
+  rc = zusf_create_uss_file_or_dir(&zusf, file_path, cf_mode, true);
   if (0 != rc)
   {
     cerr << "Error: could not create USS directory: '" << file_path << "' rc: '" << rc << "'" << endl;

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -56,7 +56,7 @@ using namespace std;
  *
  * @return RTNCD_SUCCESS on success, RTNCD_FAILURE on failure
  */
-int zusf_create_uss_file_or_dir(ZUSF *zusf, string file, string mode, bool createDir)
+int zusf_create_uss_file_or_dir(ZUSF *zusf, string file, mode_t mode, bool createDir)
 {
   struct stat file_stats;
   if (stat(file.c_str(), &file_stats) != -1)
@@ -92,7 +92,7 @@ int zusf_create_uss_file_or_dir(ZUSF *zusf, string file, string mode, bool creat
         }
       }
     }
-    const auto rc = mkdir(file.c_str(), strtol(mode.c_str(), nullptr, 8));
+    const auto rc = mkdir(file.c_str(), mode);
     if (rc != 0)
     {
       zusf->diag.e_msg_len = sprintf(zusf->diag.e_msg, "Failed to create directory '%s', errno: %d", file.c_str(), errno);
@@ -105,7 +105,7 @@ int zusf_create_uss_file_or_dir(ZUSF *zusf, string file, string mode, bool creat
     if (out.is_open())
     {
       out.close();
-      chmod(file.c_str(), strtol(mode.c_str(), nullptr, 8));
+      chmod(file.c_str(), mode);
       return RTNCD_SUCCESS;
     }
   }

--- a/native/c/zusf.hpp
+++ b/native/c/zusf.hpp
@@ -29,7 +29,7 @@ typedef struct _ListOptions
   bool long_format;
 } ListOptions;
 
-int zusf_create_uss_file_or_dir(ZUSF *zusf, std::string file, std::string mode, bool createDir);
+int zusf_create_uss_file_or_dir(ZUSF *zusf, std::string file, mode_t mode, bool createDir);
 int zusf_list_uss_file_path(ZUSF *zusf, std::string file, std::string &response, ListOptions options = ListOptions{});
 int zusf_read_from_uss_file(ZUSF *zusf, std::string file, std::string &response);
 int zusf_read_from_uss_file_streamed(ZUSF *zusf, std::string file, std::string pipe);


### PR DESCRIPTION
**What It Does**
Fixes handling cases where strtol fails to parse the given mode in the `zusf_create_uss_file_or_dir` function. An error code will be returned if an invalid mode is provided.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
