### PR TITLE
dev: optimize default make target

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ We use a custom build tool for interacting with z/OS that defines the following 
 | `z:build`     | Run `make` and `go build` on z/OS to build native binaries                  |
 | `z:clean`     | Run `make clean` on z/OS to clean build targets                             |
 | `z:delete`    | Delete all files from deploy directory                                      |
+| `z:make`      | Execute the specified Make targets on z/OS                                  |
 | `z:package`   | Create server PAX artifact in `dist` directory                              |
 | `z:rebuild`   | Upload and Build combined in one command                                    |
 | `z:test`      | Run automated tests for native components on z/OS                           |

--- a/native/c/makefile
+++ b/native/c/makefile
@@ -104,7 +104,7 @@ MTL_FLAGS+=-g1
 MTL_FLAGS64+=-g1
 .END
 
-all: libzut.so libzut.a libzds.so libzds.a libzusf.so libzusf.a libzcn.so libzcn.a libzjb.so libzjb.a zowex zoweax extattr xlclang-extenders tests
+all: libzut.so libzut.a libzds.so libzds.a libzusf.so libzusf.a libzcn.so libzcn.a libzjb.so libzjb.a zowex zoweax extattr
 xlclang-extenders: $(OUT_DIR_CXXLANG)/zut.o $(OUT_DIR_CXXLANG)/zds.o $(OUT_DIR_CXXLANG)/zjb.o $(OUT_DIR_CXXLANG)/zcn.o $(OUT_DIR_CXXLANG)/zusf.o
 # SWIG extenders: compile C++ files with SWIG macro defined for Python bindings
 swig-extenders: $(OUT_DIR_SWIG)/zut.o $(OUT_DIR_SWIG)/zds.o $(OUT_DIR_SWIG)/zjb.o $(OUT_DIR_SWIG)/zcn.o $(OUT_DIR_SWIG)/zusf.o $(OUT_DIR_SWIG)/ztso.o

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "z:make": "tsx scripts/buildTools.ts make",
     "z:package": "npm run z:artifacts && tsx scripts/buildTools.ts package",
     "z:rebuild": "tsx scripts/buildTools.ts rebuild",
-    "z:test": "npm run z:make xlclang-extenders && tsx scripts/buildTools.ts test",
+    "z:test": "npm run z:make xlclang-extenders tests && tsx scripts/buildTools.ts test",
     "z:test:python": "tsx scripts/buildTools.ts test:python",
     "z:upload": "tsx scripts/buildTools.ts upload",
     "z:watch": "tsx scripts/buildTools.ts watch"

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
     "z:build:python": "tsx scripts/buildTools.ts build:python",
     "z:clean": "tsx scripts/buildTools.ts clean",
     "z:delete": "tsx scripts/buildTools.ts delete",
+    "z:make": "tsx scripts/buildTools.ts make",
     "z:package": "npm run z:artifacts && tsx scripts/buildTools.ts package",
     "z:rebuild": "tsx scripts/buildTools.ts rebuild",
-    "z:test": "tsx scripts/buildTools.ts test",
+    "z:test": "npm run z:make xlclang-extenders && tsx scripts/buildTools.ts test",
     "z:test:python": "tsx scripts/buildTools.ts test:python",
     "z:upload": "tsx scripts/buildTools.ts upload",
     "z:watch": "tsx scripts/buildTools.ts watch"

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -468,6 +468,16 @@ async function buildPython(connection: Client) {
     console.log("Build complete!");
 }
 
+async function make(connection: Client) {
+    const targets = args.filter((arg, idx) => idx > 0 && !arg.startsWith("--")).join(" ");
+    console.log(`Running make ${targets || "all"}...`);
+    const response = await runCommandInShell(
+        connection,
+        `cd ${deployDirs.cDir} && make ${targets} ${DEBUG_MODE() ? "-DBuildType=DEBUG" : ""}\n`,
+    );
+    console.log(response);
+}
+
 async function test(connection: Client) {
     console.log("Testing native/c ...");
     const response = await runCommandInShell(
@@ -789,6 +799,9 @@ async function main() {
                 break;
             case "get-listings":
                 await getListings(sshClient);
+                break;
+            case "make":
+                await make(sshClient);
                 break;
             case "package":
                 await artifacts(sshClient, true);

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -461,19 +461,13 @@ async function build(connection: Client, goBuildEnv?: string) {
     console.log("Build complete!");
 }
 
-async function buildPython(connection: Client) {
-    console.log("Building native/python ...");
-    const response = await runCommandInShell(connection, `cd ${deployDirs.pythonDir} && make\n`);
-    DEBUG_MODE() && console.log(response);
-    console.log("Build complete!");
-}
-
-async function make(connection: Client) {
+async function make(connection: Client, inDir?: string) {
+    const pwd = inDir ?? deployDirs.cDir;
     const targets = args.filter((arg, idx) => idx > 0 && !arg.startsWith("--")).join(" ");
-    console.log(`Running make ${targets || "all"}...`);
+    console.log(`Running "make ${targets || "all"}"${inDir ? ` in ${pwd}` : ""}...`);
     const response = await runCommandInShell(
         connection,
-        `cd ${deployDirs.cDir} && make ${targets} ${DEBUG_MODE() ? "-DBuildType=DEBUG" : ""}\n`,
+        `cd ${pwd} && make ${targets} ${DEBUG_MODE() ? "-DBuildType=DEBUG" : ""}\n`,
     );
     console.log(response);
 }
@@ -484,13 +478,6 @@ async function test(connection: Client) {
         connection,
         `cd ${deployDirs.cTestDir} && _CEE_RUNOPTS="TRAP(ON,NOSPIE)" ./build-out/ztest_runner ${args[1] ?? ""} \n`,
     );
-    console.log(response);
-    console.log("Testing complete!");
-}
-
-async function testPython(connection: Client) {
-    console.log("Testing native/python ...");
-    const response = await runCommandInShell(connection, `cd ${deployDirs.pythonTestDir} && make\n`);
     console.log(response);
     console.log("Testing complete!");
 }
@@ -783,10 +770,10 @@ async function main() {
                 await build(sshClient, config.goBuildEnv);
                 break;
             case "build:python":
-                await buildPython(sshClient);
+                await make(sshClient, deployDirs.pythonDir);
                 break;
             case "test:python":
-                await testPython(sshClient);
+                await make(sshClient, deployDirs.pythonTestDir);
                 break;
             case "clean":
                 await clean(sshClient);


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Optimizes the default targets built by `make` to remove `xlclang-extenders` and `tests`.
This should make the `z:build` and `z:rebuild` scripts significantly faster, and fix `z:watch`.
Since `xlclang-extenders` is required to run tests, it has been moved to the `z:test` script.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
First clean your environment with `z:delete`, then try the `z:rebuild` and `z:test` commands.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
