### PR TITLE
Console Timeout Infrastructure

### DIFF
--- a/native/asmmac/ZWEEPILG
+++ b/native/asmmac/ZWEEPILG
@@ -18,15 +18,22 @@
 .*
 .*       ZWEEPILG
 .*
+.*  Todo:
+.*       - skip free if not &CCN_MAIN
+.*
 &NAME    ZWEEPILG ,
 .*
          COPY  CCNZGBL
-         GBLA  &DSA_SZ
+         GBLA  &ZG_DSASZ
+         GBLA  &ZG_DSASP
+         GBLB  &ZG_SAVE
+         GBLB  &ZG_BAKR
+         GBLB  &ZG_SAM64
 .*
 &MACNM   SETC  '&SYSMAC(0)'
 
-&IS_64   SETB  (&CCN_LP64)
-&IS_AR   SETB  ('CCN_ASCM' EQ 'AR')
+&IS_64   SETB  (&CCN_LP64 OR &ZG_SAM64)
+&IS_AR   SETB  ('&CCN_ASCM' EQ 'AR')
 .*
 .*       Set 31 or 64 bit instructions
 .*
@@ -37,50 +44,61 @@
 &LRx     SETC  'LGR'
 .CONT020 ANOP  ,
 .*
-         AIF   (&DSA_SZ EQ 0).CONT600
-         &LRx  1,13
+         AIF   (&ZG_DSASZ EQ 0).CONT600
+         AIF   (NOT &ZG_BAKR).CONT300
+         &LRx  2,15            Preserve R15
+         LHI   0,3             Code #3 = MSTA
+         ESTA  0,0
+         AGO   .CONT400
+.CONT300 ANOP ,
+         &LRx  1,13            -> Dynamic storage
 .*
          AIF   (&IS_64).LOAD64
-         L     13,4(,13)
-         ST    15,16(,13)
+         L     13,4(,13)       Get previous save area
+         ST    15,16(,13)      Save R15 contents there
          AGO   .CONT400
 .LOAD64  ANOP  ,
-         LG    13,128(,13)
-         STG   15,16(,13)
+         LG    13,128(,13)     Get previous save area
+         STG   15,16(,13)      Save R15 contents there
 .CONT400 ANOP  ,
 *
-         LARL  15,&CCN_LITN
+         LARL  15,&CCN_LITN    -> Literals
          USING &CCN_LITN,15
 *
          STORAGE RELEASE,                                              +
                CALLRKY=YES,                                            +
-               SP=132,                                                 +
-               LENGTH=&DSA_SZ,                                         +
+               SP=&ZG_DSASP.,                                          +
+               LENGTH=&ZG_DSASZ,                                       +
                ADDR=(1)
 *
          DROP  15
 .*
+         AIF   (NOT &ZG_BAKR).CONT500
+         &LRx  15,2            Restore R15
+         PR    ,               Return to caller
+         AGO   .EXIT
+.*
 .*       Restore R15 from SA if we released storage
 .*
-         AIF   (&IS_64).CONT500
-*
-         L     15,16(,13)
-         AGO   .CONT600
 .CONT500 ANOP
-         LG    15,16(,13)
+         AIF   (&IS_64).CONT540
+         L     15,16(,13)      Restore R15 from SA
+         AGO   .CONT600
+.CONT540 ANOP
+         LG    15,16(,13)      Restore R15 from SA
 .*
 .*       Exit linkage
 .*
 .CONT600 ANOP
          AIF   (&IS_64).ULINK64
-         L     14,12(,13)
-         LM    1,12,24(13)
+         L     14,12(,13)      Restore R14 from save area
+         LM    1,12,24(13)     Restore remaining regs
          AGO   .CONT800
 .ULINK64 ANOP
-         LG    14,8(,13)
-         LMG   1,12,32(13)
+         LG    14,8(,13)       Restore R14 from save area
+         LMG   1,12,32(13)     Restore remaining regs
 .CONT800 ANOP
-         BR    14
+         BR    14              Return to caller
 .*
 .* Common exit
 .*

--- a/native/asmmac/ZWEPROLG
+++ b/native/asmmac/ZWEPROLG
@@ -16,7 +16,23 @@
 .*
 .*  Usage:
 .*
-.*       ZWEPROLG NEWDSA=([YES|NO],[#KBs],[subpool])
+.*       ZWEPROLG NEWDSA=([YES|NO],[#KBs],[subpool]),
+.*         SAVE=[SA,BAKR],
+.*         SAM64=[NO,YES]
+.*
+.*       NEWDSA=([YES|NO],[#KBs],[subpool])
+.*         YES: (default) allocate new DSA
+.*         NO:  use existing DSA
+.*         #KBs: size of DSA in KBs (default 1024)
+.*         subpool: subpool of DSA (default 132)
+.*
+.*       SAVE=[SA,BAKR]
+.*         SA: (default) save input regs
+.*         BAKR: save registers on linkage stack
+.*
+.*       SAM64=[NO,YES]
+.*         NO:  (default) use 31-bit AMODE
+.*         YES: generate SAM64 instruction
 .*
 .*  Commonly referenced symbols:
 .*    &CCN_RHIGH
@@ -30,20 +46,26 @@
 .*    &CCN_CSECT
 .*    CCN_IASM_MACRO
 .*
-&NAME    ZWEPROLG &NEWDSA=
+&NAME    ZWEPROLG &NEWDSA=,&SAVE=SA,&SAM64=NO
 .*
          COPY  CCNZGBL
-         GBLA  &DSA_SZ
-         GBLA  &DSA_SP
+         GBLA  &ZG_DSASZ
+         GBLA  &ZG_DSASP
+         GBLB  &ZG_SAVE
+         GBLB  &ZG_BAKR
+         GBLB  &ZG_SAM64
 .*
 &MACNM   SETC  '&SYSMAC(0)'
 .*
-&DSA_SZ  SETA  0
-&DSA_SP  SETA  132
-&IS_64   SETB  (&CCN_LP64)
-&IS_AR   SETB  ('CCN_ASCM' EQ 'AR')
-&KB#     SETA  1024
-&GETDSA  SETB  0
+&ZG_DSASZ SETA  0
+&ZG_DSASP SETA  132
+&ZG_SAVE  SETB  0
+&ZG_BAKR  SETB  0
+&ZG_SAM64 SETB  0
+&IS_64    SETB  (&CCN_LP64 OR '&SAM64' EQ 'YES')
+&IS_AR    SETB  ('&CCN_ASCM' EQ 'AR')
+&KB#      SETA  1024
+&GETDSA   SETB  0
 .*
 .*       Set 31 or 64 bit instructions
 .*
@@ -64,50 +86,93 @@
 &SLRx    SETC  'SLGR'
 .CONT000 ANOP  ,
 .*
-.*       Validate paramters
+.*       Validate and handle SAVE= paramters
 .*
-         AIF   ('&NEWDSA(1)' EQ 'YES').CONT040
-         AIF   ('&NEWDSA(1)' EQ '').CONT100
-         AIF   ('&NEWDSA(1)' EQ 'NO').CONT100
+         AIF   ('&SAVE' NE 'SA' AND '&SAVE' NE 'BAKR').ERR020
+         AIF   ('&SAVE' EQ 'BAKR').CONT020
+&ZG_SAVE SETB  1
+         AGO   .CONT100
+.*
+.CONT020 ANOP ,
+&ZG_BAKR SETB  1
+         AGO   .CONT100
+.*
+.*       Must be NO or YES
+.*
+.CONT100 ANOP ,
+         AIF   ('&SAM64' NE 'NO' AND '&SAM64' NE 'YES').ERR030
+.*
+.*       SAM64=YES may only be used with SAVE=BAKR
+.*
+         AIF   ('&SAVE' NE 'BAKR' AND '&SAM64' EQ 'YES').ERR040
+.*
+.*       Set SAM64=YES if requested
+.*
+         AIF   ('&SAM64' NE 'YES').CONT200
+&ZG_SAM64 SETB  1
+.*
+.CONT200 ANOP ,
+         AIF   ('&NEWDSA(1)' EQ 'YES').CONT240
+         AIF   ('&NEWDSA(1)' EQ '').CONT300
+         AIF   ('&NEWDSA(1)' EQ 'NO').CONT300
          AGO   .ERR010
 .*
 .*       Set DSA size
 .*
-.CONT040 ANOP ,
+.CONT240 ANOP ,
 &GETDSA  SETB  1
-         AIF   ('&NEWDSA(2)' EQ '').CONT060
+         AIF   ('&NEWDSA(2)' EQ '').CONT260
 &KB#     SETA  &NEWDSA(2)
 .*
 .*       Set DSA subpool
 .*
-.CONT060 ANOP ,
-         AIF   ('&NEWDSA(3)' EQ '').CONT100
-&DSA_SP  SETA  &NEWDSA(3)
+.CONT260 ANOP ,
+         AIF   ('&NEWDSA(3)' EQ '').CONT300
+&ZG_DSASP  SETA  &NEWDSA(3)
 .*
 .*       Save input regs
 .*
-.CONT100 ANOP ,
+.CONT300 ANOP ,
+         AIF   (&ZG_SAVE).CONT380
+         AIF   (NOT &ZG_BAKR).CONT400
+.*
+.*       NOTE(Kelosky): in the future, if 31-bit caller BASSMs here
+.*       we would not want to do this because we would return in
+.*       the wrong AMODE.
+.*
+         BSM   14,0
+.*
+.*       If SAM64=YES, set AMODE to 64
+.*
+.CONT310 ANOP ,
+         AIF   (NOT &ZG_SAM64).CONT320
+         SAM64 ,                Set AMODE to 64
+.CONT320 ANOP ,
+         BAKR  14,0             Save registers on linkage stack
+         AGO   .CONT400
+.*
+.CONT380 ANOP ,
          AIF   (&IS_64).SAVE64
-         STM   14,12,12(13)
+         STM   14,12,12(13)     Save caller regs
          AGO   .CONT400
 .SAVE64  ANOP
-         STMG  14,12,8(13)
+         STMG  14,12,8(13)      Save caller regs
 .CONT400 ANOP  ,
          AIF   (NOT &GETDSA).EXIT
 .*
 .*       Obtain DSA
 .*
-         LARL  15,&CCN_LITN
+         LARL  15,&CCN_LITN      -> Literals
          USING &CCN_LITN,15
 .*
-&DSA_SZ  SETA  &KB#*1024
-         &LHIx 3,&KB#
-         &MHIx 3,1024
+&ZG_DSASZ  SETA  &KB#*1024
+         &LHIx 3,&KB#            Number of KBs
+         &MHIx 3,1024            Multiply by 1024
 *
          STORAGE OBTAIN,                                               +
                LENGTH=(3),                                             +
                CALLRKY=YES,                                            +
-               SP=&DSA_SP.,                                            +
+               SP=&ZG_DSASP.,                                          +
                BNDRY=PAGE,                                             +
                COND=NO
 .*
@@ -120,18 +185,22 @@
 .*
          &LRxx 15,2              -> New storage
 .*
+         AIF   (&ZG_BAKR).CONT600 Skip chaining if BAKR is requested
          AIF   (&IS_64).LINK64
-         ST    15,8(,13)
-         ST    13,4(,15)
-         LM    14,14,12(13)
-         LM    0,3,20(13)
-         AGO   .CONT600
+         ST    15,8(,13)         Save new storage in caller next
+         ST    13,4(,15)         Save previus in our previous
+         LM    14,14,12(13)      Restore R14
+         LM    0,3,20(13)        Restore input registers
+         AGO   .CONT620
 .LINK64  ANOP
-         STG   15,136(,13)
-         STG   13,128(,15)
-         LMG   14,14,8(13)
-         LMG   0,3,24(13)
+         STG   15,136(,13)       Save new storage in caller next
+         STG   13,128(,15)       Save previous in our previous
+         LMG   14,14,8(13)       Restore R14
+         LMG   0,3,24(13)        Restore input registers
+         AGO   .CONT620
 .CONT600 ANOP
+         MSTA  14                Save storage address (R15) in MSTA
+.CONT620 ANOP
          &LRxx 13,15
          DROP  15
          AGO   .EXIT
@@ -140,6 +209,15 @@
 .*
 .ERR010  ANOP  ,
          MNOTE 8,'&MACNM. - DSA= must be YES|NO'
+         AGO   .EXIT
+.ERR020  ANOP  ,
+         MNOTE 8,'&MACNM. - SAVE= must be SA|BAKR'
+         AGO   .EXIT
+.ERR030  ANOP  ,
+         MNOTE 8,'&MACNM. - SAM64= must be NO|YES'
+         AGO   .EXIT
+.ERR040  ANOP  ,
+         MNOTE 8,'&MACNM. - SAM64=YES may only be used with SAVE=BAKR'
          AGO   .EXIT
 .*
 .* Common exit

--- a/native/c/examples/metal/demometal.c
+++ b/native/c/examples/metal/demometal.c
@@ -11,13 +11,15 @@
 
 #include "zwto.h"
 #include "zmetal.h"
+#include "zsetjmp.h"
 
 #pragma prolog(main, " ZWEPROLG NEWDSA=(YES,128) ")
 #pragma epilog(main, " ZWEEPILG ")
 
-void test()
+void test(ZSETJMP_ENV *zenv)
 {
   zwto_debug("test called");
+  zlongjmp(zenv);
 }
 
 int main()
@@ -25,6 +27,20 @@ int main()
   PSW psw = {0};
   get_psw(&psw);
   int mode_switch = psw.p ? 0 : 1;
+
+  ZSETJMP_ENV zenv = {0};
+
+  int rc = zsetjmp(&zenv);
+  if (rc == 0)
+  {
+    zwto_debug("zsetjmp returned 0");
+    test(&zenv);
+    // ZLONGJMP(&zenv);
+  }
+  else
+  {
+    zwto_debug("zsetjmp returned %d", rc);
+  }
 
   return 0;
 }

--- a/native/c/examples/prolog/makefile
+++ b/native/c/examples/prolog/makefile
@@ -1,0 +1,127 @@
+#
+#  This program and the accompanying materials are
+#  made available under the terms of the Eclipse Public License v2.0
+#  which accompanies this distribution, and is available at
+#  https://www.eclipse.org/legal/epl-v20.html
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Copyright Contributors to the Zowe Project.
+#
+
+OUT_DIR=build-out
+OUT_DIRS=$(OUT_DIR_CXXLANG)
+
+XLC_FLAGS=_CC_ACCEPTABLE_RC=0 _C89_ACCEPTABLE_RC=0 _CXX_ACCEPTABLE_RC=0
+CXX=$(XLC_FLAGS) xlc++
+CC=$(XLC_FLAGS) xlc
+ASM=as
+BIND=ld
+
+MTL_OPTS=metal,\
+ langlvl(extended),\
+ sscom,\
+ nolongname,\
+ inline,\
+ genasm,\
+ inlrpt,\
+ csect,\
+ nose,\
+ list,\
+ warn64,\
+ optimize(2),\
+ aggregate
+
+MTL_OPTS64=$(MTL_OPTS),lp64
+MTL_FLAGS=-S -W "c,$(MTL_OPTS)"
+MTL_FLAGS64=-S -W "c,$(MTL_OPTS64)"
+
+MACLIBS= -I../../../asmmac \
+ -ISYS1.MACLIB \
+ -ISYS1.MODGEN \
+ -ICBC.SCCNSAM
+
+MTL_HEADERS=-I/usr/include/metal \
+ -I../../chdsect \
+ -I../../../c
+
+CPP_BND_FLAGS=-W "l,lp64,xplink,map,list"
+
+CPP_BND_FLAGS_AUTH=-W "l,lp64,xplink,map,list,ac=1"
+
+C_FLAGS=-W "c,lp64,langlvl(extended),xplink,exportall"\
+ -c \
+ -I../../chdsect \
+ -I../../../c
+
+DLL_CPP_FLAGS=-W "c,lp64,langlvl(extended0x),dll,xplink,exportall"\
+ -c \
+ -I./chdsect
+
+DLL_BND_FLAGS=-W "l,lp64,dll,dynam=dll,xplink,map,list"
+
+CPP_FLAGS=-W "c,lp64,langlvl(extended0x),dll,xplink"\
+ -c \
+ -I../../chdsect \
+ -I../../../c
+
+ASM_FLAGS=-mRENT
+
+# make -DBuildType=DEBUG
+.IF $(BuildType) == DEBUG
+# -g generates debugging information
+DEBUGGER_FLAGS=-qSOURCE -g9
+OTHER_C_FLAGS=-qSHOWINC -qSHOWMACROS
+
+CPP_BND_FLAGS+=$(DEBUGGER_FLAGS)
+CPP_BND_FLAGS_AUTH+=$(DEBUGGER_FLAGS)
+C_FLAGS+=$(DEBUGGER_FLAGS)
+DLL_BND_FLAGS+=$(DEBUGGER_FLAGS)
+DLL_CPP_FLAGS+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+CPP_FLAGS+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+MTL_FLAGS+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+MTL_FLAGS64+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+ASM_FLAGS+=--verbose
+
+.ELSE
+C_FLAGS+=-g0
+CPP_FLAGS+=-g0
+CPP_BND_FLAGS+=-g0
+CPP_BND_FLAGS_AUTH+=-g0
+DLL_BND_FLAGS+=-g0
+DLL_CPP_FLAGS+=-g0
+ASM_FLAGS+=--noverbose
+
+# Still investigating why we need `-g1` for the MetalC flags :'(
+MTL_FLAGS+=-g1
+MTL_FLAGS64+=-g1
+.END
+
+all: build-out build-out/prolog
+
+prolog: build-out/prolog
+
+build-out:
+	@echo 'Creating build-out'
+	mkdir -p build-out
+
+build-out/prolog.s: prolog.c
+	@echo 'Building build-out/prolog.s'
+	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^
+
+build-out/prolog.o: build-out/prolog.s
+	@echo 'Building build-out/prolog.s'
+	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+
+build-out/prolog: build-out/prolog.o
+	$(BIND) $(BIND_FLAGS_64) -V -eMAIN -o $@ $^ > $*.bind.lst
+
+clean:
+	rm -f *.o
+	rm -f *.dbg
+	rm -f *.so
+	rm -f *.a
+	rm -f *.x
+	rm -f *.lst
+	rm -f CEEDUMP.*
+	rm -rf build-out

--- a/native/c/examples/prolog/prolog.c
+++ b/native/c/examples/prolog/prolog.c
@@ -1,0 +1,68 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+#include "zwto.h"
+#include "zmetal.h"
+#include "zsetjmp.h"
+
+// void test(ZSETJMP_ENV *zenv)
+// {
+//   zwto_debug("test called");
+//   // zlongjmp(zenv);
+// }
+
+#pragma prolog(sub, " ZWEPROLG NEWDSA=(YES,128),SAVE=BAKR ")
+#pragma epilog(sub, " ZWEEPILG ")
+int sub()
+{
+  zwto_debug("sub called");
+  return 1;
+}
+
+#pragma prolog(main, " ZWEPROLG NEWDSA=(YES,128) ")
+#pragma epilog(main, " ZWEEPILG ")
+
+int main()
+{
+
+  PSW psw = {0};
+  get_psw(&psw);
+  if (psw.ba)
+    zwto_debug("main ba mode");
+  if (psw.ea)
+    zwto_debug("main ea mode");
+
+  int rc = sub();
+  zwto_debug("main returned %d", rc);
+
+  get_psw(&psw);
+  if (psw.ba)
+    zwto_debug("main ba mode");
+  if (psw.ea)
+    zwto_debug("main ea mode");
+  // int mode_switch = psw.p ? 0 : 1;
+
+  // ZSETJMP_ENV zenv = {0};
+
+  // int rc = zsetjmp(&zenv);
+  // if (rc == 0)
+  // {
+  //   zwto_debug("zsetjmp returned 0");
+  //   test(&zenv);
+  //   // ZLONGJMP(&zenv);
+  // }
+  // else
+  // {
+  //   zwto_debug("zsetjmp returned %d", rc);
+  // }
+
+  return 0;
+}

--- a/native/c/examples/rcvy/makefile
+++ b/native/c/examples/rcvy/makefile
@@ -1,0 +1,127 @@
+#
+#  This program and the accompanying materials are
+#  made available under the terms of the Eclipse Public License v2.0
+#  which accompanies this distribution, and is available at
+#  https://www.eclipse.org/legal/epl-v20.html
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Copyright Contributors to the Zowe Project.
+#
+
+OUT_DIR=build-out
+OUT_DIRS=$(OUT_DIR_CXXLANG)
+
+XLC_FLAGS=_CC_ACCEPTABLE_RC=0 _C89_ACCEPTABLE_RC=0 _CXX_ACCEPTABLE_RC=0
+CXX=$(XLC_FLAGS) xlc++
+CC=$(XLC_FLAGS) xlc
+ASM=as
+BIND=ld
+
+MTL_OPTS=metal,\
+ langlvl(extended),\
+ sscom,\
+ nolongname,\
+ inline,\
+ genasm,\
+ inlrpt,\
+ csect,\
+ nose,\
+ list,\
+ warn64,\
+ optimize(2),\
+ aggregate
+
+MTL_OPTS64=$(MTL_OPTS),lp64
+MTL_FLAGS=-S -W "c,$(MTL_OPTS)"
+MTL_FLAGS64=-S -W "c,$(MTL_OPTS64)"
+
+MACLIBS= -I../../../asmmac \
+ -ISYS1.MACLIB \
+ -ISYS1.MODGEN \
+ -ICBC.SCCNSAM
+
+MTL_HEADERS=-I/usr/include/metal \
+ -I../../chdsect \
+ -I../../../c
+
+CPP_BND_FLAGS=-W "l,lp64,xplink,map,list"
+
+CPP_BND_FLAGS_AUTH=-W "l,lp64,xplink,map,list,ac=1"
+
+C_FLAGS=-W "c,lp64,langlvl(extended),xplink,exportall"\
+ -c \
+ -I../../chdsect \
+ -I../../../c
+
+DLL_CPP_FLAGS=-W "c,lp64,langlvl(extended0x),dll,xplink,exportall"\
+ -c \
+ -I./chdsect
+
+DLL_BND_FLAGS=-W "l,lp64,dll,dynam=dll,xplink,map,list"
+
+CPP_FLAGS=-W "c,lp64,langlvl(extended0x),dll,xplink"\
+ -c \
+ -I../../chdsect \
+ -I../../../c
+
+ASM_FLAGS=-mRENT
+
+# make -DBuildType=DEBUG
+.IF $(BuildType) == DEBUG
+# -g generates debugging information
+DEBUGGER_FLAGS=-qSOURCE -g9
+OTHER_C_FLAGS=-qSHOWINC -qSHOWMACROS
+
+CPP_BND_FLAGS+=$(DEBUGGER_FLAGS)
+CPP_BND_FLAGS_AUTH+=$(DEBUGGER_FLAGS)
+C_FLAGS+=$(DEBUGGER_FLAGS)
+DLL_BND_FLAGS+=$(DEBUGGER_FLAGS)
+DLL_CPP_FLAGS+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+CPP_FLAGS+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+MTL_FLAGS+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+MTL_FLAGS64+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+ASM_FLAGS+=--verbose
+
+.ELSE
+C_FLAGS+=-g0
+CPP_FLAGS+=-g0
+CPP_BND_FLAGS+=-g0
+CPP_BND_FLAGS_AUTH+=-g0
+DLL_BND_FLAGS+=-g0
+DLL_CPP_FLAGS+=-g0
+ASM_FLAGS+=--noverbose
+
+# Still investigating why we need `-g1` for the MetalC flags :'(
+MTL_FLAGS+=-g1
+MTL_FLAGS64+=-g1
+.END
+
+all: build-out build-out/testrcvy
+
+testrcvy: build-out/testrcvy
+
+build-out:
+	@echo 'Creating build-out'
+	mkdir -p build-out
+
+build-out/testrcvy.s: testrcvy.c
+	@echo 'Building build-out/testrcvy.s'
+	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^
+
+build-out/testrcvy.o: build-out/testrcvy.s
+	@echo 'Building build-out/testrcvy.s'
+	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+
+build-out/testrcvy: build-out/testrcvy.o
+	$(BIND) $(BIND_FLAGS_64) -V -eMAIN -o $@ $^ > $*.bind.lst
+
+clean:
+	rm -f *.o
+	rm -f *.dbg
+	rm -f *.so
+	rm -f *.a
+	rm -f *.x
+	rm -f *.lst
+	rm -f CEEDUMP.*
+	rm -rf build-out

--- a/native/c/examples/rcvy/testrcvy.c
+++ b/native/c/examples/rcvy/testrcvy.c
@@ -29,12 +29,13 @@ void PERCEXIT(void *perc_exit_data)
   zwto_debug("@TEST called to percolate");
 }
 
-#pragma prolog(SOMEFUNC, " ZWEPROLG NEWDSA=(YES,128) ")
+#pragma prolog(SOMEFUNC, " ZWEPROLG NEWDSA=(YES,8),SAVE=BAKR ")
 #pragma epilog(SOMEFUNC, " ZWEEPILG ")
-int SOMEFUNC()
+void SOMEFUNC(void *parameter) ATTRIBUTE(amode31);
+void SOMEFUNC(void *parameter)
 {
   zwto_debug("@TEST called some func");
-  return 0;
+  // return 0;
 }
 
 int main()
@@ -43,13 +44,13 @@ int main()
   zenv.abexit = ABEXIT;
   zenv.perc_exit = PERCEXIT;
 
-  int val = SOMEFUNC();
+  // int val = SOMEFUNC();
 
   zwto_debug("@TEST main");
 
-  ECB e1 = {0};
-  ecb_post(&e1);
-  ecb_wait(&e1);
+  // ECB e1 = {0};
+  // ecb_post(&e1);
+  // ecb_wait(&e1);
 
   // timer(1 * 100, SOMEFUNC, NULL);
 
@@ -61,7 +62,7 @@ int main()
 
   zwto_debug("@TEST waiting for 3 seconds");
   time_wait(1 * 100 * 3);
-  // cancel_timers();
+  cancel_timers();
   zwto_debug("@TEST waiting complete");
 
   if (0 == enable_recovery(&zenv))

--- a/native/c/examples/rcvy/testrcvy.c
+++ b/native/c/examples/rcvy/testrcvy.c
@@ -29,12 +29,19 @@ void PERCEXIT(void *perc_exit_data)
   zwto_debug("@TEST called to percolate");
 }
 
-#pragma prolog(SOMEFUNC, " ZWEPROLG NEWDSA=(YES,8),SAVE=BAKR ")
+#pragma prolog(SOMEFUNC, " ZWEPROLG NEWDSA=(YES,8),SAVE=BAKR,SAM64=YES")
 #pragma epilog(SOMEFUNC, " ZWEEPILG ")
-void SOMEFUNC(void *parameter) ATTRIBUTE(amode31);
+// void SOMEFUNC(void *parameter);
 void SOMEFUNC(void *parameter)
 {
   zwto_debug("@TEST called some func");
+
+  // PSW psw = {0};
+  // get_psw(&psw);
+  // if (psw.ba)
+  //   zwto_debug("@TEST1 ba mode");
+  // if (psw.ea)
+  //   zwto_debug("@TEST1 ea mode");
   // return 0;
 }
 
@@ -43,6 +50,13 @@ int main()
   ZRCVY_ENV zenv = {0};
   zenv.abexit = ABEXIT;
   zenv.perc_exit = PERCEXIT;
+
+  // PSW psw = {0};
+  // get_psw(&psw);
+  // if (psw.ba)
+  //   zwto_debug("@TEST ba mode");
+  // if (psw.ea)
+  //   zwto_debug("@TEST ea mode");
 
   // int val = SOMEFUNC();
 
@@ -58,12 +72,19 @@ int main()
   // time_wait(1 * 100 * 3);
   // zwto_debug("@TEST waiting complete");
 
-  timer(1 * 100, SOMEFUNC, NULL);
+  // timer(1 * 100, SOMEFUNC, NULL);
 
-  zwto_debug("@TEST waiting for 3 seconds");
-  time_wait(1 * 100 * 3);
-  cancel_timers();
-  zwto_debug("@TEST waiting complete");
+  // zwto_debug("@TEST waiting for 5 seconds");
+  // time_wait(1 * 100 * 5);
+
+  // get_psw(&psw);
+  // if (psw.ba)
+  //   zwto_debug("@TEST2 ba mode");
+  // if (psw.ea)
+  //   zwto_debug("@TEST2 ea mode");
+
+  // cancel_timers();
+  // zwto_debug("@TEST waiting complete");
 
   if (0 == enable_recovery(&zenv))
   {

--- a/native/c/examples/rcvy/testrcvy.c
+++ b/native/c/examples/rcvy/testrcvy.c
@@ -29,67 +29,18 @@ void PERCEXIT(void *perc_exit_data)
   zwto_debug("@TEST called to percolate");
 }
 
-#pragma prolog(SOMEFUNC, " ZWEPROLG NEWDSA=(YES,8),SAVE=BAKR,SAM64=YES")
-#pragma epilog(SOMEFUNC, " ZWEEPILG ")
-// void SOMEFUNC(void *parameter);
-void SOMEFUNC(void *parameter)
-{
-  zwto_debug("@TEST called some func");
-
-  // PSW psw = {0};
-  // get_psw(&psw);
-  // if (psw.ba)
-  //   zwto_debug("@TEST1 ba mode");
-  // if (psw.ea)
-  //   zwto_debug("@TEST1 ea mode");
-  // return 0;
-}
-
 int main()
 {
   ZRCVY_ENV zenv = {0};
   zenv.abexit = ABEXIT;
   zenv.perc_exit = PERCEXIT;
 
-  // PSW psw = {0};
-  // get_psw(&psw);
-  // if (psw.ba)
-  //   zwto_debug("@TEST ba mode");
-  // if (psw.ea)
-  //   zwto_debug("@TEST ea mode");
-
-  // int val = SOMEFUNC();
-
   zwto_debug("@TEST main");
-
-  // ECB e1 = {0};
-  // ecb_post(&e1);
-  // ecb_wait(&e1);
-
-  // timer(1 * 100, SOMEFUNC, NULL);
-
-  // zwto_debug("@TEST waiting for 3 seconds");
-  // time_wait(1 * 100 * 3);
-  // zwto_debug("@TEST waiting complete");
-
-  // timer(1 * 100, SOMEFUNC, NULL);
-
-  // zwto_debug("@TEST waiting for 5 seconds");
-  // time_wait(1 * 100 * 5);
-
-  // get_psw(&psw);
-  // if (psw.ba)
-  //   zwto_debug("@TEST2 ba mode");
-  // if (psw.ea)
-  //   zwto_debug("@TEST2 ea mode");
-
-  // cancel_timers();
-  // zwto_debug("@TEST waiting complete");
 
   if (0 == enable_recovery(&zenv))
   {
     zwto_debug("@TEST in if");
-    // s0c3_abend(2);
+    s0c3_abend(2);
   }
   else
   {

--- a/native/c/examples/timer/makefile
+++ b/native/c/examples/timer/makefile
@@ -1,0 +1,127 @@
+#
+#  This program and the accompanying materials are
+#  made available under the terms of the Eclipse Public License v2.0
+#  which accompanies this distribution, and is available at
+#  https://www.eclipse.org/legal/epl-v20.html
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Copyright Contributors to the Zowe Project.
+#
+
+OUT_DIR=build-out
+OUT_DIRS=$(OUT_DIR_CXXLANG)
+
+XLC_FLAGS=_CC_ACCEPTABLE_RC=0 _C89_ACCEPTABLE_RC=0 _CXX_ACCEPTABLE_RC=0
+CXX=$(XLC_FLAGS) xlc++
+CC=$(XLC_FLAGS) xlc
+ASM=as
+BIND=ld
+
+MTL_OPTS=metal,\
+ langlvl(extended),\
+ sscom,\
+ nolongname,\
+ inline,\
+ genasm,\
+ inlrpt,\
+ csect,\
+ nose,\
+ list,\
+ warn64,\
+ optimize(2),\
+ aggregate
+
+MTL_OPTS64=$(MTL_OPTS),lp64
+MTL_FLAGS=-S -W "c,$(MTL_OPTS)"
+MTL_FLAGS64=-S -W "c,$(MTL_OPTS64)"
+
+MACLIBS= -I../../../asmmac \
+ -ISYS1.MACLIB \
+ -ISYS1.MODGEN \
+ -ICBC.SCCNSAM
+
+MTL_HEADERS=-I/usr/include/metal \
+ -I../../chdsect \
+ -I../../../c
+
+CPP_BND_FLAGS=-W "l,lp64,xplink,map,list"
+
+CPP_BND_FLAGS_AUTH=-W "l,lp64,xplink,map,list,ac=1"
+
+C_FLAGS=-W "c,lp64,langlvl(extended),xplink,exportall"\
+ -c \
+ -I../../chdsect \
+ -I../../../c
+
+DLL_CPP_FLAGS=-W "c,lp64,langlvl(extended0x),dll,xplink,exportall"\
+ -c \
+ -I./chdsect
+
+DLL_BND_FLAGS=-W "l,lp64,dll,dynam=dll,xplink,map,list"
+
+CPP_FLAGS=-W "c,lp64,langlvl(extended0x),dll,xplink"\
+ -c \
+ -I../../chdsect \
+ -I../../../c
+
+ASM_FLAGS=-mRENT
+
+# make -DBuildType=DEBUG
+.IF $(BuildType) == DEBUG
+# -g generates debugging information
+DEBUGGER_FLAGS=-qSOURCE -g9
+OTHER_C_FLAGS=-qSHOWINC -qSHOWMACROS
+
+CPP_BND_FLAGS+=$(DEBUGGER_FLAGS)
+CPP_BND_FLAGS_AUTH+=$(DEBUGGER_FLAGS)
+C_FLAGS+=$(DEBUGGER_FLAGS)
+DLL_BND_FLAGS+=$(DEBUGGER_FLAGS)
+DLL_CPP_FLAGS+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+CPP_FLAGS+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+MTL_FLAGS+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+MTL_FLAGS64+=$(DEBUGGER_FLAGS) $(OTHER_C_FLAGS)
+ASM_FLAGS+=--verbose
+
+.ELSE
+C_FLAGS+=-g0
+CPP_FLAGS+=-g0
+CPP_BND_FLAGS+=-g0
+CPP_BND_FLAGS_AUTH+=-g0
+DLL_BND_FLAGS+=-g0
+DLL_CPP_FLAGS+=-g0
+ASM_FLAGS+=--noverbose
+
+# Still investigating why we need `-g1` for the MetalC flags :'(
+MTL_FLAGS+=-g1
+MTL_FLAGS64+=-g1
+.END
+
+all: build-out build-out/testtime
+
+testtime: build-out/testtime
+
+build-out:
+	@echo 'Creating build-out'
+	mkdir -p build-out
+
+build-out/testtime.s: testtime.c
+	@echo 'Building build-out/testtime.s'
+	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^
+
+build-out/testtime.o: build-out/testtime.s
+	@echo 'Building build-out/testtime.s'
+	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+
+build-out/testtime: build-out/testtime.o
+	$(BIND) $(BIND_FLAGS_64) -V -eMAIN -o $@ $^ > $*.bind.lst
+
+clean:
+	rm -f *.o
+	rm -f *.dbg
+	rm -f *.so
+	rm -f *.a
+	rm -f *.x
+	rm -f *.lst
+	rm -f CEEDUMP.*
+	rm -rf build-out

--- a/native/c/examples/timer/testtime.c
+++ b/native/c/examples/timer/testtime.c
@@ -1,0 +1,52 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+#include "ihasdwa.h"
+#include "zmetal.h"
+#include "zrecovery.h"
+#include "zwto.h"
+#include "zecb.h"
+
+#pragma prolog(SOMEFUNC, " ZWEPROLG NEWDSA=(YES,8),SAVE=BAKR,SAM64=YES")
+#pragma epilog(SOMEFUNC, " ZWEEPILG ")
+void SOMEFUNC(void *PTR32 parameter)
+{
+  zwto_debug("@TEST called some func");
+}
+
+int main()
+{
+
+  PSW psw = {0};
+  get_psw(&psw);
+  if (psw.ba)
+    zwto_debug("@TEST ba mode");
+  if (psw.ea)
+    zwto_debug("@TEST ea mode");
+
+  zwto_debug("@TEST main");
+
+  // ECB e1 = {0};
+  // ecb_post(&e1);
+  // ecb_wait(&e1);
+
+  timer(1 * 100, SOMEFUNC, NULL);
+
+  zwto_debug("@TEST waiting for 3 seconds");
+  time_wait(1 * 100 * 3);
+  zwto_debug("@TEST waiting complete");
+
+  cancel_timers();
+
+  zwto_debug("@TEST exiting");
+
+  return 0;
+}

--- a/native/c/zecb.h
+++ b/native/c/zecb.h
@@ -225,9 +225,9 @@ static void time_wait(unsigned int interval)
   return;
 }
 
-typedef void (*zcli_stimer)(void *);
+typedef void (*PTR32 zcli_stimer)(void *PTR32);
 // NOTE(Kelosky): seems unworkable in LE, should use LE timer equivalent
-static void timer(unsigned int time, zcli_stimer *PTR32 cb, void *parameter)
+static void timer(unsigned int time, zcli_stimer cb, void *parameter)
 {
   int id = 0;                        // TODO(Kelosky): return & allow cancel by
   STIMERM_MODEL(dsa_stimerm_model);  // stack var

--- a/native/c/zecb.h
+++ b/native/c/zecb.h
@@ -227,7 +227,7 @@ static void time_wait(unsigned int interval)
 
 typedef void (*zcli_stimer)(void *);
 // NOTE(Kelosky): seems unworkable in LE, should use LE timer equivalent
-static void timer(unsigned int time, zcli_stimer cb, void *parameter)
+static void timer(unsigned int time, zcli_stimer *PTR32 cb, void *parameter)
 {
   int id = 0;                        // TODO(Kelosky): return & allow cancel by
   STIMERM_MODEL(dsa_stimerm_model);  // stack var

--- a/native/c/zmetal.h
+++ b/native/c/zmetal.h
@@ -241,12 +241,26 @@ static void mode_nzero()
 #endif
 
 #if defined(__IBM_METAL__)
+#define GET_ENTRY_REG64(reg, offset)                           \
+  __asm(                                                       \
+      "*                                                   \n" \
+      " LG     1," #offset "(,13)   Offset to reg          \n" \
+      " STG    1,%0                 Save reg               \n" \
+      "*                                                    "  \
+      : "=m"(reg)                                              \
+      :                                                        \
+      : "r1");
+#else
+#define GET_ENTRY_REG64(reg, offset)
+#endif
+
+#if defined(__IBM_METAL__)
 #define GET_PREV_REG64(reg, offset)                            \
   __asm(                                                       \
       "*                                                   \n" \
-      " LG     1,128(,13)                                  \n" \
-      " LG     1," #offset "(,1)                           \n" \
-      " STG    1,%0                                        \n" \
+      " LG     1,128(,13)           -> Prev SA             \n" \
+      " LG     1," #offset "(,1)    Offset to reg          \n" \
+      " STG    1,%0                 Save reg               \n" \
       "*                                                    "  \
       : "=m"(reg)                                              \
       :                                                        \
@@ -259,8 +273,8 @@ static void mode_nzero()
 #define SET_PREV_REG64(reg, offset)                            \
   __asm(                                                       \
       "*                                                   \n" \
-      " LG     1,128(,13)                                  \n" \
-      " STG    1," #offset "(,1)                           \n" \
+      " LG     1,128(,13)           -> Prev SA             \n" \
+      " STG    1," #offset "(,1)    Offset to reg          \n" \
       "*                                                    "  \
       :                                                        \
       : "m"(reg)                                               \
@@ -273,8 +287,8 @@ static void mode_nzero()
 #define GET_KEY(key)                                 \
   __asm(                                             \
       "*                                         \n" \
-      " IPK (2)                                  \n" \
-      " STC  2,%0  Save                          \n" \
+      " IPK (2)    Get key from PSW              \n" \
+      " STC  2,%0  Save key                      \n" \
       "*                                          "  \
       : "=m"(key)                                    \
       :                                              \
@@ -287,8 +301,8 @@ static void mode_nzero()
 #define SET_KEY(key)                                 \
   __asm(                                             \
       "*                                         \n" \
-      " IC   2,%0                                \n" \
-      " SPKA 0(2)                                \n" \
+      " IC   2,%0         Get key value          \n" \
+      " SPKA 0(2)         Set key in PSW         \n" \
       "*                                          "  \
       :                                              \
       : "m"(key)                                     \
@@ -298,14 +312,14 @@ static void mode_nzero()
 #endif
 
 #if defined(__IBM_METAL__)
-#define GET_PSW(psw)                              \
-  __asm(                                          \
-      "*                                    \n"   \
-      " EPSW 0,1   Create stack entry       \n"   \
-      " STM 0,1,%0   Create stack entry       \n" \
-      "*                                      "   \
-      : "=m"(psw)                                 \
-      :                                           \
+#define GET_PSW(psw)                             \
+  __asm(                                         \
+      "*                                     \n" \
+      " EPSW 0,1    Create stack entry       \n" \
+      " STM 0,1,%0  Create stack entry       \n" \
+      "*                                      "  \
+      : "=m"(psw)                                \
+      :                                          \
       : "r0", "r1");
 #else
 #define GET_PSW(psw)

--- a/native/c/zrecovery.h
+++ b/native/c/zrecovery.h
@@ -17,6 +17,7 @@
 #include "zmetal.h"
 #include "ihasdwa.h"
 #include "ihasaver.h"
+#include "zsetjmp.h"
 
 typedef struct sdwa SDWA;
 typedef struct savf4sa SAVF4SA;
@@ -44,25 +45,6 @@ typedef struct sdwarc4 SDWARC4;
       : "r0", "r1", "r14", "r15");
 #else
 #define IEAARR(routine, parm, arr, arr_parm)
-#endif
-
-#if defined(__IBM_METAL__)
-#define JUMP_ENV(f4sa, r13, rc)                                   \
-  __asm(                                                          \
-      "*                                                      \n" \
-      " LA   15,%0            -> F4SA                         \n" \
-      " LG   13,%1            = prev R13                      \n" \
-      " LMG  14,14,8(15)      Restore R14                     \n" \
-      " LMG  0,12,24(15)      Restore R0-R12                  \n" \
-      " LGHI 15," #rc "       Set RC                          \n" \
-      " BR   14               Branch and never return         \n" \
-      "*                                                        " \
-      :                                                           \
-      : "m"(f4sa),                                                \
-        "m"(r13)                                                  \
-      :);
-#else
-#define JUMP_ENV(f4sa, r13, rc)
 #endif
 
 #if defined(__IBM_METAL__)

--- a/native/c/zsetjmp.h
+++ b/native/c/zsetjmp.h
@@ -1,0 +1,80 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+#ifndef ZSETJMP_H
+#define ZSETJMP_H
+#include <stdio.h>
+#include <string.h>
+#include "zwto.h"
+#include "zmetal.h"
+#include "ihasaver.h"
+
+typedef struct savf4sa SAVF4SA;
+
+#if defined(__IBM_METAL__)
+#define JUMP_ENV(f4sa, r13, rc)                                   \
+  __asm(                                                          \
+      "*                                                      \n" \
+      " LA   15,%0            -> F4SA                         \n" \
+      " LG   13,%1            = prev R13                      \n" \
+      " LMG  14,14,8(15)      Restore R14                     \n" \
+      " LMG  0,12,24(15)      Restore R0-R12                  \n" \
+      " LGHI 15," #rc "       Set RC                          \n" \
+      " BR   14               Branch and never return         \n" \
+      "*                                                        " \
+      :                                                           \
+      : "m"(f4sa),                                                \
+        "m"(r13)                                                  \
+      :);
+#else
+#define JUMP_ENV(f4sa, r13, rc)
+#endif
+
+typedef struct
+{
+  // NOTE(Kelosky): we can also dervive R13 using f4sa->saveprev->savenext so that we probably don't need to store R13
+  unsigned long long int r13;
+
+  // main line stack regs and pointer (r13)
+  SAVF4SA f4sa;
+
+} ZSETJMP_ENV;
+
+typedef void (*ROUTINE)(ZSETJMP_ENV *);
+
+#pragma prolog(ZLONGJMP, " ZWEPROLG NEWDSA=NO ")
+#pragma epilog(ZLONGJMP, " ZWEEPILG ")
+static void ZLONGJMP(ZSETJMP_ENV *zenv)
+{
+  JUMP_ENV(zenv->f4sa, zenv->r13, 4); // TODO(Kelosky): document non-zero return code
+}
+
+static void zlongjmp(ZSETJMP_ENV *zenv)
+{
+  ZLONGJMP(zenv);
+}
+
+// NOTE(Kelosky): this function may "return twice" like setjmp()
+// NOTE(Kelosky): we must not have this function inline so to save and return to the mainline
+#pragma reachable(zsetjmp)
+static int zsetjmp(ZSETJMP_ENV *zenv) ATTRIBUTE(noinline);
+static int zsetjmp(ZSETJMP_ENV *zenv)
+{
+  unsigned long long int r13 = get_prev_r13();
+  unsigned char *save_area = (unsigned char *)r13;
+
+  memcpy(&zenv->f4sa, save_area, sizeof(SAVF4SA));
+  zenv->r13 = r13;
+
+  return 0; // NOTE(Kelosky): this never runs
+}
+
+#endif

--- a/native/c/zsetjmp.h
+++ b/native/c/zsetjmp.h
@@ -66,7 +66,8 @@ static void zlongjmp(ZSETJMP_ENV *zenv)
 static int zsetjmp(ZSETJMP_ENV *zenv) ATTRIBUTE(noinline);
 static int zsetjmp(ZSETJMP_ENV *zenv)
 {
-  unsigned long long int r13 = get_prev_r13();
+  unsigned long long int r13 = 0;
+  GET_STACK_ENV(r13); // NOTE(Kelosky): this is the same as get_prev_r13() but will be inlined
   unsigned char *save_area = (unsigned char *)r13;
 
   memcpy(&zenv->f4sa, save_area, sizeof(SAVF4SA));

--- a/native/c/zsetjmp.h
+++ b/native/c/zsetjmp.h
@@ -48,8 +48,6 @@ typedef struct
 
 } ZSETJMP_ENV;
 
-typedef void (*ROUTINE)(ZSETJMP_ENV *);
-
 #pragma prolog(ZLONGJMP, " ZWEPROLG NEWDSA=NO ")
 #pragma epilog(ZLONGJMP, " ZWEEPILG ")
 static void ZLONGJMP(ZSETJMP_ENV *zenv)
@@ -74,7 +72,7 @@ static int zsetjmp(ZSETJMP_ENV *zenv)
   memcpy(&zenv->f4sa, save_area, sizeof(SAVF4SA));
   zenv->r13 = r13;
 
-  return 0; // NOTE(Kelosky): this never runs
+  return 0;
 }
 
 #endif


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Currently, z/OS console interface unconditionally `WAIT` on an ECB that may never get `POST`ed.  When attempting to use our `STIMER` wrapper, we discovered a bug where the timer exit would get a S0C4-4.  To fix this, we needed to update `ZWEPROLG` and `ZWEEPILG` to handle an inadequate save area.  These macros now support entry/exit via `BAKR`/`PR` respectively.  

Secondly, in more thorough testing, we realized that the recovery routines incorrectly handle execution when `optimize(0)` was in effect.  

Lastly, we consolidated some of the `zrecovery.h` logic to implement a `zsetjmp` and `zlongjmp` behavior (apart from a recovery environment) for future use.  

In a future PR, we'll add the timer utility for use in console code. 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
