### PR TITLE
fix(uss): Prioritize user-specified encoding over file tag when reading/writing USS files

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Recent Changes
 
 - `native`: Added `contentLen` property to RPC responses for reading/writing data sets and USS files. [#358](https://github.com/zowe/zowe-native-proto/pull/358)
+- `native`: Fixed file tag being prioritized over user-specified codepage when reading/writing USS files. [#467](https://github.com/zowe/zowe-native-proto/pull/467)
 
 ## `0.1.4`
 

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -1073,17 +1073,20 @@ int zusf_read_from_uss_file(ZUSF *zusf, const string &file, string &response)
 
   if (zusf->encoding_opts.data_type == eDataTypeText)
   {
-    // Try to get the file's CCSID first
-    int file_ccsid = zusf_get_file_ccsid(zusf, file);
-    if (file_ccsid > 0 && file_ccsid != 65535) // Valid CCSID and not binary
-    {
-      encoding_to_use = zut_int_to_string(file_ccsid);
-      has_encoding = true;
-    }
-    else if (strlen(zusf->encoding_opts.codepage) > 0)
+    if (strlen(zusf->encoding_opts.codepage) > 0)
     {
       encoding_to_use = string(zusf->encoding_opts.codepage);
       has_encoding = true;
+    }
+    else
+    {
+      // Use tagged encoding if valid CCSID and not UTF-8 or binary
+      int file_ccsid = zusf_get_file_ccsid(zusf, file);
+      if (file_ccsid > 0 && file_ccsid != 1208 && file_ccsid != 65535)
+      {
+        encoding_to_use = zut_int_to_string(file_ccsid);
+        has_encoding = true;
+      }
     }
   }
 
@@ -1147,17 +1150,20 @@ int zusf_read_from_uss_file_streamed(ZUSF *zusf, const string &file, const strin
 
   if (zusf->encoding_opts.data_type == eDataTypeText)
   {
-    // Try to get the file's CCSID first
-    int file_ccsid = zusf_get_file_ccsid(zusf, file);
-    if (file_ccsid > 0 && file_ccsid != 65535) // Valid CCSID, not binary
-    {
-      encoding_to_use = zut_int_to_string(file_ccsid);
-      has_encoding = true;
-    }
-    else if (strlen(zusf->encoding_opts.codepage) > 0)
+    if (strlen(zusf->encoding_opts.codepage) > 0)
     {
       encoding_to_use = string(zusf->encoding_opts.codepage);
       has_encoding = true;
+    }
+    else
+    {
+      // Use tagged encoding if valid CCSID and not UTF-8 or binary
+      int file_ccsid = zusf_get_file_ccsid(zusf, file);
+      if (file_ccsid > 0 && file_ccsid != 1208 && file_ccsid != 65535)
+      {
+        encoding_to_use = zut_int_to_string(file_ccsid);
+        has_encoding = true;
+      }
     }
   }
 
@@ -1238,17 +1244,20 @@ int zusf_write_to_uss_file(ZUSF *zusf, const string &file, string &data)
 
   if (zusf->encoding_opts.data_type == eDataTypeText)
   {
-    // Try to get the file's CCSID first
-    int file_ccsid = zusf_get_file_ccsid(zusf, file);
-    if (file_ccsid > 0 && file_ccsid != 65535) // Valid CCSID and not binary
-    {
-      encoding_to_use = zut_int_to_string(file_ccsid);
-      has_encoding = true;
-    }
-    else if (strlen(zusf->encoding_opts.codepage) > 0)
+    if (strlen(zusf->encoding_opts.codepage) > 0)
     {
       encoding_to_use = string(zusf->encoding_opts.codepage);
       has_encoding = true;
+    }
+    else
+    {
+      // Use tagged encoding if valid CCSID and not UTF-8 or binary
+      int file_ccsid = zusf_get_file_ccsid(zusf, file);
+      if (file_ccsid > 0 && file_ccsid != 1208 && file_ccsid != 65535)
+      {
+        encoding_to_use = zut_int_to_string(file_ccsid);
+        has_encoding = true;
+      }
     }
   }
 
@@ -1326,17 +1335,20 @@ int zusf_write_to_uss_file_streamed(ZUSF *zusf, const string &file, const string
 
   if (zusf->encoding_opts.data_type == eDataTypeText)
   {
-    // Try to get the file's CCSID first
-    int file_ccsid = zusf_get_file_ccsid(zusf, file);
-    if (file_ccsid > 0 && file_ccsid != 65535) // Valid CCSID and not binary
-    {
-      encoding_to_use = zut_int_to_string(file_ccsid);
-      has_encoding = true;
-    }
-    else if (strlen(zusf->encoding_opts.codepage) > 0)
+    if (strlen(zusf->encoding_opts.codepage) > 0)
     {
       encoding_to_use = string(zusf->encoding_opts.codepage);
       has_encoding = true;
+    }
+    else
+    {
+      // Use tagged encoding if valid CCSID and not UTF-8 or binary
+      int file_ccsid = zusf_get_file_ccsid(zusf, file);
+      if (file_ccsid > 0 && file_ccsid != 1208 && file_ccsid != 65535)
+      {
+        encoding_to_use = zut_int_to_string(file_ccsid);
+        has_encoding = true;
+      }
     }
   }
 

--- a/packages/cli/src/download/uss-file/UssFile.handler.ts
+++ b/packages/cli/src/download/uss-file/UssFile.handler.ts
@@ -23,28 +23,6 @@ export default class DownloadUssFileHandler extends SshBaseHandler {
             params.arguments.file ?? path.join(params.arguments.directory ?? process.cwd(), baseName);
         IO.createDirsSyncFromFilePath(localFilePath);
 
-        let encoding = params.arguments.encoding;
-        const binary = params.arguments.binary;
-        if (encoding == null && binary == null) {
-            try {
-                const fileResp = await client.uss.listFiles({
-                    fspath: params.arguments.filePath,
-                    all: true,
-                    long: true,
-                });
-                if (fileResp.success && fileResp.items.length > 0) {
-                    const file = fileResp.items[0];
-                    encoding = file.filetag;
-                }
-            } catch (error) {
-                params.response.console.error(
-                    "Failed to auto-detect file encoding for %s: %s",
-                    params.arguments.filePath,
-                    error,
-                );
-            }
-        }
-
         params.response.console.log(
             "Downloading USS file '%s' to local file '%s'",
             params.arguments.filePath,
@@ -53,7 +31,7 @@ export default class DownloadUssFileHandler extends SshBaseHandler {
         const response = await client.uss.readFile({
             stream: fs.createWriteStream(localFilePath),
             fspath: params.arguments.filePath,
-            encoding: binary ? "binary" : encoding,
+            encoding: params.arguments.binary ? "binary" : params.arguments.encoding,
         });
 
         params.response.data.setMessage("Successfully downloaded content to %s", localFilePath);

--- a/packages/cli/src/upload/file-to-uss/FileToUss.handler.ts
+++ b/packages/cli/src/upload/file-to-uss/FileToUss.handler.ts
@@ -16,28 +16,10 @@ import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class UploadFileToUssFileHandler extends SshBaseHandler {
     public async processWithClient(params: IHandlerParameters, client: ZSshClient): Promise<uss.WriteFileResponse> {
-        let encoding = params.arguments.encoding;
-        const binary = params.arguments.binary;
-        if (encoding == null && binary == null) {
-            try {
-                const fileResp = await client.uss.listFiles({
-                    fspath: params.arguments.ussFile,
-                    all: true,
-                    long: true,
-                });
-                if (fileResp.success && fileResp.items.length > 0) {
-                    const file = fileResp.items[0];
-                    encoding = file.filetag;
-                }
-            } catch (error) {
-                // Ignore as the file may not exist yet
-            }
-        }
-
         const response = await client.uss.writeFile({
             stream: fs.createReadStream(params.arguments.file),
             fspath: params.arguments.ussFile,
-            encoding: binary ? "binary" : encoding,
+            encoding: params.arguments.binary ? "binary" : params.arguments.encoding,
         });
         const uploadSource: string = `local file '${params.arguments.file}'`;
         const successMsg = params.response.console.log(

--- a/packages/cli/src/view/uss-file/UssFile.handler.ts
+++ b/packages/cli/src/view/uss-file/UssFile.handler.ts
@@ -15,31 +15,9 @@ import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ViewUssFileHandler extends SshBaseHandler {
     public async processWithClient(params: IHandlerParameters, client: ZSshClient): Promise<uss.ReadFileResponse> {
-        let encoding = params.arguments.encoding;
-        const binary = params.arguments.binary;
-        if (encoding == null && binary == null) {
-            try {
-                const fileResp = await client.uss.listFiles({
-                    fspath: params.arguments.filePath,
-                    all: true,
-                    long: true,
-                });
-                if (fileResp.success && fileResp.items.length > 0) {
-                    const file = fileResp.items[0];
-                    encoding = file.filetag;
-                }
-            } catch (error) {
-                params.response.console.error(
-                    "Failed to auto-detect file encoding for %s: %s",
-                    params.arguments.filePath,
-                    error,
-                );
-            }
-        }
-
         const response = await client.uss.readFile({
             fspath: params.arguments.filePath,
-            encoding: binary ? "binary" : encoding,
+            encoding: params.arguments.binary ? "binary" : params.arguments.encoding,
         });
         const content = B64String.decode(response.data);
         params.response.data.setMessage(


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes regression from #421 that caused hanging when testing `zowe zssh uss download` command in #358.

For files tagged as UTF-8 (ccsid 1208), we were attempting to convert UTF-8 -> UTF-8 which does not behave well.

Also fixes the order of precedence for codepage checks to match z/OSMF.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Verify that the CLI commands for uploading/downloading USS files respect codepage if specified as an argument.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
