### PR TITLE
fix: Refactor base64 encoding to handle leftover bytes correctly

### DIFF
--- a/native/c/zbase64.h
+++ b/native/c/zbase64.h
@@ -97,20 +97,10 @@ static const unsigned char *get_ebcdic_decode_table()
   return table;
 }
 
-// Fast inline function to calculate encoded size with optional padding
-inline size_t encoded_size(size_t input_size, bool with_padding = true)
+// Fast inline function to calculate encoded size
+inline size_t encoded_size(size_t input_size)
 {
-  if (with_padding)
-  {
-    return ((input_size + 2) / 3) * 4;
-  }
-  else
-  {
-    // Without padding, calculate exact size needed
-    const size_t full_blocks = input_size / 3;
-    const size_t remaining = input_size % 3;
-    return (full_blocks * 4) + (remaining > 0 ? remaining + 1 : 0);
-  }
+  return ((input_size + 2) / 3) * 4;
 }
 
 // Fast inline function to calculate maximum decoded size
@@ -120,14 +110,14 @@ inline size_t max_decoded_size(size_t input_size)
 }
 
 // High-performance encode function (produces ASCII Base64 output)
-inline std::vector<char> encode(const char *input, size_t input_len, bool with_padding = true)
+inline std::vector<char> encode(const char *input, size_t input_len)
 {
   if (input_len == 0)
   {
     return std::vector<char>();
   }
 
-  const size_t output_len = encoded_size(input_len, with_padding);
+  const size_t output_len = encoded_size(input_len);
 
   std::vector<char> output;
   output.resize(output_len); // Pre-allocate exact size
@@ -178,25 +168,53 @@ inline std::vector<char> encode(const char *input, size_t input_len, bool with_p
 
     dst[0] = encode_table_ascii[(combined >> 18) & 0x3F];
     dst[1] = encode_table_ascii[(combined >> 12) & 0x3F];
-
-    if (with_padding)
-    {
-      dst[2] = (remaining > 1) ? encode_table_ascii[(combined >> 6) & 0x3F] : '=';
-      dst[3] = '=';
-    }
-    else if (remaining > 1)
-    {
-      dst[2] = encode_table_ascii[(combined >> 6) & 0x3F];
-    }
+    dst[2] = (remaining > 1) ? encode_table_ascii[(combined >> 6) & 0x3F] : '=';
+    dst[3] = '=';
   }
 
   return output;
 }
 
-// Convenience overload for string input
-inline std::string encode(const std::string &input, bool with_padding = true)
+inline std::vector<char> encode(const char *input, size_t input_len, std::vector<char> *left_over)
 {
-  std::vector<char> result = encode(&input[0], input.size(), with_padding);
+  char *temp_input = const_cast<char *>(input);
+  if (left_over != nullptr && left_over->size() > 0)
+  {
+    std::vector<char> combined_input;
+    combined_input.reserve(left_over->size() + input_len);
+    combined_input.insert(combined_input.end(), left_over->begin(), left_over->end());
+    combined_input.insert(combined_input.end(), input, input + input_len);
+    temp_input = &combined_input[0];
+    input_len = combined_input.size();
+    left_over->clear();
+  }
+  else if (input_len == 0)
+  {
+    return std::vector<char>();
+  }
+
+  // Calculate how many bytes are leftover
+  size_t extra_count = input_len % 3;
+  size_t total_bytes = input_len - extra_count;
+
+  // Copy leftover bytes to the left_over parameter
+  if (left_over != nullptr && extra_count > 0)
+  {
+    left_over->resize(extra_count);
+    for (size_t i = 0; i < extra_count; i++)
+    {
+      (*left_over)[i] = temp_input[total_bytes + i];
+    }
+  }
+
+  // Encode only the complete part (multiple of 3 bytes)
+  return encode(temp_input, total_bytes);
+}
+
+// Convenience overload for string input
+inline std::string encode(const std::string &input)
+{
+  std::vector<char> result = encode(&input[0], input.size());
   return std::string(result.begin(), result.end());
 }
 

--- a/native/c/zbase64.h
+++ b/native/c/zbase64.h
@@ -100,7 +100,7 @@ static const unsigned char *get_ebcdic_decode_table()
 // Fast inline function to calculate encoded size
 inline size_t encoded_size(size_t input_size)
 {
-  return ((input_size + 2) / 3) * 4;
+  return (input_size + 2) / 3 * 4;
 }
 
 // Fast inline function to calculate maximum decoded size
@@ -216,7 +216,7 @@ inline std::vector<char> encode(const char *input, size_t input_len, std::vector
   }
   else if (input_len == 0)
   {
-    return std::vector<char>();
+    return temp_combined;
   }
 
   // Encode only the complete part (multiple of 3 bytes)
@@ -319,7 +319,7 @@ inline std::vector<char> decode(const char *input, size_t input_len, std::vector
   }
   else if (input_len == 0)
   {
-    return std::vector<char>();
+    return temp_combined;
   }
 
   // Decode only the complete part (multiple of 4 bytes)

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -1156,10 +1156,12 @@ int zds_write_to_dsn_streamed(ZDS *zds, const string &dsn, const string &pipe, s
 
   std::vector<char> buf(FIFO_CHUNK_SIZE);
   size_t bytes_read;
+  std::vector<char> temp_encoded;
+  std::vector<char> left_over;
 
   while ((bytes_read = fread(&buf[0], 1, FIFO_CHUNK_SIZE, fin)) > 0)
   {
-    std::vector<char> temp_encoded = zbase64::decode(&buf[0], bytes_read);
+    temp_encoded = zbase64::decode(&buf[0], bytes_read, &left_over);
     const char *chunk = &temp_encoded[0];
     int chunk_len = temp_encoded.size();
     *content_len += chunk_len;
@@ -1189,6 +1191,7 @@ int zds_write_to_dsn_streamed(ZDS *zds, const string &dsn, const string &pipe, s
       fclose(fout);
       return RTNCD_FAILURE;
     }
+    temp_encoded.clear();
   }
 
   fflush(fout);

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -1069,7 +1069,7 @@ int zds_read_from_dsn_streamed(ZDS *zds, const string &dsn, const string &pipe, 
     temp_encoded.clear();
   }
 
-  if (left_over.size() > 0)
+  if (!left_over.empty())
   {
     temp_encoded = zbase64::encode(&left_over[0], left_over.size());
     fwrite(&temp_encoded[0], 1, temp_encoded.size(), fout);

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -1038,12 +1038,13 @@ int zds_read_from_dsn_streamed(ZDS *zds, const string &dsn, const string &pipe, 
   const size_t chunk_size = FIFO_CHUNK_SIZE * 3 / 4;
   std::vector<char> buf(chunk_size);
   size_t bytes_read;
+  std::vector<char> temp_encoded;
+  std::vector<char> left_over;
 
   while ((bytes_read = fread(&buf[0], 1, chunk_size, fin)) > 0)
   {
     int chunk_len = bytes_read;
     const char *chunk = &buf[0];
-    std::vector<char> temp_encoded;
 
     if (hasEncoding)
     {
@@ -1063,14 +1064,15 @@ int zds_read_from_dsn_streamed(ZDS *zds, const string &dsn, const string &pipe, 
     }
 
     *content_len += chunk_len;
-    temp_encoded = zbase64::encode(chunk, chunk_len, false);
+    temp_encoded = zbase64::encode(chunk, chunk_len, &left_over);
     fwrite(&temp_encoded[0], 1, temp_encoded.size(), fout);
+    temp_encoded.clear();
   }
 
-  const auto padding = 4 - (*content_len % 4);
-  if (padding > 0)
+  if (left_over.size() > 0)
   {
-    fwrite("===", 1, padding, fout);
+    temp_encoded = zbase64::encode(&left_over[0], left_over.size());
+    fwrite(&temp_encoded[0], 1, temp_encoded.size(), fout);
   }
 
   fflush(fout);

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -1170,12 +1170,13 @@ int zusf_read_from_uss_file_streamed(ZUSF *zusf, const string &file, const strin
   const size_t chunk_size = FIFO_CHUNK_SIZE * 3 / 4;
   std::vector<char> buf(chunk_size);
   size_t bytes_read;
+  std::vector<char> temp_encoded;
+  std::vector<char> left_over;
 
   while ((bytes_read = fread(&buf[0], 1, chunk_size, fin)) > 0)
   {
     int chunk_len = bytes_read;
     const char *chunk = &buf[0];
-    std::vector<char> temp_encoded;
 
     if (has_encoding)
     {
@@ -1193,14 +1194,15 @@ int zusf_read_from_uss_file_streamed(ZUSF *zusf, const string &file, const strin
     }
 
     *content_len += chunk_len;
-    temp_encoded = zbase64::encode(chunk, chunk_len, false);
+    temp_encoded = zbase64::encode(chunk, chunk_len, &left_over);
     fwrite(&temp_encoded[0], 1, temp_encoded.size(), fout);
+    temp_encoded.clear();
   }
 
-  const auto padding = 4 - (*content_len % 4);
-  if (padding > 0)
+  if (left_over.size() > 0)
   {
-    fwrite("===", 1, padding, fout);
+    temp_encoded = zbase64::encode(&left_over[0], left_over.size());
+    fwrite(&temp_encoded[0], 1, temp_encoded.size(), fout);
   }
 
   fflush(fout);

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -1199,7 +1199,7 @@ int zusf_read_from_uss_file_streamed(ZUSF *zusf, const string &file, const strin
     temp_encoded.clear();
   }
 
-  if (left_over.size() > 0)
+  if (!left_over.empty())
   {
     temp_encoded = zbase64::encode(&left_over[0], left_over.size());
     fwrite(&temp_encoded[0], 1, temp_encoded.size(), fout);

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -1386,10 +1386,12 @@ int zusf_write_to_uss_file_streamed(ZUSF *zusf, const string &file, const string
 
   std::vector<char> buf(FIFO_CHUNK_SIZE);
   size_t bytes_read;
+  std::vector<char> temp_encoded;
+  std::vector<char> left_over;
 
   while ((bytes_read = fread(&buf[0], 1, FIFO_CHUNK_SIZE, fin)) > 0)
   {
-    std::vector<char> temp_encoded = zbase64::decode(&buf[0], bytes_read);
+    temp_encoded = zbase64::decode(&buf[0], bytes_read, &left_over);
     const char *chunk = &temp_encoded[0];
     int chunk_len = temp_encoded.size();
     *content_len += chunk_len;
@@ -1419,6 +1421,7 @@ int zusf_write_to_uss_file_streamed(ZUSF *zusf, const string &file, const string
       fclose(fout);
       return RTNCD_FAILURE;
     }
+    temp_encoded.clear();
   }
 
   fflush(fout);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12377,9 +12377,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
+      "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
* [x] Fix content length mismatch
* [x] Fix checksum mismatch
* [x] Handle leftover bytes for decode

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
