### PR TITLE
fix: Prevent unnecessary keyring prompts when using private key

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -10,6 +10,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added support for listing all USS files with the `all` request option. When provided, the SDK includes hidden files in the list response. [#421](https://github.com/zowe/zowe-native-proto/pull/421)
 - Refactored handling of RPC notifications to be managed by a separate class `RpcNotificationManager`. [#358](https://github.com/zowe/zowe-native-proto/pull/358)
 - Added content length validation for streamed requests. [#358](https://github.com/zowe/zowe-native-proto/pull/358)
+- Removed unnecessary prompt to unlock keyring on MacOS when connecting to a new host with a private key. [#453](https://github.com/zowe/zowe-native-proto/issues/453)
 
 ## `0.1.3`
 

--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -301,7 +301,8 @@ export abstract class AbstractConfigManager {
             };
             const newConfig: IConfig = await ConfigBuilder.build(impConfig, global, opts);
             config.api.layers.merge(newConfig);
-            await config.save(false);
+            // Use api.layers.write() instead of save() to avoid keyring prompts on MacOS
+            config.api.layers.write();
         } catch {}
     }
 
@@ -576,7 +577,11 @@ export abstract class AbstractConfigManager {
             configApi.profiles.set(selectedConfig?.name!, config);
         }
 
-        await this.mProfilesCache.getTeamConfig().save();
+        if (config.secure.length > 0) {
+            await this.mProfilesCache.getTeamConfig().save();
+        } else {
+            this.mProfilesCache.getTeamConfig().api.layers.write();
+        }
     }
 
     private async getNewProfileName(


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #453

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
On MacOS, run the "Connect to Host" command and deploy to a system that uses private key.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
