### PR TITLE
Fix Link Warning

### DIFF
--- a/native/c/test/makefile
+++ b/native/c/test/makefile
@@ -106,7 +106,7 @@ ASM_FLAGS+=--noverbose
 .END
 
 
-all: clean build-out build-out/ztest_runner
+all: build-out build-out/ztest_runner
 
 
 #

--- a/native/c/zrecovery.h
+++ b/native/c/zrecovery.h
@@ -155,7 +155,7 @@ static void ZRCVYRTY(ZRCVY_ENV zenv)
 
 #pragma prolog(ZRCVYARR, " ZWEPROLG NEWDSA=(YES,128) ")
 #pragma epilog(ZRCVYARR, " ZWEEPILG ")
-int ZRCVYARR(SDWA sdwa)
+static int ZRCVYARR(SDWA sdwa)
 {
   unsigned long long int r0 = get_prev_r0(); // if r0 = 12, NO_SDWA
   unsigned long long int r2 = get_prev_r2();


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
When building tests, I introduced a link/bind-time warning for symbol `ZRCVYARR`.  This makes the function `static`.  We also remove the `clean` from the default `make` target in tests.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
