### PR TITLE
fix: Use buffered mode for opening files in VS Code editor

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the native code for "zowe-native-proto" are documented in
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- `golang`: Fixed inconsistent type of the `data` property between the `ReadDatasetResponse` and `ReadFileResponse` types. [#488](https://github.com/zowe/zowe-native-proto/pull/488)
+
 ## `0.1.6`
 
 - `native`: Fixed regression where data set download operations would fail due to a content length mismatch, due to the content length being printed as hexadecimal rather than decimal. [#482](https://github.com/zowe/zowe-native-proto/issues/482)

--- a/native/golang/cmds/ds.go
+++ b/native/golang/cmds/ds.go
@@ -104,7 +104,7 @@ func HandleReadDatasetRequest(conn *utils.StdioConn, params []byte) (result any,
 		Encoding:   request.Encoding,
 		Etag:       etag,
 		Dataset:    request.Dsname,
-		Data:       data,
+		Data:       &data,
 		ContentLen: &size,
 	}
 	return

--- a/native/golang/types/ds/responses.go
+++ b/native/golang/types/ds/responses.go
@@ -40,7 +40,7 @@ type ReadDatasetResponse struct {
 	// Dataset name
 	Dataset string `json:"dataset"`
 	// Dataset contents (omitted if streaming)
-	Data []byte `json:"data" tstype:"B64String"`
+	Data *[]byte `json:"data" tstype:"B64String"`
 	// Length of dataset contents in bytes (only used for streaming)
 	ContentLen *int `json:"contentLen,omitempty"`
 }

--- a/native/golang/types/uss/responses.go
+++ b/native/golang/types/uss/responses.go
@@ -30,7 +30,7 @@ type ReadFileResponse struct {
 	// Remote file path
 	Path string `json:"fspath"`
 	// File contents (omitted if streaming)
-	Data *[]byte `json:"data,omitempty" tstype:"B64String"`
+	Data *[]byte `json:"data" tstype:"B64String"`
 	// Length of file contents in bytes (only used for streaming)
 	ContentLen *int `json:"contentLen,omitempty"`
 }

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Client code for "zowe-native-proto-sdk" are documente
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- Fixed inconsistent type of the `data` property between the `ReadDatasetResponse` and `ReadFileResponse` types. [#488](https://github.com/zowe/zowe-native-proto/pull/488)
+
 ## `0.1.6`
 
 - Fixed a TypeError in `ZSshClient.request` that caused stream operations to fail if a callback was not provided for progress updates. [#482](https://github.com/zowe/zowe-native-proto/issues/482)

--- a/packages/sdk/src/doc/gen/uss.ts
+++ b/packages/sdk/src/doc/gen/uss.ts
@@ -175,7 +175,7 @@ export interface ReadFileResponse extends common.CommandResponse {
   /**
    * File contents (omitted if streaming)
    */
-  data?: B64String;
+  data: B64String;
   /**
    * Length of file contents in bytes (only used for streaming)
    */

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "zowe-native-proto-vsce" extension will be documented
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- Fixed regression in performance where opening data sets and USS files in the editor could be slow. [#488](https://github.com/zowe/zowe-native-proto/pull/488)
+
 ## `0.1.6`
 
 - Fixed regression where USS download operations would fail because of a missing callback function. [#482](https://github.com/zowe/zowe-native-proto/issues/482)

--- a/packages/vsce/src/api/SshMvsApi.ts
+++ b/packages/vsce/src/api/SshMvsApi.ts
@@ -73,8 +73,13 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         const response = await (await this.client).ds.readDataset({
             dsname: dataSetName,
             encoding: options.binary ? "binary" : options.encoding,
-            stream: writeStream,
+            // Pass stream if file is provided, otherwise use buffer to read into memory
+            stream: options.file ? writeStream : undefined,
         });
+        if (options.stream != null) {
+            options.stream.write(B64String.decode(response.data));
+            options.stream.end();
+        }
         return this.buildZosFilesResponse({ etag: response.etag });
     }
 

--- a/packages/vsce/src/api/SshUssApi.ts
+++ b/packages/vsce/src/api/SshUssApi.ts
@@ -48,8 +48,13 @@ export class SshUssApi extends SshCommonApi implements MainframeInteraction.IUss
         const response = await (await this.client).uss.readFile({
             fspath: ussFilePath,
             encoding: options.binary ? "binary" : options.encoding,
-            stream: writeStream,
+            // Pass stream if file is provided, otherwise use buffer to read into memory
+            stream: options.file ? writeStream : undefined,
         });
+        if (options.stream != null) {
+            options.stream.write(B64String.decode(response.data));
+            options.stream.end();
+        }
         return this.buildZosFilesResponse({ etag: response.etag });
     }
 


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run the VS Code extension and notice that opening data sets and USS files in the editor should be fast again 😋 

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
