### PR TITLE
Fix 493

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the native code for "zowe-native-proto" are documented in
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- `native`: Added default value for `--recfm` so that when no options are specified the data set will not contain errors. [#493](https://github.com/zowe/zowe-native-proto/issues/493)
+
 ## `0.1.7`
 
 - Updated CLI parser `find_kw_arg_bool` function to take in an optional boolean `check_for_negation` that, when `true`, looks for a negated option value. [#485](https://github.com/zowe/zowe-native-proto/issues/485)

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -374,6 +374,15 @@ int zds_create_dsn(ZDS *zds, std::string dsn, DS_ATTRIBUTES attributes, std::str
   return alloc_and_free(parm, dsn, &code, response);
 }
 
+int zds_create_dsn_fb(ZDS *zds, const string &dsn, string &response)
+{
+  int rc = 0;
+  unsigned int code = 0;
+  string parm = "ALLOC DA('" + dsn + "') DSORG(PO) SPACE(5,5) CYL LRECL(80) RECFM(F,B) DIR(5) NEW KEEP DSNTYPE(LIBRARY)";
+
+  return alloc_and_free(parm, dsn, &code, response);
+}
+
 int zds_create_dsn_vb(ZDS *zds, const string &dsn, string &response)
 {
   int rc = 0;

--- a/native/c/zds.hpp
+++ b/native/c/zds.hpp
@@ -58,7 +58,7 @@ typedef struct
 std::string zds_get_recfm(const fldata_t &file_info);
 
 #ifdef SWIG
-extern "C" 
+extern "C"
 {
 #endif
 /**
@@ -135,6 +135,16 @@ int zds_read_from_dd(ZDS *zds, std::string ddname, std::string &response);
  * @return int 0 for success; non zero otherwise
  */
 int zds_write_to_dd(ZDS *zds, std::string ddname, const std::string &data);
+
+/**
+ * @brief Create a data set
+ *
+ * @param zds data set returned attributes and error information
+ * @param dsn data set name to create
+ * @param response messages from dynamic allocation (which may be present even when successful requests are made)
+ * @return int 0 for success; non zero otherwise
+ */
+int zds_create_dsn_fb(ZDS *zds, const std::string &dsn, std::string &response);
 
 /**
  * @brief Create a data set

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -58,6 +58,7 @@ int handle_console_issue(const ParseResult &result);
 int handle_tso_issue(const ParseResult &result);
 
 int handle_data_set_create(const ParseResult &result);
+int handle_data_set_create_fb(const ParseResult &result);
 int handle_data_set_create_vb(const ParseResult &result);
 int handle_data_set_create_adata(const ParseResult &result);
 int handle_data_set_create_loadlib(const ParseResult &result);
@@ -186,7 +187,7 @@ int main(int argc, char *argv[])
   ds_create_cmd->add_keyword_arg("dirblk", make_aliases("--dirblk"), "Directory blocks", ArgType_Single, false);
   ds_create_cmd->add_keyword_arg("dsorg", make_aliases("--dsorg"), "Data set organization", ArgType_Single, false);
   ds_create_cmd->add_keyword_arg("primary", make_aliases("--primary"), "Primary space", ArgType_Single, false);
-  ds_create_cmd->add_keyword_arg("recfm", make_aliases("--recfm"), "Record format", ArgType_Single, false);
+  ds_create_cmd->add_keyword_arg("recfm", make_aliases("--recfm"), "Record format", ArgType_Single, false, ArgValue(std::string("FB")));
   ds_create_cmd->add_keyword_arg("lrecl", make_aliases("--lrecl"), "Record length", ArgType_Single, false);
   ds_create_cmd->add_keyword_arg("dataclass", make_aliases("--dataclass"), "Data class", ArgType_Single, false);
   ds_create_cmd->add_keyword_arg("unit", make_aliases("--unit"), "Device type", ArgType_Single, false);
@@ -200,6 +201,13 @@ int main(int argc, char *argv[])
   ds_create_cmd->add_keyword_arg("vol", make_aliases("--vol"), "Volume serial", ArgType_Single, false);
   ds_create_cmd->set_handler(handle_data_set_create);
   data_set_cmd->add_command(ds_create_cmd);
+
+  // Create-fb subcommand
+  auto ds_create_fb_cmd = command_ptr(new Command("create-fb", "create FB data set using defaults: DSORG=PO, RECFM=FB, LRECL=80 "));
+  ds_create_fb_cmd->add_alias("cre-fb");
+  ds_create_fb_cmd->add_positional_arg("dsn", "data set name, optionally with member specified", ArgType_Single, true);
+  ds_create_fb_cmd->set_handler(handle_data_set_create_fb);
+  data_set_cmd->add_command(ds_create_fb_cmd);
 
   // Create-vb subcommand
   auto ds_create_vb_cmd = command_ptr(new Command("create-vb", "create VB data set using defaults: DSORG=PO, RECFM=VB, LRECL=255"));
@@ -756,6 +764,45 @@ int handle_data_set_create(const ParseResult &result)
 
   string response;
   rc = zds_create_dsn(&zds, dsn, attributes, response);
+  if (0 != rc)
+  {
+    cerr << "Error: could not create data set: '" << dsn << "' rc: '" << rc << "'" << endl;
+    cerr << "  Details:\n"
+         << response << endl;
+    return RTNCD_FAILURE;
+  }
+
+  // Handle member creation if specified
+  size_t start = dsn.find_first_of('(');
+  size_t end = dsn.find_last_of(')');
+  if (start != string::npos && end != string::npos && end > start)
+  {
+    string member_name = dsn.substr(start + 1, end - start - 1);
+    string data = "";
+    rc = zds_write_to_dsn(&zds, dsn, data);
+    if (0 != rc)
+    {
+      cout << "Error: could not write to data set: '" << dsn << "' rc: '" << rc << "'" << endl;
+      cout << "  Details: " << zds.diag.e_msg << endl;
+      return RTNCD_FAILURE;
+    }
+    cout << "Data set and/or member created: '" << dsn << "'" << endl;
+  }
+  else
+  {
+    cout << "Data set created: '" << dsn << "'" << endl;
+  }
+
+  return rc;
+}
+
+int handle_data_set_create_fb(const ParseResult &result)
+{
+  int rc = 0;
+  string dsn = result.find_pos_arg_string("dsn");
+  ZDS zds = {0};
+  string response;
+  rc = zds_create_dsn_fb(&zds, dsn, response);
   if (0 != rc)
   {
     cerr << "Error: could not create data set: '" << dsn << "' rc: '" << rc << "'" << endl;


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

- adds default for `--recfm` on `zowex ds create` (otherwise invalid data sets are created with default options)
- adds `zowex ds cre-fb` which is similar to `zowe files create classic`

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
