### PR TITLE
refactor(lexer): support all characters as part of an identifier

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- Fixed issue where special characters '#' and '@' were detected as invalid characters in a data set name when provided to `zowex` commands. [#491](https://github.com/zowe/zowe-native-proto/issues/491)
+- Fixed issue where special characters were detected as invalid characters when provided to `zowex` commands. [#491](https://github.com/zowe/zowe-native-proto/issues/491)
 
 ## `0.1.7`
 

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the native code for "zowe-native-proto" are documented in
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- Fixed issue where special characters '#' and '@' were detected as invalid characters in a data set name when provided to `zowex` commands. [#491](https://github.com/zowe/zowe-native-proto/issues/491)
+
 ## `0.1.7`
 
 - Updated CLI parser `find_kw_arg_bool` function to take in an optional boolean `check_for_negation` that, when `true`, looks for a negated option value. [#485](https://github.com/zowe/zowe-native-proto/issues/485)

--- a/native/c/lexer.hpp
+++ b/native/c/lexer.hpp
@@ -968,7 +968,7 @@ private:
   {
     unsigned char uc = static_cast<unsigned char>(c);
     return (uc >= 'A' && uc <= 'Z') || (uc >= 'a' && uc <= 'z') ||
-           c == '$' || c == '_' || c == '/' || c == '*';
+           c == '$' || c == '_' || c == '/' || c == '*' || c == '#' || c == '@';
   }
 
   static bool is_ident_cont(char c)

--- a/native/c/lexer.hpp
+++ b/native/c/lexer.hpp
@@ -968,8 +968,7 @@ private:
     return uc != ' ' && iscntrl(uc) == 0;
   }
 
-  static bool
-  is_ident_cont(char c)
+  static bool is_ident_cont(char c)
   {
     return is_ident_start(c);
   }

--- a/native/c/lexer.hpp
+++ b/native/c/lexer.hpp
@@ -16,11 +16,9 @@
 
 #include <cctype>
 #include <cerrno>
-#include <climits>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
-#include <map>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -967,14 +965,13 @@ private:
   static bool is_ident_start(char c)
   {
     unsigned char uc = static_cast<unsigned char>(c);
-    return (uc >= 'A' && uc <= 'Z') || (uc >= 'a' && uc <= 'z') ||
-           c == '$' || c == '_' || c == '/' || c == '*' || c == '#' || c == '@';
+    return uc != ' ' && iscntrl(uc) == 0;
   }
 
-  static bool is_ident_cont(char c)
+  static bool
+  is_ident_cont(char c)
   {
-    return is_ident_start(c) || is_ascii_dec_digit(c) || c == '.' || c == '/' ||
-           c == '*' || c == '-' || c == '(' || c == ')';
+    return is_ident_start(c);
   }
 
   // combined digit check for lex_number


### PR DESCRIPTION
**What It Does**

Fixed issue where the "at symbol" (`@`) and the pound sign `#` were not correctly interpreted as identifiers

**How to Test**

- `ds restore TEST.#NC@DED` makes it to the actual restore operation (ofc it will fail because the data set doesn't exist)

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
