### PR TITLE
Fix zowex --no-warn ends with rc != 0

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to the native code for "zowe-native-proto" are documented in
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- `c`: Fixed issue where the `zowex ds lm` command always returned non-zero exit code for warnings and ignored the `--no-warn` flag. [#498](https://github.com/zowe/zowe-native-proto/issues/498)
+
 ## `0.1.8`
 
 - `native`: Added default value for `--recfm` so that when no options are specified the data set will not contain errors. [#493](https://github.com/zowe/zowe-native-proto/issues/493)
 - Fixed issue where special characters were detected as invalid characters when provided to `zowex` commands. [#491](https://github.com/zowe/zowe-native-proto/issues/491)
-- `native`: Increase default max returned entries in `zowex ds list` from 100 to 5000.  This helps with [#487](https://github.com/zowe/zowe-native-proto/issues/487) but does not fix it. In the future, users should be able to specify on the Zowe Clients the max number of entries.
+- `native`: Increase default max returned entries in `zowex ds list` from 100 to 5000. This helps with [#487](https://github.com/zowe/zowe-native-proto/issues/487) but does not fix it. In the future, users should be able to specify on the Zowe Clients the max number of entries.
 
 ## `0.1.7`
 

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -1071,7 +1071,7 @@ int handle_data_set_list_members(const ParseResult &result)
     return RTNCD_FAILURE;
   }
 
-  return rc;
+  return (!warn && rc == RTNCD_WARNING) ? RTNCD_SUCCESS : rc;
 }
 
 int handle_data_set_write(const ParseResult &result)

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -327,9 +327,12 @@ async function upload(connection: Client) {
                 });
             }
 
-            const pendingUploads = [
-                uploadFile(sftpcon, path.resolve(__dirname, "../package.json"), `${deployDirs.root}/package.json`),
-            ];
+            const pendingUploads = [];
+            if (args[1] == null) {
+                pendingUploads.push(
+                    uploadFile(sftpcon, path.resolve(__dirname, "../package.json"), `${deployDirs.root}/package.json`),
+                );
+            }
             for (let i = 0; i < files.length; i++) {
                 const from = path.resolve(__dirname, `${localDeployDir}/${files[i]}`);
                 const to = `${deployDirs.root}/${files[i]}`;


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #498

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run `./zowex ds lm SYS1.MACLIB --me 1 --no-warn` and verify that the return code is 0.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
