### PR TITLE
fix: duplicate submit in submit-jcl handler

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Recent Changes
 
 - `c`: Fixed issue where the `zowex ds lm` command always returned non-zero exit code for warnings and ignored the `--no-warn` flag. [#498](https://github.com/zowe/zowe-native-proto/issues/498)
+- `c`: Fixed issue where the `zowex job submit-jcl` command submitted the given JCL contents twice, causing two jobs to be created.
 
 ## `0.1.8`
 

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -2329,18 +2329,7 @@ int handle_job_submit_jcl(const ParseResult &result)
     data = zut_encode(data, "UTF-8", string(encoding_opts.codepage), zjb.diag);
   }
 
-  int rc = 0;
-  rc = zjb_submit(&zjb, data, jobid);
-  if (rc != RTNCD_SUCCESS)
-  {
-    cerr << "Error: could not submit job: '" << jobid << "' rc: '" << rc << "'" << endl;
-    cerr << "  Details: " << zjb.diag.e_msg << endl;
-    return rc;
-  }
-
-  cout << "Submitted " << jobid << endl;
-
-  return rc;
+  return job_submit_common(result, data, jobid, "JCL");
 }
 
 int handle_job_delete(const ParseResult &result)

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -9,6 +9,7 @@
  *
  */
 
+#include "ztype.h"
 #pragma runopts("TRAP(ON,NOSPIE)")
 
 #include <iostream>
@@ -2302,6 +2303,8 @@ int handle_job_submit_uss(const ParseResult &result)
 
 int handle_job_submit_jcl(const ParseResult &result)
 {
+  ZJB zjb = {0};
+  string jobid;
   string data;
   string line;
 
@@ -2326,8 +2329,18 @@ int handle_job_submit_jcl(const ParseResult &result)
     data = zut_encode(data, "UTF-8", string(encoding_opts.codepage), zjb.diag);
   }
 
-  string jobid;
-  return job_submit_common(result, data, jobid, data);
+  int rc = 0;
+  rc = zjb_submit(&zjb, data, jobid);
+  if (rc != RTNCD_SUCCESS)
+  {
+    cerr << "Error: could not submit job: '" << jobid << "' rc: '" << rc << "'" << endl;
+    cerr << "  Details: " << zjb.diag.e_msg << endl;
+    return rc;
+  }
+
+  cout << "Submitted " << jobid << endl;
+
+  return rc;
 }
 
 int handle_job_delete(const ParseResult &result)

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -2302,9 +2302,6 @@ int handle_job_submit_uss(const ParseResult &result)
 
 int handle_job_submit_jcl(const ParseResult &result)
 {
-  int rc = 0;
-  ZJB zjb = {0};
-
   string data;
   string line;
 
@@ -2330,8 +2327,6 @@ int handle_job_submit_jcl(const ParseResult &result)
   }
 
   string jobid;
-  rc = zjb_submit(&zjb, data, jobid);
-
   return job_submit_common(result, data, jobid, data);
 }
 


### PR DESCRIPTION
**What It Does**

Prevents duplicate submission in `zowex job submit-jcl` command

**How to Test**

- Deploy and build
- `printf "//IEFBR14$ JOB (IZUACCT),TEST,REGION=0M\n//RUN EXEC PGM=IEFBR14" | zowex job submit-jcl`
- Notice only one job is created from running this. You'll see 2 jobs when running based off of `main`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)