### PR TITLE
feat: add support for volser option when reading/writing data sets

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -11,6 +11,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c`: Implemented a logger for Metal C and C++ source code for diagnostics, debug information, and printing dumps. When enabled, log messages are written to a log file named `zowex.log` in a new `logs` folder, relative to the location of the `zowex` binary. [#107](https://github.com/zowe/zowe-native-proto/issues/107)
 - `golang`: Moved location of log file inside "logs" directory to be consistent with `zowex`. [#514](https://github.com/zowe/zowe-native-proto/pull/514)
 - `c`: Fixed issue where the `zowex ds write` command automatically created a data set when it did not exist. [#292](https://github.com/zowe/zowe-native-proto/issues/292)
+- `native`: Added support for volser option when reading/writing data sets. [#439](https://github.com/zowe/zowe-native-proto/issues/439)
 
 ## `0.1.8`
 

--- a/native/c/zdstype.h
+++ b/native/c/zdstype.h
@@ -70,6 +70,7 @@ typedef struct
 
   ZEncode encoding_opts;
   char etag[8];
+  char ddname[8];
 
   int32_t max_entries;
   int32_t buffer_size;

--- a/native/c/zowex.cpp
+++ b/native/c/zowex.cpp
@@ -192,6 +192,7 @@ int main(int argc, char *argv[])
   auto pipe_path_option = make_aliases("--pipe-path");
   auto response_format_csv_option = make_aliases("--response-format-csv", "--rfc");
   auto response_format_bytes_option = make_aliases("--response-format-bytes", "--rfb");
+  auto volser_option = make_aliases("--volser", "--vs");
 
   // Create subcommand
   auto ds_create_cmd = command_ptr(new Command("create", "create data set"));
@@ -261,6 +262,7 @@ int main(int argc, char *argv[])
   ds_view_cmd->add_keyword_arg("response-format-bytes", response_format_bytes_option, "returns the response as raw bytes", ArgType_Flag, false, ArgValue(false));
   ds_view_cmd->add_keyword_arg("return-etag", return_etag_option, "Display the e-tag for a read response in addition to data", ArgType_Flag, false, ArgValue(false));
   ds_view_cmd->add_keyword_arg("pipe-path", pipe_path_option, "Specify a FIFO pipe path for transferring binary data", ArgType_Single, false);
+  ds_view_cmd->add_keyword_arg("volser", volser_option, "Specify volume serial where the data set resides", ArgType_Single, false);
   ds_view_cmd->set_handler(handle_data_set_view);
   data_set_cmd->add_command(ds_view_cmd);
 
@@ -291,6 +293,7 @@ int main(int argc, char *argv[])
   ds_write_cmd->add_keyword_arg("etag", etag_option, "Provide the e-tag for a write response to detect conflicts before save", ArgType_Single, false);
   ds_write_cmd->add_keyword_arg("etag-only", etag_only_option, "Only print the e-tag for a write response (when successful)", ArgType_Flag, false, ArgValue(false));
   ds_write_cmd->add_keyword_arg("pipe-path", pipe_path_option, "Specify a FIFO pipe path for transferring binary data", ArgType_Single, false);
+  ds_write_cmd->add_keyword_arg("volser", volser_option, "Specify volume serial where the data set resides", ArgType_Single, false);
   ds_write_cmd->set_handler(handle_data_set_write);
   data_set_cmd->add_command(ds_write_cmd);
 
@@ -907,10 +910,26 @@ int handle_data_set_view(const ParseResult &result)
   int rc = 0;
   string dsn = result.find_pos_arg_string("dsn");
   ZDS zds = {0};
+  vector<string> dds;
 
   if (result.has_kw_arg("encoding"))
   {
     zut_prepare_encoding(result.find_kw_arg_string("encoding"), &zds.encoding_opts);
+  }
+
+  if (result.has_kw_arg("volser"))
+  {
+    string volser_value = result.find_kw_arg_string("volser");
+    if (!volser_value.empty())
+    {
+      dds.push_back("alloc dd(input) da('" + dsn + "') shr vol(" + volser_value + ")");
+      rc = loop_dynalloc(dds);
+      if (0 != rc)
+      {
+        return RTNCD_FAILURE;
+      }
+      strcpy(zds.ddname, "INPUT");
+    }
   }
 
   bool has_pipe_path = result.has_kw_arg("pipe-path");
@@ -962,6 +981,11 @@ int handle_data_set_view(const ParseResult &result)
     {
       cout << response << endl;
     }
+  }
+
+  if (dds.size() > 0)
+  {
+    free_dynalloc_dds(dds);
   }
 
   return rc;
@@ -1096,6 +1120,7 @@ int handle_data_set_write(const ParseResult &result)
   int rc = 0;
   string dsn = result.find_pos_arg_string("dsn");
   ZDS zds = {0};
+  vector<string> dds;
 
   if (result.has_kw_arg("encoding"))
   {
@@ -1108,6 +1133,21 @@ int handle_data_set_write(const ParseResult &result)
     if (!etag_value.empty())
     {
       strcpy(zds.etag, etag_value.c_str());
+    }
+  }
+
+  if (result.has_kw_arg("volser"))
+  {
+    string volser_value = result.find_kw_arg_string("volser");
+    if (!volser_value.empty())
+    {
+      dds.push_back("alloc dd(output) da('" + dsn + "') shr vol(" + volser_value + ")");
+      rc = loop_dynalloc(dds);
+      if (0 != rc)
+      {
+        return RTNCD_FAILURE;
+      }
+      strcpy(zds.ddname, "OUTPUT");
     }
   }
 
@@ -1146,6 +1186,11 @@ int handle_data_set_write(const ParseResult &result)
     }
 
     rc = zds_write_to_dsn(&zds, dsn, data);
+  }
+
+  if (dds.size() > 0)
+  {
+    free_dynalloc_dds(dds);
   }
 
   if (0 != rc)

--- a/native/golang/cmds/ds.go
+++ b/native/golang/cmds/ds.go
@@ -39,6 +39,9 @@ func HandleReadDatasetRequest(conn *utils.StdioConn, params []byte) (result any,
 		request.Encoding = fmt.Sprintf("IBM-%d", utils.DefaultEncoding)
 	}
 	args := []string{"data-set", "view", request.Dsname, "--encoding", request.Encoding, "--return-etag"}
+	if len(request.Volume) > 0 {
+		args = append(args, "--volser", request.Volume)
+	}
 
 	var etag string
 	var data []byte
@@ -133,6 +136,9 @@ func HandleWriteDatasetRequest(conn *utils.StdioConn, params []byte) (result any
 	args := []string{"data-set", "write", request.Dsname, "--encoding", request.Encoding, "--etag-only"}
 	if len(request.Etag) > 0 {
 		args = append(args, "--etag", request.Etag)
+	}
+	if len(request.Volume) > 0 {
+		args = append(args, "--volser", request.Volume)
 	}
 
 	var out []byte

--- a/native/golang/types/ds/requests.go
+++ b/native/golang/types/ds/requests.go
@@ -40,6 +40,8 @@ type ReadDatasetRequest struct {
 	Command               string `json:"command" tstype:"\"readDataset\""`
 	// Desired encoding for the dataset (optional)
 	Encoding string `json:"encoding,omitempty"`
+	// Volume serial for the data set (optional)
+	Volume string `json:"volume,omitempty"`
 	// Dataset name
 	Dsname string `json:"dsname"`
 	// Stream to write contents to
@@ -53,6 +55,8 @@ type WriteDatasetRequest struct {
 	Encoding string `json:"encoding,omitempty"`
 	// Last e-tag for the data set (optional, omit to overwrite)
 	Etag string `json:"etag,omitempty"`
+	// Volume serial for the data set (optional)
+	Volume string `json:"volume,omitempty"`
 	// Dataset name
 	Dsname string `json:"dsname"`
 	// Dataset contents

--- a/native/golang/types/ds/responses.go
+++ b/native/golang/types/ds/responses.go
@@ -40,7 +40,7 @@ type ReadDatasetResponse struct {
 	// Dataset name
 	Dataset string `json:"dataset"`
 	// Dataset contents (omitted if streaming)
-	Data *[]byte `json:"data" tstype:"B64String"`
+	Data *[]byte `json:"data" tstype:"B64String,required"`
 	// Length of dataset contents in bytes (only used for streaming)
 	ContentLen *int `json:"contentLen,omitempty"`
 }

--- a/native/golang/types/uss/responses.go
+++ b/native/golang/types/uss/responses.go
@@ -30,7 +30,7 @@ type ReadFileResponse struct {
 	// Remote file path
 	Path string `json:"fspath"`
 	// File contents (omitted if streaming)
-	Data *[]byte `json:"data" tstype:"B64String"`
+	Data *[]byte `json:"data" tstype:"B64String,required"`
 	// Length of file contents in bytes (only used for streaming)
 	ContentLen *int `json:"contentLen,omitempty"`
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -12,6 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added support for the `encoding` option to the `zssh upload uss` and the `zssh upload ds` commands. When the `encoding` option is provided, the command uses the option value as the target encoding for the uploaded content. [#427](https://github.com/zowe/zowe-native-proto/issues/427)
 - Added support for the `file` option to the `zssh download uss` and `zssh download ds` commands. When the `file` option is provided, the command uses the option value as the destination file path for the downloaded content. [#428](https://github.com/zowe/zowe-native-proto/issues/428)
 - Adopted streaming for commands that upload/download data sets and USS files. [#358](https://github.com/zowe/zowe-native-proto/pull/358)
+- Added support for `--volume-serial` option when uploading/downloading data sets. [#439](https://github.com/zowe/zowe-native-proto/issues/439)
 
 ## `0.1.1`
 

--- a/packages/cli/src/download/data-set/DataSet.definition.ts
+++ b/packages/cli/src/download/data-set/DataSet.definition.ts
@@ -67,6 +67,12 @@ export const DownloadDataSetDefinition: ICommandDefinition = {
             type: "string",
             conflictsWith: ["directory"],
         },
+        {
+            name: "volume-serial",
+            aliases: ["vs"],
+            description: "The volume serial (VOLSER) where the data set resides.",
+            type: "string",
+        },
     ],
     profile: { optional: ["ssh"] },
 };

--- a/packages/cli/src/download/data-set/DataSet.handler.ts
+++ b/packages/cli/src/download/data-set/DataSet.handler.ts
@@ -36,6 +36,7 @@ export default class DownloadDataSetHandler extends SshBaseHandler {
             stream: fs.createWriteStream(localFilePath),
             dsname: params.arguments.dataSet,
             encoding: params.arguments.binary ? "binary" : params.arguments.encoding,
+            volume: params.arguments.volumeSerial,
         });
 
         params.response.data.setMessage("Successfully downloaded content to %s", localFilePath);

--- a/packages/cli/src/upload/file-to-data-set/FileToDataSet.definition.ts
+++ b/packages/cli/src/upload/file-to-data-set/FileToDataSet.definition.ts
@@ -24,8 +24,8 @@ export const UploadFileToDataSetDefinition: ICommandDefinition = {
             options: 'iefbr14.txt "ibmuser.cntl(iefbr14)"',
         },
         {
-            description: 'Upload to "ibmuser.dataset" from the file dataset.txt with the DCB parameters',
-            options: 'dataset.txt "ibmuser.dataset" --dcb "RECFM=FB LRECL=326 BLKSIZE=23472"',
+            description: 'Upload to "ibmuser.dataset" on volume VOL001 from the file dataset.txt',
+            options: 'dataset.txt "ibmuser.dataset" --volume-serial VOL001',
         },
     ],
     positionals: [
@@ -64,6 +64,12 @@ export const UploadFileToDataSetDefinition: ICommandDefinition = {
             aliases: ["ec"],
             description: "The encoding for download and upload of z/OS data set.",
             defaultValue: null,
+            type: "string",
+        },
+        {
+            name: "volume-serial",
+            aliases: ["vs"],
+            description: "The volume serial (VOLSER) where the data set resides.",
             type: "string",
         },
     ],

--- a/packages/cli/src/upload/file-to-data-set/FileToDataSet.handler.ts
+++ b/packages/cli/src/upload/file-to-data-set/FileToDataSet.handler.ts
@@ -21,6 +21,7 @@ export default class UploadFileToDataSetHandler extends SshBaseHandler {
             stream: fs.createReadStream(params.arguments.file),
             dsname: params.arguments.dataSet,
             encoding: params.arguments.binary ? "binary" : params.arguments.encoding,
+            volume: params.arguments.volumeSerial,
         });
         const uploadSource = `local file '${params.arguments.file}'`;
         const successMsg = params.response.console.log(

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Recent Changes
 
 - Changed default number of `zowex` worker threads from 10 to 3 to reduce resource usage on z/OS. [#514](https://github.com/zowe/zowe-native-proto/pull/514)
+- Added support for `volume` option when reading/writing data sets. [#439](https://github.com/zowe/zowe-native-proto/issues/439)
 
 ## `0.1.7`
 

--- a/packages/sdk/src/doc/gen/ds.ts
+++ b/packages/sdk/src/doc/gen/ds.ts
@@ -46,6 +46,10 @@ export interface ReadDatasetRequest extends common.CommandRequest {
    */
   encoding?: string;
   /**
+   * Volume serial for the data set (optional)
+   */
+  volume?: string;
+  /**
    * Dataset name
    */
   dsname: string;
@@ -64,6 +68,10 @@ export interface WriteDatasetRequest extends common.CommandRequest {
    * Last e-tag for the data set (optional, omit to overwrite)
    */
   etag?: string;
+  /**
+   * Volume serial for the data set (optional)
+   */
+  volume?: string;
   /**
    * Dataset name
    */


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Resolves #439 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Try the CLI command `zowe zssh files upload ftds <localFile> <remoteDsn> --volume-serial <volser>`

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
