### PR TITLE
fix: regression in zowex ds write for PDS

### DIFF
--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -68,6 +68,19 @@ string zds_get_recfm(const fldata_t &file_info)
   return recfm;
 }
 
+bool zds_dataset_exists(const string &dsn)
+{
+  const auto member_idx = dsn.find('(');
+  const string dsn_without_member = member_idx == string::npos ? dsn : dsn.substr(0, member_idx);
+  FILE *fp = fopen(("//'" + dsn_without_member + "'").c_str(), "r");
+  if (fp)
+  {
+    fclose(fp);
+    return true;
+  }
+  return false;
+}
+
 int zds_read_from_dd(ZDS *zds, string ddname, string &response)
 {
   ddname = "DD:" + ddname;
@@ -183,6 +196,12 @@ int zds_write_to_dd(ZDS *zds, string ddname, const string &data)
 
 int zds_write_to_dsn(ZDS *zds, const string &dsn, string &data)
 {
+  if (!zds_dataset_exists(dsn))
+  {
+    zds->diag.e_msg_len = sprintf(zds->diag.e_msg, "Could not access '%s'", dsn.c_str());
+    return RTNCD_FAILURE;
+  }
+
   const auto hasEncoding = zds->encoding_opts.data_type == eDataTypeText && strlen(zds->encoding_opts.codepage) > 0;
   const auto codepage = string(zds->encoding_opts.codepage);
 
@@ -219,12 +238,7 @@ int zds_write_to_dsn(ZDS *zds, const string &dsn, string &data)
   }
 
   const string dsname = "//'" + dsn + "'";
-  string fopen_flags = dsname.find('(') == string::npos ? "r+" : "w"; // Create non-existent members
-  if (zds->encoding_opts.data_type == eDataTypeBinary)
-  {
-    fopen_flags += 'b';
-  }
-  fopen_flags += ",recfm=*";
+  const string fopen_flags = zds->encoding_opts.data_type == eDataTypeBinary ? "wb" : "w" + string(",recfm=*");
 
   auto *fp = fopen(dsname.c_str(), fopen_flags.c_str());
   if (nullptr == fp)
@@ -1113,6 +1127,11 @@ int zds_write_to_dsn_streamed(ZDS *zds, const string &dsn, const string &pipe, s
     zds->diag.e_msg_len = sprintf(zds->diag.e_msg, "content_len must be a valid size_t pointer");
     return RTNCD_FAILURE;
   }
+  else if (!zds_dataset_exists(dsn))
+  {
+    zds->diag.e_msg_len = sprintf(zds->diag.e_msg, "Could not access '%s'", dsn.c_str());
+    return RTNCD_FAILURE;
+  }
 
   string dsname = "//'" + dsn + "'";
   if (strlen(zds->etag) > 0)
@@ -1150,12 +1169,7 @@ int zds_write_to_dsn_streamed(ZDS *zds, const string &dsn, const string &pipe, s
 
   const auto hasEncoding = zds->encoding_opts.data_type == eDataTypeText && strlen(zds->encoding_opts.codepage) > 0;
   const auto codepage = string(zds->encoding_opts.codepage);
-  string fopen_flags = dsname.find('(') == string::npos ? "r+" : "w"; // Create non-existent members
-  if (zds->encoding_opts.data_type == eDataTypeBinary)
-  {
-    fopen_flags += 'b';
-  }
-  fopen_flags += ",recfm=*";
+  const auto fopen_flags = (zds->encoding_opts.data_type == eDataTypeBinary ? "wb" : "w") + string(",recfm=*");
 
   FILE *fout = fopen(dsname.c_str(), fopen_flags.c_str());
   if (!fout)


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes regression introduced in #513 where writing to a PDS member fails because members don't support `r+` mode.

We want to create PDS members when they don't exist - so `r+` mode should only be used for sequential DSs.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Test `echo abc | zowex ds write <dsname>` on z/OS for both a PS and member that already exist

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
