### PR TITLE
fix build error - non static function

### DIFF
--- a/native/c/zdbg.h
+++ b/native/c/zdbg.h
@@ -27,7 +27,7 @@ typedef int (*zut_print_func)(const char *fmt);
  * @param size Size of the memory region in bytes
  * @param cb_print Call back function to print the output
  */
-void zut_dump_storage(const char *title, const void *data, int size, zut_print_func cb_print)
+static void zut_dump_storage(const char *title, const void *data, int size, zut_print_func cb_print)
 {
   int len = 0;
   char buf[1024] = {0};


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

missing `static` keyword in header implementation causes binder errors when included in more than 1 file

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
