### PR TITLE
Dynamic debug printing

### DIFF
--- a/native/README.md
+++ b/native/README.md
@@ -189,6 +189,12 @@ Use `.Not()` to inverse compare values behavior. `Not()` returns a `RESULT_CHECK
 
 To create a C header from an HLASM DSECT:
 
+- Create the `asmchdr` element, e.g. `cvt.s`
+- Generate & download the header via `npm run z:chdsect cvt.s`
+- Save the file to ensure proper formating
+
+OR:
+
 - create a `.s` file in `asmchdr` folder, e.g. `asasymbp.s`
 - upload, e.g. `npm run z:upload asmchdr/asasymbp.s`
 - allocate output adata data set if none exists, e.g. `zowex data-set create-adata <hlq>.adata`

--- a/native/asmchdr/gen_chdsect.sh
+++ b/native/asmchdr/gen_chdsect.sh
@@ -1,0 +1,64 @@
+#! #!/usr/bin/env bash
+set -e
+printf "\n"
+
+echo "Setting required env vars..."
+printf "\n"
+export _BPXK_AUTOCVT=ON
+export _CEE_RUNOPTS="$_CEE_RUNOPTS FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
+export _TAG_REDIR_ERR=txt
+export _TAG_REDIR_IN=txt
+export _TAG_REDIR_OUT=txt
+
+user=$(whoami)
+
+data_set_adata=$user.ZNP.ADATA
+data_set_chdr=$user.ZNP.CHDR
+
+echo "Using ADATA data set: $data_set_adata"
+echo "Using CHDR data set: $data_set_chdr"
+printf "\n"
+
+# Create ADATA data set, ignore errors if it fails
+echo "Creating ADATA data set: $data_set_adata"
+if ! zowex data-set create-adata "$data_set_adata" >/dev/null 2>&1; then
+    echo "Warning: Failed to create ADATA data set (may already exist)"
+fi
+printf "\n"
+
+# Create CHDR data set, ignore errors if it fails
+echo "Creating CHDR data set: $data_set_chdr"
+if ! zowex data-set create-vb "$data_set_chdr" >/dev/null 2>&1; then
+    echo "Warning: Failed to create CHDR data set (may already exist)"
+fi
+printf "\n"
+
+# Get filename without extension
+filename_no_ext="${1%.*}"
+
+echo "Running assembler command..."
+echo "Command: as -madata --gadata=\"//'$data_set_adata($filename_no_ext)'\" $1"
+as -madata --gadata="//'$data_set_adata($filename_no_ext)'" $1
+echo "Assembler command completed."
+printf "\n"
+
+zowex tool ccnedsct --ad "$data_set_adata($filename_no_ext)" --cd "$data_set_chdr($filename_no_ext)"
+printf "\n"
+
+echo "Copying generated header file to build-out..."
+cp "//'$data_set_chdr($filename_no_ext)'" "build-out/$filename_no_ext.h"
+echo "Copying completed."
+printf "\n"
+
+echo "Converting EBCDIC to ASCII..."
+mv build-out/$filename_no_ext.h build-out/$filename_no_ext.h.u
+echo "Command: iconv -f 1047 -t utf8 build-out/$filename_no_ext.h.u > build-out/$filename_no_ext.h"
+iconv -f 1047 -t utf8 build-out/$filename_no_ext.h.u > build-out/$filename_no_ext.h
+chtag -tc ISO8859-1 build-out/$filename_no_ext.h
+echo "Conversion completed."
+printf "\n"
+
+echo "Cleaning up..."
+rm "build-out/$filename_no_ext.h.u"
+echo "Cleanup completed."
+printf "\n"

--- a/native/asmchdr/makefile
+++ b/native/asmchdr/makefile
@@ -1,0 +1,24 @@
+# Generic target that runs a shell script with the target name as argument
+build-%:
+	chmod +x gen_chdsect.sh
+	mkdir -p build-out
+	@echo "Running target: $*"
+	@./gen_chdsect.sh "$*"
+
+# Default target
+all:
+	@echo "Available targets:"
+	@echo "  make build-<target_name>  - Runs ./gen_chdsect.sh <target_name>"
+	@echo "  make help              - Shows this help"
+
+# Help target
+help:
+	@echo "Usage: make build-<target_name>"
+	@echo "This will run: ./gen_chdsect.sh <target_name>"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make build-cvt.s    -> ./gen_chdsect.sh cvt.s"
+	@echo "  make build-dcbd.s   -> ./gen_chdsect.sh dcbd.s"
+
+# Prevent make from trying to build files that don't exist
+.PHONY: % all help

--- a/native/c/zdbg.h
+++ b/native/c/zdbg.h
@@ -27,7 +27,7 @@ typedef int (*zut_print_func)(const char *fmt);
  * @param size Size of the memory region in bytes
  * @param cb_print Call back function to print the output
  */
-void zut_dump_storage(const char *title, const void *data, int size, zut_print_func cb_print)
+static void zut_dump_storage(const char *title, const void *data, int size, zut_print_func cb_print)
 {
   int len = 0;
   char buf[1024] = {0};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "z:artifacts": "tsx scripts/buildTools.ts artifacts",
     "z:build": "tsx scripts/buildTools.ts build",
     "z:build:python": "tsx scripts/buildTools.ts build:python",
+    "z:chdsect": "tsx scripts/buildTools.ts build:chdsect",
     "z:clean": "tsx scripts/buildTools.ts clean",
     "z:delete": "tsx scripts/buildTools.ts delete",
     "z:make": "tsx scripts/buildTools.ts make",

--- a/scripts/znpPackage.sh
+++ b/scripts/znpPackage.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-zowe files download uf $1/zowe-native-proto/libzcn.a --binary --file zowe-native-proto-package/libzcn.a
-zowe files download uf $1/zowe-native-proto/ztype.h --binary --file zowe-native-proto-package/ztype.h
-zowe files download uf $1/zowe-native-proto/zcntype.h --binary --file zowe-native-proto-package/zcntype.h
-zowe files download uf $1/zowe-native-proto/zcn.hpp --binary --file zowe-native-proto-package/zcn.hpp
-zip -r zowe-native-proto-package.zip zowe-native-proto-package


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Adds a new method, `zut_dump_storage_common` so that the width of debugging messages can be adjusted and printed via WTO (which has a max length per line and quickly wraps).  

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

Add an example function call like:
`  zut_dump_storage_common("entries", &buffer, 128, 16, 0, zut_print_debug);`

Observe output like:

```
08.34.56 STC01791  +ZWEX0001I --- Dumping storage for 'entries' at x'0000000014619760' ---
08.34.56 STC01791  +ZWEX0001I 0000000014619760 | ................ | 01000000 00000003 000002dc 00000000
08.34.56 STC01791  +ZWEX0001I 0000000014619770 | SYS1.PARMLIB     | e2e8e2f1 4bd7c1d9 d4d3c9c2 40404040
08.34.56 STC01791  +ZWEX0001I 0000000014619780 |                  | 40404040 40404040 40404040 40404040
08.34.56 STC01791  +ZWEX0001I 0000000014619790 |             .... | 40404040 40404040 40404040 00000000
08.34.56 STC01791  +ZWEX0001I 00000000146197a0 | ........PRODUCT. | 00000000 00000000 d7d9d6c4 e4c3e34b
08.34.56 STC01791  +ZWEX0001I 00000000146197b0 | PARMLIB          | d7c1d9d4 d3c9c240 40404040 40404040
08.34.56 STC01791  +ZWEX0001I 00000000146197c0 |                  | 40404040 40404040 40404040 40404040
08.34.56 STC01791  +ZWEX0001I 00000000146197d0 |     USER01...... | 40404040 e4e2c5d9 f0f10000 00000000
08.34.56 STC01791  +ZWEX0001I 00000000146197e0 |                  |
08.34.56 STC01791  +ZWEX0001I --- END ---
```

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
