### PR TITLE
Reduce size of build-out folder generated for tests

### DIFF
--- a/native/c/test/makefile
+++ b/native/c/test/makefile
@@ -24,7 +24,7 @@ BIND_FLAGS_AUTH = -bRMODE=ANY,AC=1
 BIND_FLAGS_64 = -bRMODE=ANY,AMODE=64
 BIND_FLAGS_64_AUTH = -bRMODE=ANY,AMODE=64,AC=1
 
-MTL_OPTS=metal,\
+MTL_BASE_OPTS=metal,\
  langlvl(extended),\
  sscom,\
  nolongname,\
@@ -33,16 +33,9 @@ MTL_OPTS=metal,\
  inlrpt,\
  csect,\
  nose,\
- list,\
  warn64,\
- optimize(2),\
- list,\
- showmacro,\
- aggregate
-
-MTL_OPTS64=$(MTL_OPTS),lp64
-MTL_FLAGS=-S -W "c,$(MTL_OPTS)"
-MTL_FLAGS64=-S -W "c,$(MTL_OPTS64)"
+ optimize(2)
+MTL_LIST_OPTS=
 
 MACLIBS= -I../../asmmac \
  -ISYS1.MACLIB \
@@ -54,9 +47,10 @@ MTL_HEADERS=-I/usr/include/metal\
 -I../\
 -I../chdsect
 
-CPP_BND_FLAGS=-W "l,lp64,xplink,map,list"
-
-CPP_BND_FLAGS_AUTH=-W "l,lp64,xplink,map,list,ac=1"
+CPP_BND_BASE_FLAGS=-W "l,lp64,xplink,map"
+CPP_BND_DEBUG_FLAGS=-W "l,lp64,xplink,map,list"
+CPP_BND_BASE_FLAGS_AUTH=-W "l,lp64,xplink,map,ac=1"
+CPP_BND_DEBUG_FLAGS_AUTH=-W "l,lp64,xplink,map,list,ac=1"
 
 C_FLAGS=-W "c,lp64,langlvl(extended),xplink,exportall"\
  -c \
@@ -66,7 +60,8 @@ DLL_CPP_FLAGS=-W "c,lp64,langlvl(extended0x),dll,xplink,exportall"\
  -c \
  -I./chdsect
 
-DLL_BND_FLAGS=-W "l,lp64,dll,dynam=dll,xplink,map,list"
+DLL_BND_BASE_FLAGS=-W "l,lp64,dll,dynam=dll,xplink,map"
+DLL_BND_DEBUG_FLAGS=-W "l,lp64,dll,dynam=dll,xplink,map,list"
 
 CPP_FLAGS=-W "c,lp64,langlvl(extended0x),xplink"\
  -c
@@ -98,6 +93,14 @@ DLL_BND_FLAGS+=$(DEBUGGER_FLAGS)
 MTL_FLAGS+=$(DEBUGGER_FLAGS) -qSHOWINC
 MTL_FLAGS64+=$(DEBUGGER_FLAGS) -qSHOWINC
 ASM_FLAGS+=--verbose
+# List output flags for debugging
+CPP_LIST_FLAG=-qlist=$$*.cpp.lst
+MTL_LIST_FLAG=-qlist=$$*.mtl.lst
+ASM_LIST_FLAG=-a=$$*.s.lst
+MTL_LIST_OPTS=,list,showmacro,aggregate
+CPP_BND_FLAGS=$(CPP_BND_DEBUG_FLAGS)
+CPP_BND_FLAGS_AUTH=$(CPP_BND_DEBUG_FLAGS_AUTH)
+DLL_BND_FLAGS=$(DLL_BND_DEBUG_FLAGS)
 .ELSE
 PRODUCTION_FLAGS=-qNOSOURCE -qNODEBUG
 CPP_BND_FLAGS+=$(PRODUCTION_FLAGS)
@@ -109,7 +112,20 @@ DLL_CPP_FLAGS+=$(PRODUCTION_FLAGS) -qNOSHOWINC
 MTL_FLAGS+=$(PRODUCTION_FLAGS) -qNOSHOWINC
 MTL_FLAGS64+=$(PRODUCTION_FLAGS) -qNOSHOWINC
 ASM_FLAGS+=--noverbose
+# No list output for production builds
+CPP_LIST_FLAG=
+MTL_LIST_FLAG=
+ASM_LIST_FLAG=
+MTL_LIST_OPTS=
+CPP_BND_FLAGS=$(CPP_BND_BASE_FLAGS)
+CPP_BND_FLAGS_AUTH=$(CPP_BND_BASE_FLAGS_AUTH)
+DLL_BND_FLAGS=$(DLL_BND_BASE_FLAGS)
 .END
+
+MTL_OPTS=$(MTL_BASE_OPTS)$(MTL_LIST_OPTS)
+MTL_OPTS64=$(MTL_OPTS),lp64
+MTL_FLAGS=-S -W "c,$(MTL_OPTS)"
+MTL_FLAGS64=-S -W "c,$(MTL_OPTS64)"
 
 # Apply LOG_FLAGS to all relevant compilation flags if logging is enabled
 .IF DEFINED(LOG_FLAGS)
@@ -136,7 +152,7 @@ build-out:
 # Testing utilities
 #
 build-out/ztest_runner.o: ztest_runner.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/ztest_runner: build-out/ztest_runner.o \
 build-out/zbase64.test.o \
@@ -174,142 +190,142 @@ build-out/zjsonm.o
 	$(OCXX) $(CXXLANG_BND_FLAGS) -o $@ $^ > $*.bind.lst
 
 build-out/zut.o:
-	cp ../build-out/xlclang/zut.o build-out/zut.o
+	ln -sf ../../build-out/xlclang/zut.o build-out/zut.o
 
 build-out/zutm.o:
-	cp ../build-out/zutm.o build-out/zutm.o
+	ln -sf ../../build-out/zutm.o build-out/zutm.o
 
 build-out/zutm31.o:
-	cp ../build-out/zutm31.o build-out/zutm31.o
+	ln -sf ../../build-out/zutm31.o build-out/zutm31.o
 
 build-out/zds.o:
-	cp ../build-out/xlclang/zds.o build-out/zds.o
+	ln -sf ../../build-out/xlclang/zds.o build-out/zds.o
 
 build-out/zdsm.o:
-	cp ../build-out/zdsm.o build-out/zdsm.o
+	ln -sf ../../build-out/zdsm.o build-out/zdsm.o
 
 build-out/zam.o:
-	cp ../build-out/zam.o build-out/zam.o
+	ln -sf ../../build-out/zam.o build-out/zam.o
 
 build-out/zjb.o:
-	cp ../build-out/xlclang/zjb.o build-out/zjb.o
+	ln -sf ../../build-out/xlclang/zjb.o build-out/zjb.o
 
 build-out/zjbm.o:
-	cp ../build-out/zjbm.o build-out/zjbm.o
+	ln -sf ../../build-out/zjbm.o build-out/zjbm.o
 
 build-out/zjbm31.o:
-	cp ../build-out/zjbm31.o build-out/zjbm31.o
+	ln -sf ../../build-out/zjbm31.o build-out/zjbm31.o
 
 build-out/zssi31.o:
-	cp ../build-out/zssi31.o build-out/zssi31.o
+	ln -sf ../../build-out/zssi31.o build-out/zssi31.o
 
 build-out/zcn.o:
-	cp ../build-out/xlclang/zcn.o build-out/zcn.o
+	ln -sf ../../build-out/xlclang/zcn.o build-out/zcn.o
 
 build-out/zcnm.o:
-	cp ../build-out/zcnm.o build-out/zcnm.o
+	ln -sf ../../build-out/zcnm.o build-out/zcnm.o
 
 build-out/zcnm31.o:
-	cp ../build-out/zcnm31.o build-out/zcnm31.o
+	ln -sf ../../build-out/zcnm31.o build-out/zcnm31.o
 
 build-out/zusf.o:
-	cp ../build-out/xlclang/zusf.o build-out/zusf.o
+	ln -sf ../../build-out/xlclang/zusf.o build-out/zusf.o
 
 build-out/zshmem.o:
-	cp ../build-out/zshmem.o build-out/zshmem.o
+	ln -sf ../../build-out/zshmem.o build-out/zshmem.o
 
 build-out/zbase64.test.o: zbase64.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zstd.test.o: zstd.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zstorage.test.o: zstorage.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zstorage.metal.test.s: zstorage.metal.test.c
-	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^
+	$(CC) $(MTL_FLAGS64) $(MTL_LIST_FLAG) $(MTL_HEADERS) -o $@ $^
 
 build-out/zstorage.metal.test.o: build-out/zstorage.metal.test.s
-	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+	$(ASM) $(ASM_FLAGS) $(ASM_LIST_FLAG) $(MACLIBS) -o $@ $^
 
 build-out/zut.test.o: zut.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zjb.test.o: zjb.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zds.test.o: zds.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zcn.test.o: zcn.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zrecovery.test.o: zrecovery.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zrecovery.metal.test.s: zrecovery.metal.test.c
-	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^
+	$(CC) $(MTL_FLAGS64) $(MTL_LIST_FLAG) $(MTL_HEADERS) -o $@ $^
 
 build-out/zrecovery.metal.test.o: build-out/zrecovery.metal.test.s
-	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+	$(ASM) $(ASM_FLAGS) $(ASM_LIST_FLAG) $(MACLIBS) -o $@ $^
 
 build-out/zmetal.test.o: zmetal.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zmetal.metal.test.s: zmetal.metal.test.c
-	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^
+	$(CC) $(MTL_FLAGS64) $(MTL_LIST_FLAG) $(MTL_HEADERS) -o $@ $^
 
 build-out/zmetal.metal.test.o: build-out/zmetal.metal.test.s
-	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+	$(ASM) $(ASM_FLAGS) $(ASM_LIST_FLAG) $(MACLIBS) -o $@ $^
 
 build-out/zusf.test.o: zusf.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zlogger.test.o: zlogger.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zlogger_metal.s: ../zlogger_metal.c
-	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^
+	$(CC) $(MTL_FLAGS64) $(MTL_LIST_FLAG) $(MTL_HEADERS) -o $@ $^
 
 build-out/zlogger_metal.o: build-out/zlogger_metal.s
-	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+	$(ASM) $(ASM_FLAGS) $(ASM_LIST_FLAG) $(MACLIBS) -o $@ $^
 
 build-out/zjson.test.o: zjson.test.cpp
-	$(OCXX) $(CXXLANG_FLAGS) -qlist=$*.cpp.lst -c $^ -o $@
+	$(OCXX) $(CXXLANG_FLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zjsonm.s: ../zjsonm.c
-	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^
+	$(CC) $(MTL_FLAGS64) $(MTL_LIST_FLAG) $(MTL_HEADERS) -o $@ $^
 
 build-out/zjsonm.o: build-out/zjsonm.s
-	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+	$(ASM) $(ASM_FLAGS) $(ASM_LIST_FLAG) $(MACLIBS) -o $@ $^
 
 # build-out/testrcvy.s: testrcvy.c
-# 	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -o $@ $^
+# 	$(CC) $(MTL_FLAGS64) $(MTL_LIST_FLAG) $(MTL_HEADERS) -o $@ $^
 
 # build-out/testrcvy.o: build-out/testrcvy.s
-# 	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+# 	$(ASM) $(ASM_FLAGS) $(ASM_LIST_FLAG) $(MACLIBS) -o $@ $^
 
 # build-out/testrcvy: build-out/testrcvy.o
 # 	$(BIND) $(BIND_FLAGS_64) -V -eMAIN -o $@ $^ > $*.bind.lst
 
 # build-out/testasm1.o: testasm1.s
-# 	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+# 	$(ASM) $(ASM_FLAGS) $(ASM_LIST_FLAG) $(MACLIBS) -o $@ $^
 
 # build-out/testasm1: build-out/testasm1.o
 # 	$(BIND) $(BIND_FLAGS_AUTH) -V -eTESTASM1 -o $@ $^ > $*.bind.lst
 
 # build-out/testasm4.o: testasm4.s
-# 	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+# 	$(ASM) $(ASM_FLAGS) $(ASM_LIST_FLAG) $(MACLIBS) -o $@ $^
 
 # build-out/testasm4: build-out/testasm4.o
 # 	$(BIND) $(BIND_FLAGS_64) -V -eTESTASM4 -o $@ $^ > $*.bind.lst
 
 # build-out/main.s: main.c
-# 	$(CC) $(MTL_FLAGS64) -qlist=$*.mtl.lst $(MTL_HEADERS) -I../chdsect -I../ -o $@ $^
+# 	$(CC) $(MTL_FLAGS64) $(MTL_LIST_FLAG) $(MTL_HEADERS) -I../chdsect -I../ -o $@ $^
 
 # build-out/main.o: build-out/main.s
-# 	$(ASM) $(ASM_FLAGS) -a=$*.s.lst $(MACLIBS) -o $@ $^
+# 	$(ASM) $(ASM_FLAGS) $(ASM_LIST_FLAG) $(MACLIBS) -o $@ $^
 
 # build-out/main: build-out/main.o
 # 	$(BIND) $(BIND_FLAGS_64) -V -eMAIN -o $@ $^ > $*.bind.lst


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
These changes should reduce the size of the `c/test/build-out` folder by a few hundred MB 😋 
* Disables generation of `.lst` files unless DEBUG flag is set
* Creates symlinks to `.o` files instead of copying them

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
