### PR TITLE
fix: Retry button should invoke `installServer/uninstallServer` again

### DIFF
--- a/packages/sdk/src/ZSshUtils.ts
+++ b/packages/sdk/src/ZSshUtils.ts
@@ -115,12 +115,11 @@ export class ZSshUtils {
                 Logger.getAppLogger().error(errMsg);
 
                 if (options?.onError) {
-                    const shouldContinue = await options.onError(new Error(errMsg), "upload");
-                    if (!shouldContinue) {
+                    const shouldRetry = await options.onError(new Error(errMsg), "upload");
+                    if (!shouldRetry) {
                         throw new Error(errMsg);
                     }
-                    // If shouldContinue is true, the error handler might have resolved the issue
-                    // or the user chose to continue despite the error
+                    return this.installServer(session, serverPath, localDir, options);
                 } else {
                     throw new Error(errMsg);
                 }

--- a/packages/sdk/src/ZSshUtils.ts
+++ b/packages/sdk/src/ZSshUtils.ts
@@ -177,6 +177,7 @@ export class ZSshUtils {
                     if (!shouldContinue) {
                         throw new Error(errMsg);
                     }
+                    return this.uninstallServer(session, serverPath, options);
                 } else {
                     throw new Error(errMsg);
                 }


### PR DESCRIPTION
**What It Does**

- Fixes an issue from #533 where the Retry button did not invoke `installServer` when server deployment fails OR `uninstallServer` when server uninstall fails

**How to Test**

Here's what I do to fill up a volume/dir to run out of free space:
- run `df -m ~` to see how much free space is left in your home dir
- then run `dd if=/dev/zero of=/your/home/dir/large_file.dat bs=1024576 count=X` where `X` is the number of available megabytes returned from `df -m ~`

_Install:_
- Deploy to a volume or directory where you don't have any free space; see the friendly error
- Make some free space and select "Retry"
- See that deployment succeeds and same progress bar is reused 😋 

_Uninstall:_
- Uninstall from a volume or directory where you don't have permission to delete; see the friendly error
- Get appropriate perms for the directory and select "Retry"
- See that uninstall succeeds 😋 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
