### PR TITLE
fix: same return value in both branches

### DIFF
--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -444,9 +444,7 @@ export abstract class AbstractConfigManager {
             }
 
             if (errorMessage.includes("Cannot parse privateKey: Malformed OpenSSH private key")) {
-                if (!(await this.handleInvalidPrivateKey(newConfig))) {
-                    return undefined;
-                }
+                await this.handleInvalidPrivateKey(newConfig);
                 return undefined;
             }
         }


### PR DESCRIPTION
**What It Does**

Fixes issue detected by static analysis tool where the same value was returned in both branches (true/false) of `if` statement

**How to Test**

Just build 😋 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)