### PR TITLE
Fix npm package script failing in Node 24

### DIFF
--- a/scripts/bundleCliTgz.js
+++ b/scripts/bundleCliTgz.js
@@ -25,7 +25,7 @@ try {
     execSync("npm install --ignore-scripts", execOptions);
 
     const sdkDir = path.join("node_modules", "zowe-native-proto-sdk");
-    fs.rmSync(path.join(tempDir, sdkDir), { recursive: true, force: true });
+    fs.unlinkSync(path.join(tempDir, sdkDir));
     fs.cpSync(fs.realpathSync(sdkDir), path.join(tempDir, sdkDir), { recursive: true });
     fs.rmSync(path.join(tempDir, "node_modules", "cpu-features"), { recursive: true, force: true });
     execSync(`npm pack --pack-destination=${outDir}`, execOptions);


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Use `fs.unlinkSync` instead of `fs.rmSync`, which seems to have broken for symlinked directories in Node.js 24.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
See that CI is passing 😋 

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
