### PR TITLE
Disable push trigger in zos-py-build workflow

### DIFF
--- a/.github/workflows/zos-py-build.yml
+++ b/.github/workflows/zos-py-build.yml
@@ -5,9 +5,9 @@ on:
     paths:
       - ".github/workflows/zos-py-build.yml"
       - "native/python/**"
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
   workflow_call:
     inputs:
       version:


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Currently all our pushes to main branch have a failing check because of the Python build workflow, which is expected to fail until https://github.com/zowe/zowe-native-proto/issues/381 is addressed and we have `swig` on the build system.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
