### PR TITLE
Skip fetching data set attributes for non-SSH profiles

### DIFF
--- a/packages/vsce/src/api/SshMvsApi.ts
+++ b/packages/vsce/src/api/SshMvsApi.ts
@@ -29,7 +29,11 @@ class SshAttributesProvider implements IAttributesProvider {
 
     public constructor(public cachedAttrs?: Dataset) {}
 
-    public fetchAttributes(_context: DsInfo): AttributeInfo {
+    public fetchAttributes(context: DsInfo): AttributeInfo {
+        if (context.profile.type !== "ssh") {
+            return [];
+        }
+
         const keys = new Map<string, AttributeEntryInfo>();
         const addAttribute = <K extends keyof Dataset>(prop: K, label: string, description?: string): void => {
             const value = this.cachedAttrs?.[prop];
@@ -51,6 +55,7 @@ class SshAttributesProvider implements IAttributesProvider {
         addAttribute("secondary", "Secondary Space", `Secondary space (${spacu})`);
         addAttribute("storclass", "Storage Class");
         addAttribute("usedx", "Used Extents");
+        this.cachedAttrs = undefined;
 
         return [{ title: this.extensionName, keys }];
     }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fix the ZNP VSCE returning attributes when "Show Attributes" command is invoked in ZE for other profile types like z/OSMF.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
In Zowe Explorer, list attributes first for a dataset first using an SSH profile, then using an z/OSMF profile and verify that SSH attributes are cleared out.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
