### PR TITLE
Fix profile validation hanging after deployment error

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Updated error handling to format request timeout errors. When a timeout error is received, the request is cancelled and the user receives a notification with context of where the error occurred. [#416](https://github.com/zowe/zowe-native-proto/issues/416)
 - When listing data sets with attributes, a comprehensive set is now retrieved that is similar to what ISPF displays. [#629](https://github.com/zowe/zowe-native-proto/issues/629)
+- Fixed profile validation hanging after deployment error. [#691](https://github.com/zowe/zowe-native-proto/pull/691)
 
 ## `0.2.0`
 

--- a/packages/vsce/src/api/SshCommonApi.ts
+++ b/packages/vsce/src/api/SshCommonApi.ts
@@ -97,7 +97,7 @@ export class SshCommonApi implements MainframeInteraction.ICommon {
                         }
                     }
                 } else {
-                    await SshErrorHandler.getInstance().handleError(
+                    void SshErrorHandler.getInstance().handleError(
                         err as Error,
                         ZoweExplorerApiType.All,
                         "SSH connection status check failed",


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes an issue related to #683 - we may still want to add a timeout in the future 😋 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
* Check out the `main` branch
* Set `serverPath` in SSH profile to invalid path with non-existent parent directory
* Validate the profile by attempting to use it in ZE tree
* Notice that deployment fails (expected) but validation progress bar doesn't stop
* Switch to this PR's branch
* Test again and see that progress bar stops and profile validation returns error

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
