### PR TITLE
Improve Metal C handling in watch task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,29 +20,50 @@
     {
       "type": "npm",
       "script": "z:watch",
-      "problemMatcher": {
-        "owner": "custom",
-        "fileLocation": ["search", { "include": ["${workspaceFolder}/native"] }],
-        "pattern": [
-          {
-            "regexp": "(?:error:)"
-          },
-          {
-            "regexp": "^\"\\./(.+)\", line (\\d+)\\.(\\d+): (\\w+\\d+) \\((.)\\) (.+)$",
-            "file": 1,
-            "line": 2,
-            "column": 3,
-            "code": 4,
-            "severity": 5,
-            "message": 6
+      "problemMatcher": [
+        {
+          "owner": "zos-cpp",
+          "fileLocation": ["search", { "include": ["${workspaceFolder}/native"] }],
+          "pattern": [
+            {
+              "regexp": "(?:error:)"
+            },
+            {
+              "regexp": "^\"\\./(.+)\", line (\\d+)\\.(\\d+): (\\w+\\d+) \\((.)\\) (.+)$",
+              "file": 1,
+              "line": 2,
+              "column": 3,
+              "code": 4,
+              "severity": 5,
+              "message": 6
+            }
+          ],
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "^\\d{1,2}/\\d{1,2}/\\d{4}, \\d{1,2}:\\d{2}:\\d{2} (?:AM|PM) \\[.\\]\\s",
+            "endsPattern": "^\\d{1,2}/\\d{1,2}/\\d{4}, \\d{1,2}:\\d{2}:\\d{2} (?:AM|PM) watching for changes\\.\\.\\."
           }
-        ],
-        "background": {
-          "activeOnStart": true,
-          "beginsPattern": "^\\d{1,2}/\\d{1,2}/\\d{4}, \\d{1,2}:\\d{2}:\\d{2} (?:AM|PM) \\[.\\]\\s",
-          "endsPattern": "^\\d{1,2}/\\d{1,2}/\\d{4}, \\d{1,2}:\\d{2}:\\d{2} (?:AM|PM) watching for changes\\.\\.\\."
+        },
+        {
+          "owner": "zos-metal",
+          "severity": "error",
+          "fileLocation": ["search", { "include": ["${workspaceFolder}/native"] }],
+          "pattern": [
+            {
+              "regexp": "^ERROR (\\w+) ./(.+):(\\d+)\\s+(.+)\\.",
+              "file": 2,
+              "line": 3,
+              "code": 1,
+              "message": 4
+            }
+          ],
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "^\\d{1,2}/\\d{1,2}/\\d{4}, \\d{1,2}:\\d{2}:\\d{2} (?:AM|PM) \\[.\\]\\s",
+            "endsPattern": "^\\d{1,2}/\\d{1,2}/\\d{4}, \\d{1,2}:\\d{2}:\\d{2} (?:AM|PM) watching for changes\\.\\.\\."
+          }
         }
-      },
+      ],
       "isBackground": true,
       "presentation": {
         "reveal": "always"

--- a/native/zowed/makefile
+++ b/native/zowed/makefile
@@ -45,7 +45,7 @@ $(OUT_DIR):
 	mkdir -p $(OUT_DIR)/commands
 
 # Build the shared library (.so file)
-$(OUT_DIR)/$(LIBRARY): $(OUT_DIR) $(LIB_OBJECTS) $(CMDS_OBJECTS) $(XLCLANG_OBJECTS) $(OUT_DIR)/zjsonm.o
+$(OUT_DIR)/$(LIBRARY): $(OUT_DIR) $(LIB_OBJECTS) $(CMDS_OBJECTS) $(XLCLANG_OBJECTS) $(METAL_OBJECTS) $(OUT_DIR)/zjsonm.o
 	$(CXX_LIB) $(DLL_BND_FLAGS) -o $(OUT_DIR)/$(LIBRARY) $(LIB_OBJECTS) $(CMDS_OBJECTS) \
 	$(XLCLANG_OBJECTS) $(METAL_OBJECTS) $(OUT_DIR)/zjsonm.o > $(OUT_DIR)/libzowed.bind.lst
 

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -272,7 +272,7 @@ class WatchUtils {
         if (cSourceChanged) {
             result = await this.makeTask();
         }
-        if (zowedSourceChanged || typeof result === "string") {
+        if (zowedSourceChanged || typeof result === "string" || result === 0) {
             await this.makeTask(deployDirs.zowedDir);
         }
     }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
* Fixes VS Code problem matcher not detecting Metal C build errors
* Fixes edits to Metal C not triggering `zowed` binary to rebuild

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run `z:watch` task in VS Code, then edit a Metal C file like `zjbm.c` and verify that `zowed` binary is rebuilt.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
