### PR TITLE
fix(zowed): Allow unknown fields for request validation

### DIFF
--- a/native/zowed/builder.hpp
+++ b/native/zowed/builder.hpp
@@ -122,15 +122,16 @@ public:
 
   // Validate both request and response using separate schemas
   template <typename RequestT, typename ResponseT>
-  CommandBuilder &validate(bool allow_unknown_fields = false)
+  CommandBuilder &validate()
   {
-    request_validator_ = [allow_unknown_fields](const zjson::Value &params) -> validator::ValidationResult
+    // Allow unknown fields in requests for forward compatibility but not in responses
+    request_validator_ = [](const zjson::Value &params) -> validator::ValidationResult
     {
-      return validator::validate_schema(params, validator::SchemaRegistry<RequestT>::fields, validator::SchemaRegistry<RequestT>::field_count, allow_unknown_fields);
+      return validator::validate_schema(params, validator::SchemaRegistry<RequestT>::fields, validator::SchemaRegistry<RequestT>::field_count, true);
     };
-    response_validator_ = [allow_unknown_fields](const zjson::Value &params) -> validator::ValidationResult
+    response_validator_ = [](const zjson::Value &params) -> validator::ValidationResult
     {
-      return validator::validate_schema(params, validator::SchemaRegistry<ResponseT>::fields, validator::SchemaRegistry<ResponseT>::field_count, allow_unknown_fields);
+      return validator::validate_schema(params, validator::SchemaRegistry<ResponseT>::fields, validator::SchemaRegistry<ResponseT>::field_count, false);
     };
     return *this;
   }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Allow unknown fields in JSON request objects, to support the following scenario:
* Version X of the backend is installed on z/OS
* Version Y (`>X`) of the VSCE is installed locally
* If the VSCE provides a new optional field that the backend does not support, this should be ignored/allowed.

Thanks @awharn for suggesting this 😋 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Launch `zowed` and test a JsonRPC command with extra field like the following:
`{"jsonrpc":"2.0","id":1,"method":"listDatasets","params":{"pattern":"SYS1.PARMLIB","animal":"doggo"}}`

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
