### PR TITLE
chore(workflows): add `workflow-dispatch` to `zos-build.yml`

### DIFF
--- a/.github/workflows/zos-build.yml
+++ b/.github/workflows/zos-build.yml
@@ -20,6 +20,7 @@ on:
         required: true
       SSH_MARIST_USERNAME:
         required: true
+  workflow_dispatch:
 
 permissions:
   checks: write


### PR DESCRIPTION
**What It Does**

Adds `workflow-dispatch` to `zos-build.yml` to allow developers to run the z/OS build action against branches that don't yet have an open PR.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)