### PR TITLE
fix: use `awk` in `gen_chdsect.sh`

### DIFF
--- a/native/asmchdr/gen_chdsect.sh
+++ b/native/asmchdr/gen_chdsect.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
+set -e
 printf "\n"
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+export PATH="$script_dir/../c/build-out:$PATH"
 
 echo "Setting required env vars..."
 printf "\n"
@@ -58,9 +62,24 @@ echo "Conversion completed."
 printf "\n"
 
 echo "Adding #ifdef for ibm-clang vs legacy pragma syntax..."
-sed -i \
-  's/#pragma pack(packed)/#ifdef __open_xl__\n#pragma pack(1)\n#else\n#pragma pack(packed)\n#endif/g; s/#pragma pack(reset)/#ifdef __open_xl__\n#pragma pack()\n#else\n#pragma pack(reset)\n#endif/g' \
-  build-out/$filename_no_ext.h
+awk '{
+  if ($0 ~ /#pragma pack\(packed\)/) {
+    print "#ifdef __open_xl__"
+    print "#pragma pack(1)"
+    print "#else"
+    print "#pragma pack(packed)"
+    print "#endif"
+  } else if ($0 ~ /#pragma pack\(reset\)/) {
+    print "#ifdef __open_xl__"
+    print "#pragma pack()"
+    print "#else"
+    print "#pragma pack(reset)"
+    print "#endif"
+  } else {
+    print $0
+  }
+}' build-out/$filename_no_ext.h > build-out/$filename_no_ext.h.tmp && \
+  mv build-out/$filename_no_ext.h.tmp build-out/$filename_no_ext.h
 echo "Pragma ifdef replacement completed."
 printf "\n"
 


### PR DESCRIPTION
**What It Does**

The `gen_chdsect.sh` script was using GNU extensions of `sed`, which is not supported by the version available on z/OS.
This PR refactors the script to use `awk` instead, and adds `set -e` to make the script stop on the first failure.

**How to Test**

- Checkout this branch and `npm run z:delete`
- `npm run z:rebuild`
- `npm run z:chdsect cvt.s` should succeed w/o errors

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)