### PR TITLE
fix(test/zowex/ds): more missing std prefixes

### DIFF
--- a/native/c/test/zowex.ds.test.cpp
+++ b/native/c/test/zowex.ds.test.cpp
@@ -833,12 +833,12 @@ void zowex_ds_tests()
                         it("should return ISPF statistics attributes when listing members with attributes",
                            [&]() -> void
                            {
-                             string ds = get_random_ds();
+                             auto ds = get_random_ds();
                              _ds.push_back(ds);
 
                              _create_ds(ds, "--dsorg PO --dirblk 2");
 
-                             string response;
+                             std::string response;
 
                              execute_command_with_output(
                                  zowex_command + " data-set create-member '" + ds + "(STAT1)'",
@@ -847,7 +847,7 @@ void zowex_ds_tests()
                              execute_command_with_output(
                                  "echo \"TEST\" | " + zowex_command + " data-set write '" + ds + "(STAT1)'",
                                  response);
-                             string command = zowex_command + " data-set lm " + ds + " --attributes";
+                             std::string command = zowex_command + " data-set lm " + ds + " --attributes";
 
                              int rc = execute_command_with_output(command, response);
 


### PR DESCRIPTION
**What It Does**

b6b5eeffa0c0a9139ccc914e0d9d773b8444ba77 was merged w/o the `std::` prefix on `string`, see line 836, 841, and 850 of `zowex.ds.test.cpp`

This causes `npm run z:test` to fail after building latest `main` changes on an internal system. Adding the prefix allows the tests to build and run w/o errors.

**How to Test**

- Checkout this branch, `npm run z:delete`
- `npm run z:rebuild` and `npm run z:test` should pass w/o errors or failing tests 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)