### PR TITLE
fix(buildTools): fix error in `test` script from partial merge

### DIFF
--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -1277,9 +1277,7 @@ async function make(connection: Client, inDir?: string) {
 
 async function test(connection: Client) {
     const cTestCmd = `cd ${deployDirs.cTestDir} && ./build-out/ztest_runner ${args[1] ?? ""}`;
-    const zowedTestCmd = `cd ${path.posix.relative(deployDirs.cTestDir, deployDirs.zowedTestDir)} && ${testEnv} ./build-out/zowed_test_runner ${args[1] ?? ""}`;
-    const exitMaxRc = `[ "$rc1" -gt "$rc2" ] && exit "$rc1" || exit "$rc2"`;
-    await runCommandInShell(connection, `${cTestCmd}; rc1=$?; ${zowedTestCmd}; rc2=$?; ${exitMaxRc}\n`, {
+    await runCommandInShell(connection, `${cTestCmd}\n`, {
         streamOutput: true,
         stepName: "Running tests",
     });


### PR DESCRIPTION
**What It Does**

Fixes issue with `test` script in `buildTools.ts` from a partial merge between `zowex server` changes and recent PRs

**How to Test**

- `npm run z:delete && npm run z:rebuild && npm run z:test` should succeed w/o any unexpected client-side failures from the build tool

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
