### PR TITLE
chore: update undici version in shrinkwrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10767,8 +10767,8 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.1",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
**What It Does**

Updates transitive dev dependency `undici` to 6.24.1, resolving 3 related Dependabot alerts and a high severity vulnerability in `npm audit`.

**How to Test**

`npm install && npm run build` should succeed w/o errors

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)