### PR TITLE
chore: add repro section to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,16 @@ labels: bug
 
 <!-- A clear and concise description of the bug or error. -->
 
+**To Reproduce**
+
+<!--
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
 **Expected and actual results**
 
 <!--
@@ -20,8 +30,8 @@ Details about the behavior:
 2. Expected results:
 3. Actual results:
 4. Applicable log files:
-
 -->
+
 **Describe your environment**
 
 <!--


### PR DESCRIPTION
**What It Does**

Thanks @pujal0909 for the suggestion

Adds "To Reproduce" section to template for new bug reports

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)