### PR TITLE
test(zowex): Detect active PDSMAN jobs with suffix

### DIFF
--- a/native/c/test/zowex.ds.test.cpp
+++ b/native/c/test/zowex.ds.test.cpp
@@ -109,7 +109,7 @@ void zowex_ds_tests()
                             [&]() -> void
                             {
                               std::string response;
-                              int rc = execute_command_with_output(zowex_command + " job ls --owner \"*\" --prefix PDSMAN --status ACTIVE", response);
+                              int rc = execute_command_with_output(zowex_command + " job ls --owner \"*\" --prefix \"PDSMAN*\" --status ACTIVE", response);
                               if (rc == 0)
                               {
                                 is_pdsman_active = response.find("PDSMAN") != std::string::npos;


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Follow up to #876 to skip the "should compress data set" test on systems where job name is `PDSMANx`.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
