### PR TITLE
chore: update lodash version in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6319,8 +6319,8 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-deep": {


### PR DESCRIPTION
**What It Does**

Updates `lodash` version in the package lock to avoid the recent vulnerability.

**How to Test**

- `npm install` should succeed without warning about high-severity vulnerabilities

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)