### PR TITLE
Update --version and -v to provide a lighter version output.

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Changed `zowex --version` and `zowex -v` to return just the version number. [#925](https://github.com/zowe/zowe-native-proto/pull/925)
 - `c`: Removed duplicate `-v` and `--version` aliases on the `zowex version` command. [#922](https://github.com/zowe/zowe-native-proto/pull/922)
 - `c`: Added the `getInfo` RPC to retrieve the middleware version and build information. [#922](https://github.com/zowe/zowe-native-proto/pull/922)
 

--- a/native/c/commands/core.cpp
+++ b/native/c/commands/core.cpp
@@ -108,6 +108,12 @@ int handle_version(plugin::InvocationContext &context)
   return 0;
 }
 
+int handle_version_simple(plugin::InvocationContext &context)
+{
+  context.output_stream() << g_version << std::endl;
+  return 0;
+}
+
 int handle_plugins_list(plugin::InvocationContext &context)
 {
   std::ostream &out = context.output_stream();
@@ -175,7 +181,7 @@ int handle_command(plugin::InvocationContext &context)
   const auto is_interactive = context.get<bool>("interactive", false);
   if (context.get<bool>("version", false))
   {
-    const auto version_rc = handle_version(context);
+    const auto version_rc = handle_version_simple(context);
     if (!is_interactive)
     {
       return version_rc;

--- a/native/c/test/zowex.test.cpp
+++ b/native/c/test/zowex.test.cpp
@@ -35,11 +35,52 @@ void zowex_tests()
                 {
                   int rc = 0;
                   std::string response;
-                  rc = execute_command_with_output(zowex_command + " --version", response);
+                  rc = execute_command_with_output(zowex_command + " version", response);
                   ExpectWithContext(rc, response).ToBe(0);
                   Expect(response).ToContain("zowex");
-                  Expect(response).ToContain("Version");
+                  Expect(response).ToContain("Version:");
+
+                  // Version information
+                  static const std::regex rev(R"(Version:\s*(\S+))");
+                  std::smatch mv;
+
+                  Expect(std::regex_search(response, mv, rev)).ToBe(true);
+                  const std::string version = mv[1].str();
+
+                  Expect(version.length()).ToBeGreaterThanOrEqualTo(5); // X.X.X at minimum
+
+                  Expect(response).ToContain("Build Date:");
+
+                  // Build date information
+                  static const std::regex red(R"(Build Date:\s*([^\r\n]+))");
+                  std::smatch md;
+
+                  Expect(std::regex_search(response, md, red)).ToBe(true);
+                  const std::string buildDate = md[1].str();
+
+                  Expect(buildDate.length()).ToBeGreaterThanOrEqualTo(11); // MMM DD YYYY at minimum
+
                   Expect(response).Not().ToContain("unknown");
+                });
+             it("should list a short version of the tool",
+                []() -> void
+                {
+                  int rc = 0;
+                  std::string response;
+                  rc = execute_command_with_output(zowex_command + " --version", response);
+                  ExpectWithContext(rc, response).ToBe(0);
+                  Expect(response).Not().ToContain("zowex");
+                  Expect(response).Not().ToContain("Version");
+                  Expect(response).Not().ToContain("Build Date");
+                  Expect(response).Not().ToContain("unknown");
+
+                  static const std::regex rev(R"(^\s*(\d+\.\d+\.\d+)(?:[-+][^\r\n]*)?\s*$)");
+                  std::smatch mv;
+
+                  Expect(std::regex_search(response, mv, rev)).ToBe(true);
+                  const std::string version = mv[1].str();
+
+                  Expect(version.length()).ToBeGreaterThanOrEqualTo(5); // X.X.X at minimum
                 });
 #ifdef RELEASE_BUILD
              it("should remain less than 10mb in size",


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Alters the behavior of `zowex -v` and `zowex --version` to only output the version number.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run the relevant commands

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
