### PR TITLE
fix(vsce): Don't swallow errors for createDataset

### DIFF
--- a/native/c/zjb.cpp
+++ b/native/c/zjb.cpp
@@ -8,6 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  *
  */
+
 #include <sstream>
 #include <string>
 #include <cstring>

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "zowex-vsce" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- Fixed error handling of methods in `SshMvsApi` class so that errors are thrown and propagated to extenders. [#917](https://github.com/zowe/zowex/issues/917)
+
 ## `0.5.0`
 
 - **Breaking:** Renamed contributed setting IDs from `zowe-native-proto` to `zowex`. All references to `zowe-native-proto` should be replaced with `zowex` in VS Code `settings.json` files. [#831](https://github.com/zowe/zowex/issues/831)

--- a/packages/vsce/src/api/SshCommonApi.ts
+++ b/packages/vsce/src/api/SshCommonApi.ts
@@ -180,4 +180,13 @@ export class SshCommonApi implements MainframeInteraction.ICommon {
         // All attempts failed
         return undefined;
     }
+
+    /**
+     * Converts an `ImperativeError` to a plain JS error to avoid losing additional details
+     * @param maybeError The thrown error to convert
+     */
+    protected buildRequestError(maybeError: unknown): Error | unknown {
+        if (!(maybeError instanceof ImperativeError)) return maybeError;
+        return new Error(`${maybeError.message}\n${maybeError.additionalDetails}`);
+    }
 }

--- a/packages/vsce/src/api/SshMvsApi.ts
+++ b/packages/vsce/src/api/SshMvsApi.ts
@@ -17,7 +17,6 @@ import {
     type AttributeInfo,
     type DataSetAttributesProvider,
     type DsInfo,
-    Gui,
     type IAttributesProvider,
     imperative,
     type MainframeInteraction,
@@ -285,9 +284,9 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
                 attributes: datasetAttributes,
             });
         } catch (error) {
-            if (error instanceof imperative.ImperativeError) {
-                Gui.errorMessage(error.additionalDetails);
-            }
+            throw error instanceof imperative.ImperativeError
+                ? new Error(`${error.message}\n${error.additionalDetails}`)
+                : error;
         }
         return this.buildZosFilesResponse(response, response.success);
     }
@@ -296,19 +295,10 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         dataSetName: string,
         _options?: zosfiles.IUploadOptions,
     ): Promise<zosfiles.IZosFilesResponse> {
-        let response: ds.CreateMemberResponse = { success: false };
-        try {
-            response = await (await this.client).ds.createMember({
-                dsname: dataSetName,
-                overwrite: true, // Overwrite detection already handled on client side
-            });
-            if (!response.success) {
-                Gui.errorMessage(`Failed to create data set member: ${dataSetName}`);
-            }
-        } catch (error) {
-            Gui.errorMessage(`Failed to create data set member: ${dataSetName}`);
-            Gui.errorMessage(`Error: ${error}`);
-        }
+        const response = await (await this.client).ds.createMember({
+            dsname: dataSetName,
+            overwrite: true, // Overwrite detection already handled on client side
+        });
         return this.buildZosFilesResponse(response, response.success);
     }
 
@@ -335,9 +325,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
             dsnameBefore: currentDataSetName,
             dsnameAfter: newDataSetName,
         });
-        return this.buildZosFilesResponse({
-            success: response.success,
-        });
+        return this.buildZosFilesResponse(response, response.success);
     }
 
     public async renameDataSetMember(
@@ -350,9 +338,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
             memberBefore,
             memberAfter,
         });
-        return this.buildZosFilesResponse({
-            success: response.success,
-        });
+        return this.buildZosFilesResponse(response, response.success);
     }
 
     public async hMigrateDataSet(_dataSetName: string): Promise<zosfiles.IZosFilesResponse> {
@@ -360,19 +346,10 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
     }
 
     public async hRecallDataSet(dataSetName: string): Promise<zosfiles.IZosFilesResponse> {
-        let response: ds.RestoreDatasetResponse = { success: false };
-        try {
-            response = await (await this.client).ds.restoreDataset({
-                dsname: dataSetName,
-            });
-            if (!response.success) {
-                Gui.errorMessage(`Failed to restore dataset ${dataSetName}`);
-            }
-        } catch (error) {
-            Gui.errorMessage(`Failed to restore dataset ${dataSetName}`);
-            Gui.errorMessage(`Error: ${error}`);
-        }
-        return this.buildZosFilesResponse(response);
+        const response = await (await this.client).ds.restoreDataset({
+            dsname: dataSetName,
+        });
+        return this.buildZosFilesResponse(response, response.success);
     }
 
     public async deleteDataSet(
@@ -382,9 +359,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         const response = await (await this.client).ds.deleteDataset({
             dsname: dataSetName,
         });
-        return this.buildZosFilesResponse({
-            success: response.success,
-        });
+        return this.buildZosFilesResponse(response, response.success);
     }
 
     // biome-ignore lint/suspicious/noExplicitAny: apiResponse has no strong type

--- a/packages/vsce/src/api/SshMvsApi.ts
+++ b/packages/vsce/src/api/SshMvsApi.ts
@@ -284,11 +284,9 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
                 attributes: datasetAttributes,
             });
         } catch (error) {
-            throw error instanceof imperative.ImperativeError
-                ? new Error(`${error.message}\n${error.additionalDetails}`)
-                : error;
+            throw this.buildRequestError(error);
         }
-        return this.buildZosFilesResponse(response, response.success);
+        return this.buildZosFilesResponse(response);
     }
 
     public async createDataSetMember(
@@ -299,7 +297,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
             dsname: dataSetName,
             overwrite: true, // Overwrite detection already handled on client side
         });
-        return this.buildZosFilesResponse(response, response.success);
+        return this.buildZosFilesResponse(response);
     }
 
     public async allocateLikeDataSet(
@@ -325,7 +323,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
             dsnameBefore: currentDataSetName,
             dsnameAfter: newDataSetName,
         });
-        return this.buildZosFilesResponse(response, response.success);
+        return this.buildZosFilesResponse(response);
     }
 
     public async renameDataSetMember(
@@ -338,7 +336,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
             memberBefore,
             memberAfter,
         });
-        return this.buildZosFilesResponse(response, response.success);
+        return this.buildZosFilesResponse(response);
     }
 
     public async hMigrateDataSet(_dataSetName: string): Promise<zosfiles.IZosFilesResponse> {
@@ -349,7 +347,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         const response = await (await this.client).ds.restoreDataset({
             dsname: dataSetName,
         });
-        return this.buildZosFilesResponse(response, response.success);
+        return this.buildZosFilesResponse(response);
     }
 
     public async deleteDataSet(
@@ -359,11 +357,11 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         const response = await (await this.client).ds.deleteDataset({
             dsname: dataSetName,
         });
-        return this.buildZosFilesResponse(response, response.success);
+        return this.buildZosFilesResponse(response);
     }
 
     // biome-ignore lint/suspicious/noExplicitAny: apiResponse has no strong type
     private buildZosFilesResponse(apiResponse: any, success = true, errorText?: string): zosfiles.IZosFilesResponse {
-        return { apiResponse, commandResponse: "", success, errorMessage: errorText };
+        return { apiResponse, commandResponse: "", success: apiResponse?.success ?? success, errorMessage: errorText };
     }
 }

--- a/packages/vsce/src/api/SshUssApi.ts
+++ b/packages/vsce/src/api/SshUssApi.ts
@@ -130,7 +130,7 @@ export class SshUssApi extends SshCommonApi implements MainframeInteraction.IUss
             force: force,
         });
 
-        return Buffer.from(JSON.stringify(this.buildZosFilesResponse(response, response.success)));
+        return Buffer.from(JSON.stringify(this.buildZosFilesResponse(response)));
     }
 
     public async create(ussPath: string, type: string, mode?: string | undefined): Promise<zosfiles.IZosFilesResponse> {
@@ -139,7 +139,7 @@ export class SshUssApi extends SshCommonApi implements MainframeInteraction.IUss
             isDir: type === "directory",
             permissions: mode,
         });
-        return this.buildZosFilesResponse(response, response.success);
+        return this.buildZosFilesResponse(response);
     }
 
     public async delete(ussPath: string, recursive?: boolean | undefined): Promise<zosfiles.IZosFilesResponse> {
@@ -147,7 +147,7 @@ export class SshUssApi extends SshCommonApi implements MainframeInteraction.IUss
             fspath: ussPath,
             recursive: recursive,
         });
-        return this.buildZosFilesResponse(response, response.success);
+        return this.buildZosFilesResponse(response);
     }
 
     public async move(oldPath: string, newPath: string): Promise<void> {
@@ -162,7 +162,7 @@ export class SshUssApi extends SshCommonApi implements MainframeInteraction.IUss
             source: currentUssPath,
             target: newUssPath,
         });
-        return this.buildZosFilesResponse(response, response.success);
+        return this.buildZosFilesResponse(response);
     }
 
     public async getTag(ussPath: string): Promise<string> {
@@ -217,6 +217,6 @@ export class SshUssApi extends SshCommonApi implements MainframeInteraction.IUss
 
     // biome-ignore lint/suspicious/noExplicitAny: The apiResponse has no strong type
     private buildZosFilesResponse(apiResponse: any, success = true): zosfiles.IZosFilesResponse {
-        return { apiResponse, commandResponse: "", success };
+        return { apiResponse, commandResponse: "", success: apiResponse?.success ?? success };
     }
 }


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #917 - note that some DS operations now show 2 error messages instead of 1, but this is consistent with how other APIs behave and should be resolved once ZRS is merged into ZE.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
