### PR TITLE
fix: Workaround S0C4

### DIFF
--- a/native/c/test/zowex.ds.test.cpp
+++ b/native/c/test/zowex.ds.test.cpp
@@ -101,20 +101,9 @@ void zowex_ds_tests()
                   Expect(response).ToContain("view");
                   Expect(response).ToContain("write"); });
 
-             bool is_pdsman_active = false;
              describe("compress",
                       [&]() -> void
                       {
-                        beforeAll(
-                            [&]() -> void
-                            {
-                              std::string response;
-                              int rc = execute_command_with_output(zowex_command + " job ls --owner \"*\" --prefix \"PDSMAN*\" --status ACTIVE", response);
-                              if (rc == 0)
-                              {
-                                is_pdsman_active = response.find("PDSMAN") != std::string::npos;
-                              }
-                            });
                         beforeEach(
                             [&]() -> void
                             {
@@ -157,10 +146,10 @@ void zowex_ds_tests()
                              Expect(response).ToContain("Error: data set '" + ds + "' is not a PDS");
                            });
 
-                        // TODO: Unskip test once incompatibility with PDSMAN is resolved
+                        // NOTE: This test may fail if we don't save/clear/restore registers for PDSMAN/IEBCOPY
                         // See https://github.com/zowe/zowe-native-proto/issues/790
-                        itif("should compress a data set", [&]() -> void
-                             {
+                        it("should compress a data set", [&]() -> void
+                           {
                              std::string ds = _ds.back();
                              _create_ds(ds, "--dsorg PO --dirblk 2");
 
@@ -169,7 +158,7 @@ void zowex_ds_tests()
                              int rc = execute_command_with_output(command, response);
                              ExpectWithContext(rc, response).ToBe(0);
                              Expect(response).ToContain("Data set");
-                             Expect(response).ToContain("compressed"); }, !is_pdsman_active);
+                             Expect(response).ToContain("compressed"); });
 
                         // TODO: https://github.com/zowe/zowe-native-proto/issues/666
                         xit("should error when the data set is VSAM", []() -> void {});

--- a/native/c/zmetal.h
+++ b/native/c/zmetal.h
@@ -338,7 +338,7 @@ static void *PTR64 load_module(const char *name)
 
   auth_off(); // NOTE(Kelosky): force auth off before loading any module
 
-  unsigned char save_registers[88] = {0}; // Save all 8 bytes of registers 2-13 for PDSMAN/IEBCOPY
+  unsigned long long save_registers[11] = {0}; // Save 8 bytes for each register 2-13 for PDSMAN/IEBCOPY
   LOAD(name_truncated, ep, rc, rsn, save_registers[0]);
   if (0 != rc)
   {

--- a/native/c/zmetal.h
+++ b/native/c/zmetal.h
@@ -106,12 +106,17 @@ static int test_auth()
 #endif
 
 #if defined(__IBM_METAL__)
-#define LOAD(name, ep, rc, rsn)                                 \
+#define LOAD(name, ep, rc, rsn, save_regs)                      \
   __asm(                                                        \
       "*                                                    \n" \
-      " SLGR  2,2          Clear for PDSMAN/IEBCOPY         \n" \
+      "* This can be removed for testing S0C4 on compress   \n" \
+      "* Store registers for PDSMAN/IEBCOPY into save_high  \n" \
+      " STMG  2,13,%3      Store for PDSMAN/IEBCOPY         \n" \
       "*                                                    \n" \
-      " LOAD EPLOC=%3,"                                         \
+      "* Clear high-half of registers 2-15 for PDSMAN       \n" \
+      " LMH   2,15,=16F'0' Clear for PDSMAN/IEBCOPY         \n" \
+      "*                                                    \n" \
+      " LOAD EPLOC=%4,"                                         \
       "PLISTVER=MAX,"                                           \
       "ERRET=*+4+6+4+4+4                                    \n" \
       "*                                                    \n" \
@@ -124,14 +129,19 @@ static int test_auth()
       " STG 0,%0           Zero                             \n" \
       " ST 1,%1            r1 = rc                          \n" \
       " ST 15,%2           r15 = rsn                        \n" \
+      "*                                                    \n" \
+      "* Restore saved registers from save_regs             \n" \
+      " LMG   2,13,%3      Restore for PDSMAN/IEBCOPY       \n" \
+      "*                                                    \n" \
       "*                                                      " \
       : "=m"(ep),                                               \
         "=m"(rc),                                               \
-        "=m"(rsn)                                               \
+        "=m"(rsn),                                              \
+        "=m"(save_regs)                                         \
       : "m"(name)                                               \
       : "r0", "r1", "r2", "r14", "r15");
 #else
-#define LOAD(name, ep, rc, rsn)
+#define LOAD(name, ep, rc, rsn, save_regs)
 #endif
 
 #if defined(__IBM_METAL__)
@@ -328,7 +338,8 @@ static void *PTR64 load_module(const char *name)
 
   auth_off(); // NOTE(Kelosky): force auth off before loading any module
 
-  LOAD(name_truncated, ep, rc, rsn);
+  unsigned char save_registers[88] = {0}; // Save all 8 bytes of registers 2-13 for PDSMAN/IEBCOPY
+  LOAD(name_truncated, ep, rc, rsn, save_registers[0]);
   if (0 != rc)
   {
     return NULL;


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

- Store entire (64 bits) registers 2-13
- Clears the high-half (bit: 0-31) of registers 2-15
- Restores entire (64 bits) registers 2-13 back to their original state

<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
**Reproducing the bug:**
- Comment out the clearing of the high-half to see  the `S0C4`
  - <img width="532" height="72" alt="image" src="https://github.com/user-attachments/assets/644b53ef-243e-4861-9295-68bfcde4bf92" />
- `npm run z:upload c/zutm.c z/zmetal.h`
- SSH-ed in: `cd <znp-dir>/c && make && ./build-out/zowex ds compress <HLQ>.TEST.PDS`
<img width="845" height="85" alt="image" src="https://github.com/user-attachments/assets/5002c275-f2c1-4a2a-8893-4319e5e232bc" />

**Testing the fix:**
- Uncomment the clearing of the high-half
  - <img width="525" height="72" alt="image" src="https://github.com/user-attachments/assets/0daaa7c4-83e4-403f-86a1-fe2b1446eac8" />
- `npm run z:upload c/zutm.c z/zmetal.h`
- SSH-ed in: `cd <znp-dir>/c && make && ./build-out/zowex ds compress <HLQ>.TEST.PDS`
<img width="362" height="32" alt="image" src="https://github.com/user-attachments/assets/890768ed-c636-41d3-9bc8-92077a1c43e2" />


**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
