### PR TITLE
chore: Rename "Zowe Native Proto" to "Zowe Remote SSH", "zowex"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: bug
 
 <!-- Thanks for deciding to open an issue. Before submitting, please see the following information. -->
 
-<!-- Before opening a new issue, please search our existing issues: https://github.com/zowe/zowe-native-proto/issues -->
+<!-- Before opening a new issue, please search our existing issues: https://github.com/zowe/zowex/issues -->
 
 **Describe the bug**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for Zowe Native Protocol
+about: Suggest an idea for Zowe Remote SSH
 labels: enhancement
 ---
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,22 +58,22 @@ jobs:
         id: cli-artifact-upload
         if: ${{ matrix.os == 'ubuntu' }}
         with:
-          name: zowe-native-proto-cli
-          path: dist/zowe-native-proto-cli-*.tgz
+          name: zowex-cli
+          path: dist/zowex-cli-*.tgz
 
       - uses: actions/upload-artifact@v4
         id: vsce-artifact-upload
         if: ${{ matrix.os == 'ubuntu' }}
         with:
-          name: zowe-native-proto-vsce
+          name: zowex-vsce
           path: dist/*.vsix
 
       - uses: actions/upload-artifact@v4
         id: sdk-artifact-upload
         if: ${{ matrix.os == 'ubuntu' }}
         with:
-          name: zowe-native-proto-sdk
-          path: dist/zowe-native-proto-sdk-*.tgz
+          name: zowex-sdk
+          path: dist/zowex-sdk-*.tgz
 
       - name: Comment on PR
         if: ${{ github.event_name == 'pull_request' && matrix.os == 'ubuntu' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,15 +102,15 @@ jobs:
       - name: Publish Snapshot to Artifactory
         if: ${{ !inputs.dry-run && env.TRAIN == 'Nightly' }}
         run: |
-          jfrog rt u --detailed-summary dist/*cli*.tgz libs-snapshot-local/org/zowe/zowe-native-proto/CLI/$TRAIN/zowe-native-proto-cli-$NEW_VERSION_SUFFIX.tgz
-          jfrog rt u --detailed-summary dist/*sdk*.tgz libs-snapshot-local/org/zowe/zowe-native-proto/SDK/$TRAIN/zowe-native-proto-sdk-$NEW_VERSION_SUFFIX.tgz
-          jfrog rt u --detailed-summary dist/*.vsix libs-snapshot-local/org/zowe/zowe-native-proto/VSCode/$TRAIN/zowe-native-proto-vsce-$NEW_VERSION_SUFFIX.vsix
-          jfrog rt u --detailed-summary dist/*.pax.Z libs-snapshot-local/org/zowe/zowe-native-proto/Server/$TRAIN/zowe-server-$NEW_VERSION_SUFFIX.pax.Z
+          jfrog rt u --detailed-summary dist/*cli*.tgz libs-snapshot-local/org/zowe/zowex/CLI/$TRAIN/zowex-cli-$NEW_VERSION_SUFFIX.tgz
+          jfrog rt u --detailed-summary dist/*sdk*.tgz libs-snapshot-local/org/zowe/zowex/SDK/$TRAIN/zowex-sdk-$NEW_VERSION_SUFFIX.tgz
+          jfrog rt u --detailed-summary dist/*.vsix libs-snapshot-local/org/zowe/zowex/VSCode/$TRAIN/zowex-vsce-$NEW_VERSION_SUFFIX.vsix
+          jfrog rt u --detailed-summary dist/*.pax.Z libs-snapshot-local/org/zowe/zowex/Server/$TRAIN/zowe-server-$NEW_VERSION_SUFFIX.pax.Z
 
       - name: Publish Release to Artifactory
         if: ${{ !inputs.dry-run && env.TRAIN == 'Release' }}
         run: |
-          jfrog rt u --detailed-summary dist/*cli*.tgz libs-release-local/org/zowe/zowe-native-proto/$NEW_VERSION_SUFFIX/zowe-native-proto-cli-$NEW_VERSION_SUFFIX.tgz
-          jfrog rt u --detailed-summary dist/*sdk*.tgz libs-release-local/org/zowe/zowe-native-proto/$NEW_VERSION_SUFFIX/zowe-native-proto-sdk-$NEW_VERSION_SUFFIX.tgz
-          jfrog rt u --detailed-summary dist/*.vsix libs-release-local/org/zowe/zowe-native-proto/$NEW_VERSION_SUFFIX/zowe-native-proto-vsce-$NEW_VERSION_SUFFIX.vsix
-          jfrog rt u --detailed-summary dist/*.pax.Z libs-release-local/org/zowe/zowe-native-proto/$NEW_VERSION_SUFFIX/zowe-server-$NEW_VERSION_SUFFIX.pax.Z
+          jfrog rt u --detailed-summary dist/*cli*.tgz libs-release-local/org/zowe/zowex/$NEW_VERSION_SUFFIX/zowex-cli-$NEW_VERSION_SUFFIX.tgz
+          jfrog rt u --detailed-summary dist/*sdk*.tgz libs-release-local/org/zowe/zowex/$NEW_VERSION_SUFFIX/zowex-sdk-$NEW_VERSION_SUFFIX.tgz
+          jfrog rt u --detailed-summary dist/*.vsix libs-release-local/org/zowe/zowex/$NEW_VERSION_SUFFIX/zowex-vsce-$NEW_VERSION_SUFFIX.vsix
+          jfrog rt u --detailed-summary dist/*.pax.Z libs-release-local/org/zowe/zowex/$NEW_VERSION_SUFFIX/zowe-server-$NEW_VERSION_SUFFIX.pax.Z

--- a/.github/workflows/zos-build.yml
+++ b/.github/workflows/zos-build.yml
@@ -52,7 +52,7 @@ jobs:
                 port: 65522
                 user: "${{ secrets.SSH_MARIST_ZNP_ID }}"
                 password: "${{ secrets.SSH_MARIST_ZNP_PASS }}"
-              deployDir: "/ZOWE/tmp/zowe-native-proto"
+              deployDir: "/ZOWE/tmp/zowex"
               preBuildCmd: "export PATH=/usr/lpp/IBM/cnw/v2r1/openxl/bin:$PATH"
           EOF
 

--- a/.github/workflows/zos-py-build.yml
+++ b/.github/workflows/zos-py-build.yml
@@ -50,7 +50,7 @@ jobs:
                 port: 65522
                 user: "${{ secrets.SSH_MARIST_ZNP_ID }}"
                 password: "${{ secrets.SSH_MARIST_ZNP_PASS }}"
-              deployDir: "/ZOWE/tmp/zowe-native-proto"
+              deployDir: "/ZOWE/tmp/zowex"
               preBuildCmd: "export PATH=/usr/lpp/IBM/cnw/v2r1/openxl/bin:$PATH"
           EOF
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ node_modules
 prebuilds
 out
 typedoc*
-zowe-native-proto-package
+zowex-package
 
 # Files
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "preLaunchTask": "npm: watch"
     },
     {
-      "name": "Debug Zowe SSH Command",
+      "name": "Debug Zowe Remote SSH Command",
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "zowe",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Zowe Native Protocol
+# Zowe Remote SSH
 
 An open-source, native protocol for z/OS mainframe operations via SSH with minimal server-side configuration.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To test server changes without having to download artifacts and re-deploy them e
       "type": "ssh",
       "properties": {
         ...
-        "serverPath": "~/zowe-native-proto/c/build-out"
+        "serverPath": "~/zowex/c/build-out"
       }
     }
   }
@@ -115,7 +115,7 @@ We use a custom build tool for interacting with z/OS that defines the following 
 >
 >   another:
 >     sshProfile: ssh2
->     deployDir: /tmp/zowe-native-proto
+>     deployDir: /tmp/zowex
 > ```
 
 ## Architecture
@@ -144,9 +144,9 @@ graph LR
   cpp-->uss
   cpp-->jobs
   end
-  click sdk "https://github.com/zowe/zowe-native-proto/blob/main/doc/client/architecture.md#sdk-package"
-  click cli "https://github.com/zowe/zowe-native-proto/blob/main/doc/client/architecture.md#cli-plug-in"
-  click vsce "https://github.com/zowe/zowe-native-proto/blob/main/doc/client/architecture.md#vs-code-extension"
-  click ioserver "https://github.com/zowe/zowe-native-proto/blob/main/doc/backend/server_architecture.md"
-  click zowex "https://github.com/zowe/zowe-native-proto/blob/main/doc/backend/zowex_architecture.md"
+  click sdk "https://github.com/zowe/zowex/blob/main/doc/client/architecture.md#sdk-package"
+  click cli "https://github.com/zowe/zowex/blob/main/doc/client/architecture.md#cli-plug-in"
+  click vsce "https://github.com/zowe/zowex/blob/main/doc/client/architecture.md#vs-code-extension"
+  click ioserver "https://github.com/zowe/zowex/blob/main/doc/backend/server_architecture.md"
+  click zowex "https://github.com/zowe/zowex/blob/main/doc/backend/zowex_architecture.md"
 ```

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,7 +14,7 @@ profiles:
     #   # password: password  # Use password instead of private key
 
     # USS directory on z/OS where native code is built
-    deployDir: ~/zowe-native-proto
+    deployDir: ~/zowex
 
     # Command to run before building the native code
     # preBuildCmd: '. ~/entrypoint.sh'  # Run script to configure build environment

--- a/doc/add-new-command.md
+++ b/doc/add-new-command.md
@@ -350,7 +350,7 @@ Create a test script to verify your command works end-to-end:
 **`test-ping.ts`:**
 
 ```typescript
-import { ZSshClient } from "zowe-native-proto-sdk/src/ZSshClient";
+import { ZSshClient } from "zowex-sdk/src/ZSshClient";
 import { ProfileInfo } from "@zowe/imperative";
 
 async function main() {

--- a/doc/add-new-command.md
+++ b/doc/add-new-command.md
@@ -1,6 +1,6 @@
-# Adding a New Command to Zowe Native Protocol
+# Adding a New Command to Zowe Remote SSH
 
-This guide walks you through creating a new command for the Zowe Native Protocol stack, from the low-level C++ implementation through the middleware layer to the SDK. We'll use a simple `ping` command as an example that takes an optional message and returns a pong response with a timestamp.
+This guide walks you through creating a new command for the Zowe Remote SSH stack, from the low-level C++ implementation through the middleware layer to the SDK. We'll use a simple `ping` command as an example that takes an optional message and returns a pong response with a timestamp.
 
 > **💡 Example Source Code**: For a complete working example, see the [`examples/add-new-command`](../examples/add-new-command) directory, which demonstrates adding commands across all layers of the stack (C++ backend, middleware, SDK, CLI, and VS Code extension).
 
@@ -389,7 +389,7 @@ async function main() {
     // Test 3: Another custom message
     console.log("\nTest 3: Another Custom Message");
     const anotherResponse = await client.sample.ping({
-      message: "Zowe Native Protocol rocks!",
+      message: "Zowe Remote SSH rocks!",
     });
     console.log("  Data:", anotherResponse.data);
     console.log("  Timestamp:", anotherResponse.timestamp);
@@ -435,7 +435,7 @@ Test 2: Custom Message
   Timestamp: Mon Oct  6 14:23:46 2025
 
 Test 3: Another Custom Message
-  Data: PONG: Zowe Native Protocol rocks!
+  Data: PONG: Zowe Remote SSH rocks!
   Timestamp: Mon Oct  6 14:23:47 2025
 
 ✅ All tests passed!
@@ -446,7 +446,7 @@ Disconnected from server
 
 ## Summary
 
-You've successfully added a new command to the Zowe Native Protocol stack! Here's what you did:
+You've successfully added a new command to the Zowe Remote SSH stack! Here's what you did:
 
 1. **Created a low-level C++ command** in `native/c/commands/` that can be invoked directly via `zowex`
 2. **Tested it locally** on z/OS using the zowex CLI

--- a/doc/architecture-comparisons.md
+++ b/doc/architecture-comparisons.md
@@ -1,6 +1,6 @@
-# Comparing Zowe Native Protocol (ZNP) vs z/OSMF REST API
+# Comparing Zowe Remote SSH (ZNP) vs z/OSMF REST API
 
-This document helps illustrate the architectural differences between Zowe Native Protocol (SSH-based) and z/OSMF REST API approaches for mainframe access in Zowe Clients.
+This document helps illustrate the architectural differences between Zowe Remote SSH (SSH-based) and z/OSMF REST API approaches for mainframe access in Zowe Clients.
 
 ## High-Level Architecture
 
@@ -265,7 +265,7 @@ graph TB
 
 ```mermaid
 graph TB
-    subgraph "Zowe Native Protocol"
+    subgraph "Zowe Remote SSH"
         SSH_CONN["Single SSH Connection<br/>• Persistent<br/>• Multiplexed<br/>• Keep-alive"]
         SSH_BENEFIT["✅ Lower latency<br/>✅ Persistent state<br/>✅ Concurrent requests"]
         SSH_CONN --> SSH_BENEFIT
@@ -287,7 +287,7 @@ graph TB
 
 ```mermaid
 graph TB
-    subgraph "Zowe Native Protocol"
+    subgraph "Zowe Remote SSH"
         ZNP_RESOURCE["Resource Usage<br/>• Single SSH daemon process<br/>• Embedded zowex server<br/>• Efficient connection reuse"]
         ZNP_SCALE["Scaling Behavior<br/>• Multiplexed requests<br/>• Worker pool management<br/>• Predictable resource usage"]
         ZNP_RESOURCE --> ZNP_SCALE
@@ -309,7 +309,7 @@ graph TB
 
 ```mermaid
 flowchart TD
-    subgraph "Zowe Native Protocol Path"
+    subgraph "Zowe Remote SSH Path"
         ZNP_START["Client Request"] --> ZNP_SSH["SSH Transport"]
         ZNP_SSH --> ZNP_JSON["JSON-RPC Parsing"]
         ZNP_JSON --> ZNP_CPP["C++ Command Handler"]
@@ -398,7 +398,7 @@ graph TB
 ```mermaid
 sequenceDiagram
     participant Dev as Developer
-    participant ZNP as Zowe Native Protocol
+    participant ZNP as Zowe Remote SSH
     participant ZOSMF as z/OSMF REST API
 
     Note over Dev: Scenario: Rapid file editing workflow
@@ -425,7 +425,7 @@ sequenceDiagram
 
 ```mermaid
 graph LR
-    subgraph "Zowe Native Protocol"
+    subgraph "Zowe Remote SSH"
         ZNP_STREAM["Streaming Support<br/>• Base64 chunks<br/>• Named pipes<br/>• Progress tracking"]
         ZNP_BINARY["Binary Handling<br/>• Direct encoding<br/>• Efficient transfer<br/>• Large file support"]
     end

--- a/examples/add-new-command/packages/cli/src/issue/ping/PingCommand.handler.ts
+++ b/examples/add-new-command/packages/cli/src/issue/ping/PingCommand.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { ZSshClient } from "zowe-native-proto-sdk";
+import type { ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class PingCommandHandler extends SshBaseHandler {

--- a/examples/binary-ssh/tests/config.example.json
+++ b/examples/binary-ssh/tests/config.example.json
@@ -1,10 +1,10 @@
 {
     "chunkSize": 32768,
-    "serverPath": "/u/users/ibmuser/zowe-native-proto/c/build-out",
+    "serverPath": "/u/users/ibmuser/zowex/c/build-out",
     "sshProfile": "ssh",
     "testCount": 5,
     "testFile": "resources/test1m.bin",
-    "ussDir": "/tmp/zowe-native-proto",
+    "ussDir": "/tmp/zowex",
     "verboseSsh": false,
     "zosmfProfile": "zosmf"
 }

--- a/examples/binary-ssh/tests/test-sftp.ts
+++ b/examples/binary-ssh/tests/test-sftp.ts
@@ -13,7 +13,7 @@ import { statSync, unlinkSync } from "node:fs";
 import { parse } from "node:path";
 import { promisify } from "node:util";
 import { NodeSSH, type Config as NodeSSHConfig } from "node-ssh";
-import { ZSshUtils } from "zowe-native-proto-sdk/src";
+import { ZSshUtils } from "zowex-sdk/src";
 import * as utils from "./utils";
 const userConfig = require("./config.json");
 const testPrefix = parse(__filename).name;

--- a/examples/binary-ssh/tests/test-znp.ts
+++ b/examples/binary-ssh/tests/test-znp.ts
@@ -11,7 +11,7 @@
 
 import { readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { parse } from "node:path";
-import { B64String, ZSshClient, ZSshUtils } from "zowe-native-proto-sdk/src";
+import { B64String, ZSshClient, ZSshUtils } from "zowex-sdk/src";
 import * as utils from "./utils";
 const userConfig = require("./config.json");
 const testPrefix = parse(__filename).name;

--- a/examples/deploy.ts
+++ b/examples/deploy.ts
@@ -28,12 +28,12 @@ import { AsciiToEbcdicTransform } from "../scripts/buildTools";
  *
  * Arguments:
  *   ssh-profile   Name of a Zowe SSH profile
- *   deploy-dir    USS directory for the deploy (e.g. ~/zowe-native-proto)
+ *   deploy-dir    USS directory for the deploy (e.g. ~/zowex)
  *   example...    Optional list of examples to deploy (default: all)
  *
  * Examples:
- *   npx tsx examples/deploy.ts myssh ~/zowe-native-proto
- *   npx tsx examples/deploy.ts myssh ~/zowe-native-proto pong-server jsonrpc-ssh
+ *   npx tsx examples/deploy.ts myssh ~/zowex
+ *   npx tsx examples/deploy.ts myssh ~/zowex pong-server jsonrpc-ssh
  */
 
 const ALL_EXAMPLES = ["pong-server", "jsonrpc-ssh", "binary-ssh"];
@@ -166,7 +166,7 @@ async function main() {
         console.error("Usage: npx tsx examples/deploy.ts <ssh-profile> <deploy-dir> [example...]");
         console.error("");
         console.error("  ssh-profile   Name of a Zowe SSH profile");
-        console.error("  deploy-dir    USS directory for the deploy (e.g. ~/zowe-native-proto)");
+        console.error("  deploy-dir    USS directory for the deploy (e.g. ~/zowex)");
         console.error("  example...    Optional: pong-server, jsonrpc-ssh, binary-ssh (default: all)");
         process.exit(1);
     }

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -1,139 +1,139 @@
 # Change Log
 
-All notable changes to the native code for "zowe-native-proto" are documented in this file.
+All notable changes to the native code for "zowex" are documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## Recent Changes
 
-- `c`: Changed `zowex --version` and `zowex -v` to return just the version number. [#925](https://github.com/zowe/zowe-native-proto/pull/925)
-- `c`: Removed duplicate `-v` and `--version` aliases on the `zowex version` command. [#922](https://github.com/zowe/zowe-native-proto/pull/922)
-- `c`: Added the `getInfo` RPC to retrieve the middleware version and build information. [#922](https://github.com/zowe/zowe-native-proto/pull/922)
-- `c`: Added a DCB abend exit for handling edge cases around PDS member open, write, and close operations. When an abend is encountered, it is either delayed or ignored (when applicable) and an error is returned gracefully via the diagnostic structure (`ZDIAG`) rather than terminating the process. Refer to [DCB abend exits](doc/dcb-abend-exit.md) for more information on how and when abends are handled. **Note:** In the event of an end-of-space (end-of-volume) abend, the operating system closes the DCB if the ignore request is honored from the abend exit. However, the abend might still percolate during end-of-volume `CLOSE` routines. An ESTAE/ESTAEX recovery routine should be used to gracefully handle these cases. [#839](https://github.com/zowe/zowe-native-proto/issues/839)
-- `c`: Fixed an issue where listing the members of a protected, partitioned data set resulted in an unclear error message. Now, the error messages are more specific and include information about insufficient permissions when applicable. [#297](https://github.com/zowe/zowe-native-proto/issues/297)
+- `c`: Changed `zowex --version` and `zowex -v` to return just the version number. [#925](https://github.com/zowe/zowex/pull/925)
+- `c`: Removed duplicate `-v` and `--version` aliases on the `zowex version` command. [#922](https://github.com/zowe/zowex/pull/922)
+- `c`: Added the `getInfo` RPC to retrieve the middleware version and build information. [#922](https://github.com/zowe/zowex/pull/922)
+- `c`: Added a DCB abend exit for handling edge cases around PDS member open, write, and close operations. When an abend is encountered, it is either delayed or ignored (when applicable) and an error is returned gracefully via the diagnostic structure (`ZDIAG`) rather than terminating the process. Refer to [DCB abend exits](doc/dcb-abend-exit.md) for more information on how and when abends are handled. **Note:** In the event of an end-of-space (end-of-volume) abend, the operating system closes the DCB if the ignore request is honored from the abend exit. However, the abend might still percolate during end-of-volume `CLOSE` routines. An ESTAE/ESTAEX recovery routine should be used to gracefully handle these cases. [#839](https://github.com/zowe/zowex/issues/839)
+- `c`: Fixed an issue where listing the members of a protected, partitioned data set resulted in an unclear error message. Now, the error messages are more specific and include information about insufficient permissions when applicable. [#297](https://github.com/zowe/zowex/issues/297)
 
 ## `0.4.0`
 
-- `c`: Added `zowex uss issue` command and the `unixCommand` RPC for executing USS shell commands using `spawn()` with `_BPX_SHAREAS=YES` for efficient same-address-space execution. [#867](https://github.com/zowe/zowe-native-proto/pull/867)
-- `c`: Fixed an issue where submitting JCL from the VS Code editor with CRLF line endings caused job submission errors. [#882](https://github.com/zowe/zowe-native-proto/pull/882)
-- `c`: Fixed an issue where VSAM index or data components returned `*VSAM*` for the volume serial. Now, an accurate volume serial is returned for both component types. [#864](https://github.com/zowe/zowe-native-proto/pull/864)
-- `c`: Fixed an issue where listing data sets would fail with an "unsupported entry type" error if the pattern matched a VSAM PATH or alternate index (AIX). Now, matching VSAM PATH or AIX data sets are returned in the list results. [#841](https://github.com/zowe/zowe-native-proto/issues/841)
-- `c`: Added `zowex system view-syslog` command. [#829](https://github.com/zowe/zowe-native-proto/issues/829)
-- `c`: Added an option for command handler arguments to coerce all input values into a string, allowing developers to have more control over expected formatting and type constraints. [#875](https://github.com/zowe/zowe-native-proto/pull/875)
-- **Breaking:** `c`: Renamed the `zds_read_from_dsn` function to `zds_read`. [#831](https://github.com/zowe/zowe-native-proto/issues/831)
-- **Breaking:** `c`: Removed the `zds_read_from_dd` function in favor of the newly-consolidated `zds_read` function. [#831](https://github.com/zowe/zowe-native-proto/issues/831)
-- **Breaking:** `c`: Removed the standalone `zowed` binary and its entry point. The server is now exclusively an embedded subcommand of `zowex` (the z/OS backend CLI binary) via `zowex server`, eliminating the need for a separate binary and `libzowed.so` dynamic loading. [#846](https://github.com/zowe/zowe-native-proto/issues/846)
-- **Breaking:** `c`: Renamed the `ZOWED_NUM_WORKERS` environment variable to `ZOWEX_NUM_WORKERS` (controls the number of parallel worker threads the server uses to handle requests). [#846](https://github.com/zowe/zowe-native-proto/issues/846)
-- `c`: Enabled `-O2` optimization for release builds, improving runtime performance of native binaries. [#846](https://github.com/zowe/zowe-native-proto/issues/846)
-- `c`: Added `zowex system list-subsystems` with optional filter. [#842](https://github.com/zowe/zowe-native-proto/issues/842)
-- `c`: Added `zowex system` command group and relocated items `list-parmlib`, `list-proclib`, and `display-symbol` from `zowex tool` to this group. [#843](https://github.com/zowe/zowe-native-proto/issues/843) and [#844](https://github.com/zowe/zowe-native-proto/issues/844)
-- `c`: Added support for displaying member statistics. [#630](https://github.com/zowe/zowe-native-proto/issues/630)
+- `c`: Added `zowex uss issue` command and the `unixCommand` RPC for executing USS shell commands using `spawn()` with `_BPX_SHAREAS=YES` for efficient same-address-space execution. [#867](https://github.com/zowe/zowex/pull/867)
+- `c`: Fixed an issue where submitting JCL from the VS Code editor with CRLF line endings caused job submission errors. [#882](https://github.com/zowe/zowex/pull/882)
+- `c`: Fixed an issue where VSAM index or data components returned `*VSAM*` for the volume serial. Now, an accurate volume serial is returned for both component types. [#864](https://github.com/zowe/zowex/pull/864)
+- `c`: Fixed an issue where listing data sets would fail with an "unsupported entry type" error if the pattern matched a VSAM PATH or alternate index (AIX). Now, matching VSAM PATH or AIX data sets are returned in the list results. [#841](https://github.com/zowe/zowex/issues/841)
+- `c`: Added `zowex system view-syslog` command. [#829](https://github.com/zowe/zowex/issues/829)
+- `c`: Added an option for command handler arguments to coerce all input values into a string, allowing developers to have more control over expected formatting and type constraints. [#875](https://github.com/zowe/zowex/pull/875)
+- **Breaking:** `c`: Renamed the `zds_read_from_dsn` function to `zds_read`. [#831](https://github.com/zowe/zowex/issues/831)
+- **Breaking:** `c`: Removed the `zds_read_from_dd` function in favor of the newly-consolidated `zds_read` function. [#831](https://github.com/zowe/zowex/issues/831)
+- **Breaking:** `c`: Removed the standalone `zowed` binary and its entry point. The server is now exclusively an embedded subcommand of `zowex` (the z/OS backend CLI binary) via `zowex server`, eliminating the need for a separate binary and `libzowed.so` dynamic loading. [#846](https://github.com/zowe/zowex/issues/846)
+- **Breaking:** `c`: Renamed the `ZOWED_NUM_WORKERS` environment variable to `ZOWEX_NUM_WORKERS` (controls the number of parallel worker threads the server uses to handle requests). [#846](https://github.com/zowe/zowex/issues/846)
+- `c`: Enabled `-O2` optimization for release builds, improving runtime performance of native binaries. [#846](https://github.com/zowe/zowex/issues/846)
+- `c`: Added `zowex system list-subsystems` with optional filter. [#842](https://github.com/zowe/zowex/issues/842)
+- `c`: Added `zowex system` command group and relocated items `list-parmlib`, `list-proclib`, and `display-symbol` from `zowex tool` to this group. [#843](https://github.com/zowe/zowex/issues/843) and [#844](https://github.com/zowe/zowex/issues/844)
+- `c`: Added support for displaying member statistics. [#630](https://github.com/zowe/zowex/issues/630)
 - `c`: Added `toolSearch` command in the server (used to search for data sets) for use by client SDK.
-- `c`: Added the `pattern` option to the `data-set list-members` zowex command to filter the returned members. [#817](https://github.com/zowe/zowe-native-proto/pull/817)
-- `c`: Implemented `zowex uss copy` command to copy USS files and directories. [#379](https://github.com/zowe/zowe-native-proto/issues/379)
-- `c`: Implemented `zowex uss move` command to move files and directories in z/OS Unix. [#378](https://github.com/zowe/zowe-native-proto/issues/378)
-- `python`: Implemented basic move APIs and fixed build issues. [#789](https://github.com/zowe/zowe-native-proto/pull/789)
-- `c`: Updated the `gen_chdsect.sh` shell script used to generate chdsect header files to generate appropriate pragma syntax expected by the `ibm-clang` C/C++ compiler. When the headers are included in Open XL-compiled code, the new pragma syntax is used. Otherwise, the legacy `pack(packed)` and `pack(reset)` macro syntax is used. [#368](https://github.com/zowe/zowe-native-proto/issues/368)
-- `native`: Migrated compiler from xlclang/xlclang++ to ibm-clang/ibm-clang++ (Open XL C/C++, v2.1, supports C++17). The `xlclang-extenders` makefile target has been removed in favor of the `all` target. [#653](https://github.com/zowe/zowe-native-proto/issues/653)
-- `c`: Modernized C++ code to align with C++17 best practices and adopted new standard library implementations (`unordered_map`, `to_string`, `if constexpr`, brace initialization, etc.). [#812](https://github.com/zowe/zowe-native-proto/pull/812)
-- `c`: Removed all cases of `using namespace std` in native code to prevent namespace collisions and unintended effects on API consumers. All uses of `std` classes and utilities are now explicitly prefixed with `std::`. [#812](https://github.com/zowe/zowe-native-proto/pull/812)
-- `c`: Removed redundant standard library utilities from the `zstd.hpp` C++ header, in favor of the verified implementations included with ibm-clang and C++17. [#812](https://github.com/zowe/zowe-native-proto/pull/812)
-- `c`: Renamed `zut_int_to_string` to `zut_hex_to_string` to align with use cases for the function. [#812](https://github.com/zowe/zowe-native-proto/pull/812)
+- `c`: Added the `pattern` option to the `data-set list-members` zowex command to filter the returned members. [#817](https://github.com/zowe/zowex/pull/817)
+- `c`: Implemented `zowex uss copy` command to copy USS files and directories. [#379](https://github.com/zowe/zowex/issues/379)
+- `c`: Implemented `zowex uss move` command to move files and directories in z/OS Unix. [#378](https://github.com/zowe/zowex/issues/378)
+- `python`: Implemented basic move APIs and fixed build issues. [#789](https://github.com/zowe/zowex/pull/789)
+- `c`: Updated the `gen_chdsect.sh` shell script used to generate chdsect header files to generate appropriate pragma syntax expected by the `ibm-clang` C/C++ compiler. When the headers are included in Open XL-compiled code, the new pragma syntax is used. Otherwise, the legacy `pack(packed)` and `pack(reset)` macro syntax is used. [#368](https://github.com/zowe/zowex/issues/368)
+- `native`: Migrated compiler from xlclang/xlclang++ to ibm-clang/ibm-clang++ (Open XL C/C++, v2.1, supports C++17). The `xlclang-extenders` makefile target has been removed in favor of the `all` target. [#653](https://github.com/zowe/zowex/issues/653)
+- `c`: Modernized C++ code to align with C++17 best practices and adopted new standard library implementations (`unordered_map`, `to_string`, `if constexpr`, brace initialization, etc.). [#812](https://github.com/zowe/zowex/pull/812)
+- `c`: Removed all cases of `using namespace std` in native code to prevent namespace collisions and unintended effects on API consumers. All uses of `std` classes and utilities are now explicitly prefixed with `std::`. [#812](https://github.com/zowe/zowex/pull/812)
+- `c`: Removed redundant standard library utilities from the `zstd.hpp` C++ header, in favor of the verified implementations included with ibm-clang and C++17. [#812](https://github.com/zowe/zowex/pull/812)
+- `c`: Renamed `zut_int_to_string` to `zut_hex_to_string` to align with use cases for the function. [#812](https://github.com/zowe/zowex/pull/812)
 
 ## `0.2.4`
 
-- `c`: Fixed an issue where errors during `zowex` initialization and command execution were unhandled, causing abends as a result. Now, if a fatal error is encountered, the error is caught and its details are displayed before the process exits. [#784](https://github.com/zowe/zowe-native-proto/issues/784)
-- `c`: Fixed an issue where the `zowex uss list` command would return the file type `d` for symlinked directories instead of `l`. Now, symlinks in a file list are marked with file type `l`. [#791](https://github.com/zowe/zowe-native-proto/issues/791)
-- `c`: Fixed an issue where the `zowex uss delete` command could not remove symlinks or directories containing symlinks. Now, the command properly deletes a directory with a symlink in it, and treats the link as a file. No sub-directories or files in the target link are deleted. [#792](https://github.com/zowe/zowe-native-proto/issues/792)
-- `c`: Added support for `multivolume` attribute when listing data sets. [#782](https://github.com/zowe/zowe-native-proto/pull/782)
-- `c`: Fixed an issue with the `zowex ds write` command where e-tag arguments without alphabetic characters resulted in e-tag validation being skipped. Now, e-tag validation is performed regardless of whether the e-tag contains alphabetic characters. [#676](https://github.com/zowe/zowe-native-proto/issues/676)
+- `c`: Fixed an issue where errors during `zowex` initialization and command execution were unhandled, causing abends as a result. Now, if a fatal error is encountered, the error is caught and its details are displayed before the process exits. [#784](https://github.com/zowe/zowex/issues/784)
+- `c`: Fixed an issue where the `zowex uss list` command would return the file type `d` for symlinked directories instead of `l`. Now, symlinks in a file list are marked with file type `l`. [#791](https://github.com/zowe/zowex/issues/791)
+- `c`: Fixed an issue where the `zowex uss delete` command could not remove symlinks or directories containing symlinks. Now, the command properly deletes a directory with a symlink in it, and treats the link as a file. No sub-directories or files in the target link are deleted. [#792](https://github.com/zowe/zowex/issues/792)
+- `c`: Added support for `multivolume` attribute when listing data sets. [#782](https://github.com/zowe/zowex/pull/782)
+- `c`: Fixed an issue with the `zowex ds write` command where e-tag arguments without alphabetic characters resulted in e-tag validation being skipped. Now, e-tag validation is performed regardless of whether the e-tag contains alphabetic characters. [#676](https://github.com/zowe/zowex/issues/676)
 
 ## `0.2.3`
 
-- `c`: Added `zowex ds copy` command to copy data sets and members with optional `--replace` flag (overwrites matching members) and `--delete-target-members` flag (deletes all target members before copying, making target match source exactly). Supports PDS-to-PDS, member-to-member, and sequential-to-sequential copies. Note: RECFM=U data sets are not supported. [#750](https://github.com/zowe/zowe-native-proto/pull/750)
-- `c`: Added rename data set members functionality to the backend. [#765](https://github.com/zowe/zowe-native-proto/pull/765)
+- `c`: Added `zowex ds copy` command to copy data sets and members with optional `--replace` flag (overwrites matching members) and `--delete-target-members` flag (deletes all target members before copying, making target match source exactly). Supports PDS-to-PDS, member-to-member, and sequential-to-sequential copies. Note: RECFM=U data sets are not supported. [#750](https://github.com/zowe/zowex/pull/750)
+- `c`: Added rename data set members functionality to the backend. [#765](https://github.com/zowe/zowex/pull/765)
 - `c`: Implement `zowex job watch` command to watch spool output for a string or regex until terminating.
 - `c`: Implement `zut_bpxwdyn_rtdsn` to obtain and return a system allocated data set name.
 - `c`: Implement command `zowex job view-file` to print contents of a job output data set.
-- The `zowex job submit-jcl` command now displays the submitted job in the following format: `JobName(JobId)` [#733](https://github.com/zowe/zowe-native-proto/issues/733)
-- `c`: Rename command `zowex job view-file` to `zowex job view-file-by-id` so that `view-file` can be used to print a specific file (data set) name. [#740](https://github.com/zowe/zowe-native-proto/issues/740)
-- `c`: The zowex CLI parser now supports enabling passthrough arguments for commands. When enabled, arguments passed after a double-dash (`--`) are passed directly to the command as raw input. [#729](https://github.com/zowe/zowe-native-proto/pull/729)
-- Added the rename dataset functionality to the backend. [#376](https://github.com/zowe/zowe-native-proto/issues/376)
-- `c`: Fixed results being truncated when listing all jobs on a system. [#735](https://github.com/zowe/zowe-native-proto/issues/735)
-- `c`: Fixed default behavior of `zowex job list` command to list jobs for only the current user. [#739](https://github.com/zowe/zowe-native-proto/issues/739)
-- `c`: Added `--status` argument to `zowex job list` command that supports filtering by job status. [#743](https://github.com/zowe/zowe-native-proto/issues/743)
-- `zowed`: Fixed `maxItems` property being ignored when listing data sets and jobs. [#745](https://github.com/zowe/zowe-native-proto/issues/745)
-- `c`: Fixed an issue where writing to a `RECFM=U` data set could exhibit undefined behavior. Now, writing to a `RECFM=U` data set results in an explicit error as the record format is supported as read-only. [#751](https://github.com/zowe/zowe-native-proto/pull/751)
-- `c`: Fixed an issue where BPAM write operations would accidentally wipe the contents of a data set if one of the lines exceeded the record length. Now, the line is truncated according to the max record length of the data set, and the user is warned about line ranges that exceed the record length. [#587](https://github.com/zowe/zowe-native-proto/issues/587)
-- `c`: PDS and PDSE members are now edited using a partitioned access method to preserve and update ISPF statistics. [#587](https://github.com/zowe/zowe-native-proto/issues/587)
-- `c`: Added support for handling ASA control characters when writing to sequential and partitioned data sets. [#751](https://github.com/zowe/zowe-native-proto/pull/751)
-- `c`: Added support for line truncation detection when writing to data sets. The truncated line ranges are displayed as a warning message after the write process is complete. [#751](https://github.com/zowe/zowe-native-proto/pull/751)
-- `c`: Fixed an issue where the output stream was checked to determine the input method for write commands, causing unexpected behavior when piping data to the commands. Now, the commands check if the input stream is a pseudo-terminal before continuing. [#756](https://github.com/zowe/zowe-native-proto/issues/756)
-- `c`: Fixed an issue where the write commands would inadvertently add duplicate newlines when reading user input in interactive mode. Now, a newline character is only added between lines and after the first line of text is processed. [#755](https://github.com/zowe/zowe-native-proto/issues/755)
+- The `zowex job submit-jcl` command now displays the submitted job in the following format: `JobName(JobId)` [#733](https://github.com/zowe/zowex/issues/733)
+- `c`: Rename command `zowex job view-file` to `zowex job view-file-by-id` so that `view-file` can be used to print a specific file (data set) name. [#740](https://github.com/zowe/zowex/issues/740)
+- `c`: The zowex CLI parser now supports enabling passthrough arguments for commands. When enabled, arguments passed after a double-dash (`--`) are passed directly to the command as raw input. [#729](https://github.com/zowe/zowex/pull/729)
+- Added the rename dataset functionality to the backend. [#376](https://github.com/zowe/zowex/issues/376)
+- `c`: Fixed results being truncated when listing all jobs on a system. [#735](https://github.com/zowe/zowex/issues/735)
+- `c`: Fixed default behavior of `zowex job list` command to list jobs for only the current user. [#739](https://github.com/zowe/zowex/issues/739)
+- `c`: Added `--status` argument to `zowex job list` command that supports filtering by job status. [#743](https://github.com/zowe/zowex/issues/743)
+- `zowed`: Fixed `maxItems` property being ignored when listing data sets and jobs. [#745](https://github.com/zowe/zowex/issues/745)
+- `c`: Fixed an issue where writing to a `RECFM=U` data set could exhibit undefined behavior. Now, writing to a `RECFM=U` data set results in an explicit error as the record format is supported as read-only. [#751](https://github.com/zowe/zowex/pull/751)
+- `c`: Fixed an issue where BPAM write operations would accidentally wipe the contents of a data set if one of the lines exceeded the record length. Now, the line is truncated according to the max record length of the data set, and the user is warned about line ranges that exceed the record length. [#587](https://github.com/zowe/zowex/issues/587)
+- `c`: PDS and PDSE members are now edited using a partitioned access method to preserve and update ISPF statistics. [#587](https://github.com/zowe/zowex/issues/587)
+- `c`: Added support for handling ASA control characters when writing to sequential and partitioned data sets. [#751](https://github.com/zowe/zowex/pull/751)
+- `c`: Added support for line truncation detection when writing to data sets. The truncated line ranges are displayed as a warning message after the write process is complete. [#751](https://github.com/zowe/zowex/pull/751)
+- `c`: Fixed an issue where the output stream was checked to determine the input method for write commands, causing unexpected behavior when piping data to the commands. Now, the commands check if the input stream is a pseudo-terminal before continuing. [#756](https://github.com/zowe/zowex/issues/756)
+- `c`: Fixed an issue where the write commands would inadvertently add duplicate newlines when reading user input in interactive mode. Now, a newline character is only added between lines and after the first line of text is processed. [#755](https://github.com/zowe/zowex/issues/755)
 
 ## `0.2.2`
 
-- `c`: Re-enable `zowex ds compress` and correct 0C4 abend. [#640](https://github.com/zowe/zowe-native-proto/issues/640)
-- `c`: Fixed an issue where `--wait ACTIVE` on `zowex job` commands would wait indefinitely if the job was fast enough to reach the `OUTPUT` phase before polling its status. [#700](https://github.com/zowe/zowe-native-proto/pull/700)
-- `zowed`: Fixed `message` property of `error` object in the JSON response to contain valuable details about errors thrown by `zowex`. [#712](https://github.com/zowe/zowe-native-proto/pull/712)
-- `c`: You can now access dynamic arguments from a command handler through its `InvocationContext` parameter. [#715](https://github.com/zowe/zowe-native-proto/pull/715)
-- `zowed`: Fixed an issue where the `submitJcl` command failed if an encoding was not specified for the JCL contents. [#724](https://github.com/zowe/zowe-native-proto/pull/724)
-- `c`: Fixed an issue where multibyte codepages like IBM-939 were not always encoded correctly when writing data sets and USS files. [#718](https://github.com/zowe/zowe-native-proto/pull/718)
+- `c`: Re-enable `zowex ds compress` and correct 0C4 abend. [#640](https://github.com/zowe/zowex/issues/640)
+- `c`: Fixed an issue where `--wait ACTIVE` on `zowex job` commands would wait indefinitely if the job was fast enough to reach the `OUTPUT` phase before polling its status. [#700](https://github.com/zowe/zowex/pull/700)
+- `zowed`: Fixed `message` property of `error` object in the JSON response to contain valuable details about errors thrown by `zowex`. [#712](https://github.com/zowe/zowex/pull/712)
+- `c`: You can now access dynamic arguments from a command handler through its `InvocationContext` parameter. [#715](https://github.com/zowe/zowex/pull/715)
+- `zowed`: Fixed an issue where the `submitJcl` command failed if an encoding was not specified for the JCL contents. [#724](https://github.com/zowe/zowex/pull/724)
+- `c`: Fixed an issue where multibyte codepages like IBM-939 were not always encoded correctly when writing data sets and USS files. [#718](https://github.com/zowe/zowex/pull/718)
 
 ## `0.2.1`
 
 - `c`: Disallow `zowex compress ds` to prevent lurking abend.
-- `c`: Fixed `zowex uss create-file` and `create-dir` commands to respect the `mode` option when provided. [#626](https://github.com/zowe/zowe-native-proto/pull/626)
-- `c`: Fixed issue where `zowex uss chown` (and `zusf_chown_uss_file_or_dir`) silently succeeded with exit code `0` when a non-existent user or group was supplied. The command now validates `user:group` input and returns a non-zero exit code with a clear error message when invalid. [#565](https://github.com/zowe/zowe-native-proto/pull/565)
-- `c`: Fixed issue where uploading changes to a data set did not always flush to disk. [#643](https://github.com/zowe/zowe-native-proto/issues/643)
-- `c`: Updated commands that read data from stdin to read literal text rather than parsing hex string. [#645](https://github.com/zowe/zowe-native-proto/pull/645)
-- `c`: Reverted previous fix to preserve ISPF stats on PDS members since it could cause uploading changes to fail. [#669](https://github.com/zowe/zowe-native-proto/pull/669)
-- `zowed`: Fixed issue where enabling verbose logging would cause a deadlock during initialization. [#652](https://github.com/zowe/zowe-native-proto/issues/652)
-- `zowed`: Implemented support for automatic worker recovery. If a worker crashes or throws an exception, it is replaced with a new worker. If the maximum number of replacement attempts have been exceeded, the worker is disabled to prevent thrashing the CPU with replacement requests. [#410](https://github.com/zowe/zowe-native-proto/issues/410)
-- `zowed`: Optimized the `get_ready_worker` function to avoid worst-case linear search for the next available worker. [#651](https://github.com/zowe/zowe-native-proto/pull/651)
-- `zowed`: Replaced the options logic with the parser library to avoid code duplication and establish consistency with backend. [#655](https://github.com/zowe/zowe-native-proto/issues/655)
-- `zowed`: Implemented support for server-side request timeouts. If the request timeout is exceeded for a single worker, the hanging worker is replaced and the ongoing request is discarded. [#416](https://github.com/zowe/zowe-native-proto/issues/416)
-- `c`: De-duplicated makefile contents through `.INCLUDE` keyword and separate toolchain file. [#651](https://github.com/zowe/zowe-native-proto/pull/651)
-- `zowed`: Fixed issue where opening a file larger than 10 MB could fail with "Invalid JSON" error. [#656](https://github.com/zowe/zowe-native-proto/issues/656)
-- `c`: Fix PSW alignment issue. [#559](https://github.com/zowe/zowe-native-proto/issues/559)
-- When listing data sets with attributes, a comprehensive set is now retrieved that is similar to what ISPF displays. [#629](https://github.com/zowe/zowe-native-proto/issues/629)
+- `c`: Fixed `zowex uss create-file` and `create-dir` commands to respect the `mode` option when provided. [#626](https://github.com/zowe/zowex/pull/626)
+- `c`: Fixed issue where `zowex uss chown` (and `zusf_chown_uss_file_or_dir`) silently succeeded with exit code `0` when a non-existent user or group was supplied. The command now validates `user:group` input and returns a non-zero exit code with a clear error message when invalid. [#565](https://github.com/zowe/zowex/pull/565)
+- `c`: Fixed issue where uploading changes to a data set did not always flush to disk. [#643](https://github.com/zowe/zowex/issues/643)
+- `c`: Updated commands that read data from stdin to read literal text rather than parsing hex string. [#645](https://github.com/zowe/zowex/pull/645)
+- `c`: Reverted previous fix to preserve ISPF stats on PDS members since it could cause uploading changes to fail. [#669](https://github.com/zowe/zowex/pull/669)
+- `zowed`: Fixed issue where enabling verbose logging would cause a deadlock during initialization. [#652](https://github.com/zowe/zowex/issues/652)
+- `zowed`: Implemented support for automatic worker recovery. If a worker crashes or throws an exception, it is replaced with a new worker. If the maximum number of replacement attempts have been exceeded, the worker is disabled to prevent thrashing the CPU with replacement requests. [#410](https://github.com/zowe/zowex/issues/410)
+- `zowed`: Optimized the `get_ready_worker` function to avoid worst-case linear search for the next available worker. [#651](https://github.com/zowe/zowex/pull/651)
+- `zowed`: Replaced the options logic with the parser library to avoid code duplication and establish consistency with backend. [#655](https://github.com/zowe/zowex/issues/655)
+- `zowed`: Implemented support for server-side request timeouts. If the request timeout is exceeded for a single worker, the hanging worker is replaced and the ongoing request is discarded. [#416](https://github.com/zowe/zowex/issues/416)
+- `c`: De-duplicated makefile contents through `.INCLUDE` keyword and separate toolchain file. [#651](https://github.com/zowe/zowex/pull/651)
+- `zowed`: Fixed issue where opening a file larger than 10 MB could fail with "Invalid JSON" error. [#656](https://github.com/zowe/zowex/issues/656)
+- `c`: Fix PSW alignment issue. [#559](https://github.com/zowe/zowex/issues/559)
+- When listing data sets with attributes, a comprehensive set is now retrieved that is similar to what ISPF displays. [#629](https://github.com/zowe/zowex/issues/629)
 
 ## `0.2.0`
 
-- `c`: Fixed issue where uploading changes to a PDS member removed its ISPF stats. [#556](https://github.com/zowe/zowe-native-proto/issues/556)
-- `c`: Streamlined argument checks and access within command handlers. Handlers can now use `get`, `get_if` and `find` to search for arguments and retrieve their values, regardless of whether the argument is a keyword or positional argument. [#574](https://github.com/zowe/zowe-native-proto/pull/574)
-- `c`: Command handlers can now be called directly by providing an `InvocationContext`. The context provides helper functions for error, input, and output stream redirection. Handlers can use this context to print output and errors, as well as setting content length. [#574](https://github.com/zowe/zowe-native-proto/pull/574)
-- `c`: Organized command handlers into separate source files and namespaces in the `commands` folder. Reduced size of main entrypoint function by moving command registration to a `register_commands` function contained in each namespace. [#409](https://github.com/zowe/zowe-native-proto/issues/409)
-- `native`: Added a `--depth` option to the `zowex uss list` command for listing USS directories recursively. [#575](https://github.com/zowe/zowe-native-proto/pull/575)
+- `c`: Fixed issue where uploading changes to a PDS member removed its ISPF stats. [#556](https://github.com/zowe/zowex/issues/556)
+- `c`: Streamlined argument checks and access within command handlers. Handlers can now use `get`, `get_if` and `find` to search for arguments and retrieve their values, regardless of whether the argument is a keyword or positional argument. [#574](https://github.com/zowe/zowex/pull/574)
+- `c`: Command handlers can now be called directly by providing an `InvocationContext`. The context provides helper functions for error, input, and output stream redirection. Handlers can use this context to print output and errors, as well as setting content length. [#574](https://github.com/zowe/zowex/pull/574)
+- `c`: Organized command handlers into separate source files and namespaces in the `commands` folder. Reduced size of main entrypoint function by moving command registration to a `register_commands` function contained in each namespace. [#409](https://github.com/zowe/zowex/issues/409)
+- `native`: Added a `--depth` option to the `zowex uss list` command for listing USS directories recursively. [#575](https://github.com/zowe/zowex/pull/575)
 - `native`: Added `zowex job list-proclib` to list proclib concatenation.
-- `c`: Fixed issue where a directory handle was leaked when running `chmod`, `chown`, `chtag` or `delete` USS commands. [#577](https://github.com/zowe/zowe-native-proto/issues/577)
-- `c`: Fixed issue where a file handle was leaked if the `fldata` function call failed when listing data set members. [#577](https://github.com/zowe/zowe-native-proto/issues/577)
-- `c`: Fixed issue where a file handle was leaked if the `fldata` function call failed in the `handle_data_set_compress` command handler. [#577](https://github.com/zowe/zowe-native-proto/issues/577)
-- `c`: Fixed issue in the `zut_substitute_symbol` function where passing patterns with a length greater than the input buffer would cause a buffer overflow. [#577](https://github.com/zowe/zowe-native-proto/issues/577)
-- `c`: Fixed undefined behavior in the `zut_bpxwdyn` function by verifying that the allocated 31-bit region is valid before writing to it. [#577](https://github.com/zowe/zowe-native-proto/issues/577)
-- `c`: The CLI parser now prints unexpected, trailing positional arguments when handling command input. [#594](https://github.com/zowe/zowe-native-proto/issues/594)
-- Rewrote the middleware (`zowed`) in C++. This removes our dependency on Golang, improves performance, and allows parallel requests to be handled in a single address space. [#595](https://github.com/zowe/zowe-native-proto/pull/595)
-- `c`: Fixed issue where automatic codepage conversion with `_BPXK_AUTOCVT` was not disabled for all USS read and write operations, which could interfere with the `--encoding` option. [#620](https://github.com/zowe/zowe-native-proto/pull/620)
+- `c`: Fixed issue where a directory handle was leaked when running `chmod`, `chown`, `chtag` or `delete` USS commands. [#577](https://github.com/zowe/zowex/issues/577)
+- `c`: Fixed issue where a file handle was leaked if the `fldata` function call failed when listing data set members. [#577](https://github.com/zowe/zowex/issues/577)
+- `c`: Fixed issue where a file handle was leaked if the `fldata` function call failed in the `handle_data_set_compress` command handler. [#577](https://github.com/zowe/zowex/issues/577)
+- `c`: Fixed issue in the `zut_substitute_symbol` function where passing patterns with a length greater than the input buffer would cause a buffer overflow. [#577](https://github.com/zowe/zowex/issues/577)
+- `c`: Fixed undefined behavior in the `zut_bpxwdyn` function by verifying that the allocated 31-bit region is valid before writing to it. [#577](https://github.com/zowe/zowex/issues/577)
+- `c`: The CLI parser now prints unexpected, trailing positional arguments when handling command input. [#594](https://github.com/zowe/zowex/issues/594)
+- Rewrote the middleware (`zowed`) in C++. This removes our dependency on Golang, improves performance, and allows parallel requests to be handled in a single address space. [#595](https://github.com/zowe/zowex/pull/595)
+- `c`: Fixed issue where automatic codepage conversion with `_BPXK_AUTOCVT` was not disabled for all USS read and write operations, which could interfere with the `--encoding` option. [#620](https://github.com/zowe/zowex/pull/620)
 
 ## `0.1.10`
 
 - `c`: Added `zowex tool list-parmlib` command to list parmlib concatenation data sets.
-- Added plug-in support to the `zowex` backend. Plug-ins can contribute commands that users invoke through `zowex`. For more information on how to create and register a plug-in with `zowex`, please refer to the `plugins.md` file in the `doc/` root-level folder. [#148](https://github.com/zowe/zowe-native-proto/issues/148)
+- Added plug-in support to the `zowex` backend. Plug-ins can contribute commands that users invoke through `zowex`. For more information on how to create and register a plug-in with `zowex`, please refer to the `plugins.md` file in the `doc/` root-level folder. [#148](https://github.com/zowe/zowex/issues/148)
 
 ## `0.1.9`
 
-- `golang`: Fixed an issue where an empty response on the `HandleReadFileRequest` function would result in a panic. [#550](https://github.com/zowe/zowe-native-proto/pull/550)
-- `c`: Fixed issue where the `zowex ds lm` command always returned non-zero exit code for warnings and ignored the `--no-warn` flag. [#498](https://github.com/zowe/zowe-native-proto/issues/498)
-- `c`: Fixed issue where the `zowex job submit-jcl` command submitted the given JCL contents twice, causing two jobs to be created. [#508](https://github.com/zowe/zowe-native-proto/issues/508)
-- `c`: Implemented a logger for Metal C and C++ source code for diagnostics, debug information, and printing dumps. When enabled, log messages are written to a log file named `zowex.log` in a new `logs` folder, relative to the location of the `zowex` binary. [#107](https://github.com/zowe/zowe-native-proto/issues/107)
-- `golang`: Moved location of log file inside "logs" directory to be consistent with `zowex`. [#514](https://github.com/zowe/zowe-native-proto/pull/514)
-- `c`: Fixed issue where the `zowex ds write` command automatically created a data set when it did not exist. [#292](https://github.com/zowe/zowe-native-proto/issues/292)
-- `native`: Fixed issue where the `zowex ds ls` command could hang when listing data sets that the system cannot open. [#496](https://github.com/zowe/zowe-native-proto/issues/496)
-- `c`: Added `--local-encoding` option for read and write operations on data sets, USS files, and job files to specify the source encoding of content (defaults to UTF-8). [#511](https://github.com/zowe/zowe-native-proto/issues/511)
-- `c`: Fixed issue where the `zowex ds create` command did not parse `--alcunit` and integer arguments (e.g., `--primary`). [#414](https://github.com/zowe/zowe-native-proto/issues/414)
-- `c`: Fixed issue where listing data sets fails if the `OBTAIN` service fails while obtaining attributes for a data set in the list of matches. [#529](https://github.com/zowe/zowe-native-proto/issues/529)
-- `native`: Added support for `volser` option when reading/writing data sets. [#439](https://github.com/zowe/zowe-native-proto/issues/439)
-- `native`: Reduced number of memory allocations in vectors by reserving capacity before adding elements. [#522](https://github.com/zowe/zowe-native-proto/issues/522)
+- `golang`: Fixed an issue where an empty response on the `HandleReadFileRequest` function would result in a panic. [#550](https://github.com/zowe/zowex/pull/550)
+- `c`: Fixed issue where the `zowex ds lm` command always returned non-zero exit code for warnings and ignored the `--no-warn` flag. [#498](https://github.com/zowe/zowex/issues/498)
+- `c`: Fixed issue where the `zowex job submit-jcl` command submitted the given JCL contents twice, causing two jobs to be created. [#508](https://github.com/zowe/zowex/issues/508)
+- `c`: Implemented a logger for Metal C and C++ source code for diagnostics, debug information, and printing dumps. When enabled, log messages are written to a log file named `zowex.log` in a new `logs` folder, relative to the location of the `zowex` binary. [#107](https://github.com/zowe/zowex/issues/107)
+- `golang`: Moved location of log file inside "logs" directory to be consistent with `zowex`. [#514](https://github.com/zowe/zowex/pull/514)
+- `c`: Fixed issue where the `zowex ds write` command automatically created a data set when it did not exist. [#292](https://github.com/zowe/zowex/issues/292)
+- `native`: Fixed issue where the `zowex ds ls` command could hang when listing data sets that the system cannot open. [#496](https://github.com/zowe/zowex/issues/496)
+- `c`: Added `--local-encoding` option for read and write operations on data sets, USS files, and job files to specify the source encoding of content (defaults to UTF-8). [#511](https://github.com/zowe/zowex/issues/511)
+- `c`: Fixed issue where the `zowex ds create` command did not parse `--alcunit` and integer arguments (e.g., `--primary`). [#414](https://github.com/zowe/zowex/issues/414)
+- `c`: Fixed issue where listing data sets fails if the `OBTAIN` service fails while obtaining attributes for a data set in the list of matches. [#529](https://github.com/zowe/zowex/issues/529)
+- `native`: Added support for `volser` option when reading/writing data sets. [#439](https://github.com/zowe/zowex/issues/439)
+- `native`: Reduced number of memory allocations in vectors by reserving capacity before adding elements. [#522](https://github.com/zowe/zowex/issues/522)
 - `c`: Added wrappers for Web Enablement Toolkit to be invoked via Metal C as header only or from LE-C using a 64-bit wrapper.
 - `c`: Added the `zstd::optional` class for handling optional values.
 - `c`: Added the `zstd::unique_ptr` class and `zstd::make_unique` function for RAII-based automatic memory management.
@@ -141,103 +141,103 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## `0.1.8`
 
-- `native`: Added default value for `--recfm` so that when no options are specified the data set will not contain errors. [#493](https://github.com/zowe/zowe-native-proto/issues/493)
-- Fixed issue where special characters were detected as invalid characters when provided to `zowex` commands. [#491](https://github.com/zowe/zowe-native-proto/issues/491)
-- `native`: Increase default max returned entries in `zowex ds list` from 100 to 5000. This helps with [#487](https://github.com/zowe/zowe-native-proto/issues/487) but does not fix it. In the future, users should be able to specify on the Zowe Clients the max number of entries.
+- `native`: Added default value for `--recfm` so that when no options are specified the data set will not contain errors. [#493](https://github.com/zowe/zowex/issues/493)
+- Fixed issue where special characters were detected as invalid characters when provided to `zowex` commands. [#491](https://github.com/zowe/zowex/issues/491)
+- `native`: Increase default max returned entries in `zowex ds list` from 100 to 5000. This helps with [#487](https://github.com/zowe/zowex/issues/487) but does not fix it. In the future, users should be able to specify on the Zowe Clients the max number of entries.
 
 ## `0.1.7`
 
-- Updated CLI parser `find_kw_arg_bool` function to take in an optional boolean `check_for_negation` that, when `true`, looks for a negated option value. [#485](https://github.com/zowe/zowe-native-proto/issues/485)
-- Fixed issue where listing data set members did not check for the negated option value. Now, the command handler passes the `check_for_negation` option to the `find_kw_arg_bool` function to check the value of the negated, equivalent option. [#485](https://github.com/zowe/zowe-native-proto/issues/485)
-- `golang`: Fixed inconsistent type of the `data` property between the `ReadDatasetResponse` and `ReadFileResponse` types. [#488](https://github.com/zowe/zowe-native-proto/pull/488)
+- Updated CLI parser `find_kw_arg_bool` function to take in an optional boolean `check_for_negation` that, when `true`, looks for a negated option value. [#485](https://github.com/zowe/zowex/issues/485)
+- Fixed issue where listing data set members did not check for the negated option value. Now, the command handler passes the `check_for_negation` option to the `find_kw_arg_bool` function to check the value of the negated, equivalent option. [#485](https://github.com/zowe/zowex/issues/485)
+- `golang`: Fixed inconsistent type of the `data` property between the `ReadDatasetResponse` and `ReadFileResponse` types. [#488](https://github.com/zowe/zowex/pull/488)
 
 ## `0.1.6`
 
-- `native`: Fixed regression where data set download operations would fail due to a content length mismatch, due to the content length being printed as hexadecimal rather than decimal. [#482](https://github.com/zowe/zowe-native-proto/issues/482)
+- `native`: Fixed regression where data set download operations would fail due to a content length mismatch, due to the content length being printed as hexadecimal rather than decimal. [#482](https://github.com/zowe/zowex/issues/482)
 
 ## `0.1.5`
 
 - `native`: Added completion code for `POST` so that users of the library code may determine if a timeout has occurred.
-- `native`: Added `timeout` for `zowex console issue` to prevent indefinite hang when no messages are returned. [#470](https://github.com/zowe/zowe-native-proto/pull/470)
-- `native`: Added `contentLen` property to RPC responses for reading/writing data sets and USS files. [#358](https://github.com/zowe/zowe-native-proto/pull/358)
-- `native`: Fixed file tag being prioritized over user-specified codepage when reading/writing USS files. [#467](https://github.com/zowe/zowe-native-proto/pull/467)
-- `native`: Fixed issue where `max-entries` argument was incorrectly parsed as a string rather than an integer. [#469](https://github.com/zowe/zowe-native-proto/issues/469)
-- `native`: The `zowex` root command now has a command handler to make adding new options easier. [#468](https://github.com/zowe/zowe-native-proto/pull/468)
+- `native`: Added `timeout` for `zowex console issue` to prevent indefinite hang when no messages are returned. [#470](https://github.com/zowe/zowex/pull/470)
+- `native`: Added `contentLen` property to RPC responses for reading/writing data sets and USS files. [#358](https://github.com/zowe/zowex/pull/358)
+- `native`: Fixed file tag being prioritized over user-specified codepage when reading/writing USS files. [#467](https://github.com/zowe/zowex/pull/467)
+- `native`: Fixed issue where `max-entries` argument was incorrectly parsed as a string rather than an integer. [#469](https://github.com/zowe/zowex/issues/469)
+- `native`: The `zowex` root command now has a command handler to make adding new options easier. [#468](https://github.com/zowe/zowex/pull/468)
 
 ## `0.1.4`
 
 - `c`: Fixed an issue where the CLI help text showed the `[options]` placeholder in the usage example before the positional arguments, which is not a supported syntax. Now, the usage text shows the `[options]` placeholder after the positional arguments for the given command.
-- `c`: Added `zowex version` command to print the latest build information for the `zowex` executable. The version output contains the build date and the package version. [#366](https://github.com/zowe/zowe-native-proto/issues/366)
-- `c`: Added `full_status` variable from job output to the CSV output for the `zowex job view-status --rfc` command. [#450](https://github.com/zowe/zowe-native-proto/pull/450)
-- `golang`: If the `zowed` process abnormally terminates due to a SIGINT or SIGTERM signal, the worker processes are now gracefully terminated. [#372](https://github.com/zowe/zowe-native-proto/issues/372)
-- `c`: Updated `zowex uss list` command to provide same attributes as output from the `ls -l` UNIX command when the `--long` flag is specified. [#346](https://github.com/zowe/zowe-native-proto/issues/346)
-- `c`: Updated `zowex uss list` command to match format of the `ls -l` UNIX command. [#383](https://github.com/zowe/zowe-native-proto/issues/383)
-- `c`: Added `response-format-csv` option to the `zowex uss list` command to print the file attributes in CSV format. [#346](https://github.com/zowe/zowe-native-proto/issues/346)
-- `golang`: Added additional data points to the USS item response for the `HandleListFilesRequest` command handler. [#346](https://github.com/zowe/zowe-native-proto/issues/346)
+- `c`: Added `zowex version` command to print the latest build information for the `zowex` executable. The version output contains the build date and the package version. [#366](https://github.com/zowe/zowex/issues/366)
+- `c`: Added `full_status` variable from job output to the CSV output for the `zowex job view-status --rfc` command. [#450](https://github.com/zowe/zowex/pull/450)
+- `golang`: If the `zowed` process abnormally terminates due to a SIGINT or SIGTERM signal, the worker processes are now gracefully terminated. [#372](https://github.com/zowe/zowex/issues/372)
+- `c`: Updated `zowex uss list` command to provide same attributes as output from the `ls -l` UNIX command when the `--long` flag is specified. [#346](https://github.com/zowe/zowex/issues/346)
+- `c`: Updated `zowex uss list` command to match format of the `ls -l` UNIX command. [#383](https://github.com/zowe/zowex/issues/383)
+- `c`: Added `response-format-csv` option to the `zowex uss list` command to print the file attributes in CSV format. [#346](https://github.com/zowe/zowex/issues/346)
+- `golang`: Added additional data points to the USS item response for the `HandleListFilesRequest` command handler. [#346](https://github.com/zowe/zowex/issues/346)
 
 ## `0.1.3`
 
-- `c`: Fixed S0C4 where supervisor state, key 4 caller invokes `zcn_put` while running in SUPERVISOR state. [#392](https://github.com/zowe/zowe-native-proto/issues/392)
-- `c`: Fixed S0C4 where supervisor state, key 4 caller invokes `zcn` APIs and several miscellaneous issues. [#389](https://github.com/zowe/zowe-native-proto/issues/389)
-- `c`: Fixed issue where canceled jobs displayed as "CC nnnn" instead of the string "CANCELED". [#169](https://github.com/zowe/zowe-native-proto/issues/169)
-- `c`: Fixed issue where input job SYSOUT files could not be listed or displayed". [#196](https://github.com/zowe/zowe-native-proto/issues/196)
-- `native`: Fixed issue where `zowed` failed to process RPC requests larger than 64 KB. [#364](https://github.com/zowe/zowe-native-proto/pull/364)
-- `golang`: `zowed` now returns the UNIX permissions for each item's `mode` property in a USS list response. [#341](https://github.com/zowe/zowe-native-proto/pull/341)
-- `c`: Added `--long` option to the `zowex uss list` command to return the long format for list output, containing additional file metadata. [#341](https://github.com/zowe/zowe-native-proto/pull/341)
-- `c`: Added `--all` option to the `zowex uss list` command to show hidden files when listing a UNIX directory. [#341](https://github.com/zowe/zowe-native-proto/pull/341)
-- `c`: Added `ListOptions` parameter to the `zusf_list_uss_file_path` function to support listing the long format and hidden files. [#341](https://github.com/zowe/zowe-native-proto/pull/341)
-- `c`: Fixed issue where the record format (`recfm` attribute) was listed as unknown for a Partitioned Data Set (PDS) with no members. Now, the record format for all data sets is retrieved through the Volume Table of Contents. [#351](https://github.com/zowe/zowe-native-proto/pull/351)
+- `c`: Fixed S0C4 where supervisor state, key 4 caller invokes `zcn_put` while running in SUPERVISOR state. [#392](https://github.com/zowe/zowex/issues/392)
+- `c`: Fixed S0C4 where supervisor state, key 4 caller invokes `zcn` APIs and several miscellaneous issues. [#389](https://github.com/zowe/zowex/issues/389)
+- `c`: Fixed issue where canceled jobs displayed as "CC nnnn" instead of the string "CANCELED". [#169](https://github.com/zowe/zowex/issues/169)
+- `c`: Fixed issue where input job SYSOUT files could not be listed or displayed". [#196](https://github.com/zowe/zowex/issues/196)
+- `native`: Fixed issue where `zowed` failed to process RPC requests larger than 64 KB. [#364](https://github.com/zowe/zowex/pull/364)
+- `golang`: `zowed` now returns the UNIX permissions for each item's `mode` property in a USS list response. [#341](https://github.com/zowe/zowex/pull/341)
+- `c`: Added `--long` option to the `zowex uss list` command to return the long format for list output, containing additional file metadata. [#341](https://github.com/zowe/zowex/pull/341)
+- `c`: Added `--all` option to the `zowex uss list` command to show hidden files when listing a UNIX directory. [#341](https://github.com/zowe/zowex/pull/341)
+- `c`: Added `ListOptions` parameter to the `zusf_list_uss_file_path` function to support listing the long format and hidden files. [#341](https://github.com/zowe/zowex/pull/341)
+- `c`: Fixed issue where the record format (`recfm` attribute) was listed as unknown for a Partitioned Data Set (PDS) with no members. Now, the record format for all data sets is retrieved through the Volume Table of Contents. [#351](https://github.com/zowe/zowex/pull/351)
 - `c`: Added CLI parser and lexer library for use in `zowex`. For an example of how to use the new CLI parser library, refer to the sample CLI code in `examples/native-cli/testcli.cpp`.
 - `c`: Fixed an issue where the zowex `ds list` command always printed data set attributes when passing the argument `--response-format-csv`, even if the attributes argument was `false`.
-- `c`: Fixed an issue where the `zusf_chmod_uss_file_or_dir` function did not handle invalid input before passing the mode to the `chmod` C standard library function. [#399](https://github.com/zowe/zowe-native-proto/pull/399)
-- `c`: Refactored the Base64 encoder and decoder to remove external dependency. [#385](https://github.com/zowe/zowe-native-proto/issues/385)
+- `c`: Fixed an issue where the `zusf_chmod_uss_file_or_dir` function did not handle invalid input before passing the mode to the `chmod` C standard library function. [#399](https://github.com/zowe/zowex/pull/399)
+- `c`: Refactored the Base64 encoder and decoder to remove external dependency. [#385](https://github.com/zowe/zowex/issues/385)
 
 ## `0.1.2`
 
-- `golang`: `zowed` now prints a ready message once it can accept input over stdin. [#221](https://github.com/zowe/zowe-native-proto/pull/221)
-- `golang`: Reduced startup time for `zowed` by initializing workers in the background. [#237](https://github.com/zowe/zowe-native-proto/pull/237)
-- `golang`: Added verbose option to enable debug logging. [#237](https://github.com/zowe/zowe-native-proto/pull/237)
-- `golang`: Added SHA256 checksums to the ready message to allow checks for outdated server. [#236](https://github.com/zowe/zowe-native-proto/pull/236)
-- `c,golang`: Added support for streaming USS file contents for read and write operations (`zusf_read_from_uss_file_streamed`, `zusf_write_to_uss_file_streamed`). [#311](https://github.com/zowe/zowe-native-proto/pull/311)
-- `c,golang`: Added support for streaming data set contents for read and write operations (`zds_read_from_dsn_streamed`, `zds_write_to_dsn_streamed`). [#326](https://github.com/zowe/zowe-native-proto/pull/326)
+- `golang`: `zowed` now prints a ready message once it can accept input over stdin. [#221](https://github.com/zowe/zowex/pull/221)
+- `golang`: Reduced startup time for `zowed` by initializing workers in the background. [#237](https://github.com/zowe/zowex/pull/237)
+- `golang`: Added verbose option to enable debug logging. [#237](https://github.com/zowe/zowex/pull/237)
+- `golang`: Added SHA256 checksums to the ready message to allow checks for outdated server. [#236](https://github.com/zowe/zowex/pull/236)
+- `c,golang`: Added support for streaming USS file contents for read and write operations (`zusf_read_from_uss_file_streamed`, `zusf_write_to_uss_file_streamed`). [#311](https://github.com/zowe/zowex/pull/311)
+- `c,golang`: Added support for streaming data set contents for read and write operations (`zds_read_from_dsn_streamed`, `zds_write_to_dsn_streamed`). [#326](https://github.com/zowe/zowex/pull/326)
 - `c`: Added support for `recfm` (record format) attribute when listing data sets.
 - `c`: Fixed issue where data sets were not opened with the right `recfm` for reading/writing.
 
 ## `0.1.1`
 
-- `c`: Fixed issue where running the `zowex uss write` or `zowex ds write` commands without the `--etag-only` parameter resulted in a S0C4 and abrupt termination. [#216](https://github.com/zowe/zowe-native-proto/pull/216)
-- `c`: Fixed issue where running the `zowex uss write` or `zowex ds write` commands without the `--encoding` parameter resulted in a no-op. [#216](https://github.com/zowe/zowe-native-proto/pull/216)
-- `golang`: Fixed issue where a jobs list request returns unexpected results whenever a search query does not match any jobs. [#217](https://github.com/zowe/zowe-native-proto/pull/217)
-- `c`: Fixed issue where e-tag calculation did not match when a data set was saved with the `--encoding` parameter provided. [#219](https://github.com/zowe/zowe-native-proto/pull/219)
+- `c`: Fixed issue where running the `zowex uss write` or `zowex ds write` commands without the `--etag-only` parameter resulted in a S0C4 and abrupt termination. [#216](https://github.com/zowe/zowex/pull/216)
+- `c`: Fixed issue where running the `zowex uss write` or `zowex ds write` commands without the `--encoding` parameter resulted in a no-op. [#216](https://github.com/zowe/zowex/pull/216)
+- `golang`: Fixed issue where a jobs list request returns unexpected results whenever a search query does not match any jobs. [#217](https://github.com/zowe/zowex/pull/217)
+- `c`: Fixed issue where e-tag calculation did not match when a data set was saved with the `--encoding` parameter provided. [#219](https://github.com/zowe/zowex/pull/219)
 
 ## `0.1.0`
 
-- `c`: Enable `langlvl(extended0x)` for C++ code to support C++0x features (`auto`, `nullptr`, etc.) [#35](https://github.com/zowe/zowe-native-proto/pull/35)
-- `c`: Replace all applicable `NULL` references with `nullptr` in C++ code. [#36](https://github.com/zowe/zowe-native-proto/pull/36)
-- `c,golang`: Add support for writing data sets and USS files with the given encoding. [#37](https://github.com/zowe/zowe-native-proto/pull/37)
-- `golang`: Added `restoreDataset` function in the middleware. [#38](https://github.com/zowe/zowe-native-proto/pull/38)
+- `c`: Enable `langlvl(extended0x)` for C++ code to support C++0x features (`auto`, `nullptr`, etc.) [#35](https://github.com/zowe/zowex/pull/35)
+- `c`: Replace all applicable `NULL` references with `nullptr` in C++ code. [#36](https://github.com/zowe/zowex/pull/36)
+- `c,golang`: Add support for writing data sets and USS files with the given encoding. [#37](https://github.com/zowe/zowex/pull/37)
+- `golang`: Added `restoreDataset` function in the middleware. [#38](https://github.com/zowe/zowex/pull/38)
 - `golang`: Added `procstep` and `dsname` to the list of fields when getting spool files
-- `golang`: Added `tygo` to generate types based on the Go types for the TypeScript SDK. [#71](https://github.com/zowe/zowe-native-proto/pull/71)
-- `c,golang`: Added `watch:native` npm script to detect and upload changes to files during development. [#100](https://github.com/zowe/zowe-native-proto/pull/100)
-- `c,golang`: Added `chmod`, `chown`, `chtag` and `delete` functionality for USS files & folders. [#143](https://github.com/zowe/zowe-native-proto/pull/143)
-- `c,golang`: Added support for recursive `chmod` functionality for USS folders. [#143](https://github.com/zowe/zowe-native-proto/pull/143)
-- `c,golang`: Added capability to submit JCL from stdin. [#143](https://github.com/zowe/zowe-native-proto/pull/143)
-- `c`: Add support for `mkdir -p` behavior when making a new USS directory. [#143](https://github.com/zowe/zowe-native-proto/pull/143)
-- `golang`: Refactored error handling in Go layer to forward errors to client as JSON. [#143](https://github.com/zowe/zowe-native-proto/pull/143)
-- `c`: Fixed dangling pointers in CLI code & refactored reading resource contents to avoid manual memory allocation. [#167](https://github.com/zowe/zowe-native-proto/pull/167)
-- `golang`: Added `createDataset` function in the middleware. [#95](https://github.com/zowe/zowe-native-proto/pull/95)
-- `c,golang`: Added `createMember` function. [#95](https://github.com/zowe/zowe-native-proto/pull/95)
-- `c,golang`: Added `cancelJob` function. [#138](https://github.com/zowe/zowe-native-proto/pull/138)
-- `c,golang`: Added `holdJob` and `releaseJob` functions. [#182](https://github.com/zowe/zowe-native-proto/pull/182)
-- `c`: Fixed issue where data set search patterns did not return the same results as z/OSMF. [#74](https://github.com/zowe/zowe-native-proto/issues/74)
-- `c`: Added check for maximum data set pattern length before making a list request. Now, requests with patterns longer than 44 characters are rejected. [#185](https://github.com/zowe/zowe-native-proto/pull/185)
-- `c,golang`: Fixed issue where submit JCL handler did not convert input data from UTF-8 and did not support an `--encoding` option. [#198](https://github.com/zowe/zowe-native-proto/pull/198)
-- `c`: Fixed issue where submit JCL handler did not support raw bytes from stdin when the binary is directly invoked through a shell. [#198](https://github.com/zowe/zowe-native-proto/pull/198)
-- `c,golang`: Added `submitUss` function. [#184](https://github.com/zowe/zowe-native-proto/pull/184)
-- `golang`: Fixed issue where listing a non-existent data set pattern resulted in a panic and abrupt termination of `zowed`. [#200](https://github.com/zowe/zowe-native-proto/issues/200)
-- `golang`: Fixed issue where a newline was present in the job ID when returning a response for the "submitJcl" command. [#211](https://github.com/zowe/zowe-native-proto/pull/211)
-- `c`: Added conflict detection for USS and Data Set write operations through use of the `--etag` option. [#144](https://github.com/zowe/zowe-native-proto/issues/144)
-- `golang`: Added `Etag` property to request and response types for both USS and Data Set write operations. [#144](https://github.com/zowe/zowe-native-proto/issues/144)
+- `golang`: Added `tygo` to generate types based on the Go types for the TypeScript SDK. [#71](https://github.com/zowe/zowex/pull/71)
+- `c,golang`: Added `watch:native` npm script to detect and upload changes to files during development. [#100](https://github.com/zowe/zowex/pull/100)
+- `c,golang`: Added `chmod`, `chown`, `chtag` and `delete` functionality for USS files & folders. [#143](https://github.com/zowe/zowex/pull/143)
+- `c,golang`: Added support for recursive `chmod` functionality for USS folders. [#143](https://github.com/zowe/zowex/pull/143)
+- `c,golang`: Added capability to submit JCL from stdin. [#143](https://github.com/zowe/zowex/pull/143)
+- `c`: Add support for `mkdir -p` behavior when making a new USS directory. [#143](https://github.com/zowe/zowex/pull/143)
+- `golang`: Refactored error handling in Go layer to forward errors to client as JSON. [#143](https://github.com/zowe/zowex/pull/143)
+- `c`: Fixed dangling pointers in CLI code & refactored reading resource contents to avoid manual memory allocation. [#167](https://github.com/zowe/zowex/pull/167)
+- `golang`: Added `createDataset` function in the middleware. [#95](https://github.com/zowe/zowex/pull/95)
+- `c,golang`: Added `createMember` function. [#95](https://github.com/zowe/zowex/pull/95)
+- `c,golang`: Added `cancelJob` function. [#138](https://github.com/zowe/zowex/pull/138)
+- `c,golang`: Added `holdJob` and `releaseJob` functions. [#182](https://github.com/zowe/zowex/pull/182)
+- `c`: Fixed issue where data set search patterns did not return the same results as z/OSMF. [#74](https://github.com/zowe/zowex/issues/74)
+- `c`: Added check for maximum data set pattern length before making a list request. Now, requests with patterns longer than 44 characters are rejected. [#185](https://github.com/zowe/zowex/pull/185)
+- `c,golang`: Fixed issue where submit JCL handler did not convert input data from UTF-8 and did not support an `--encoding` option. [#198](https://github.com/zowe/zowex/pull/198)
+- `c`: Fixed issue where submit JCL handler did not support raw bytes from stdin when the binary is directly invoked through a shell. [#198](https://github.com/zowe/zowex/pull/198)
+- `c,golang`: Added `submitUss` function. [#184](https://github.com/zowe/zowex/pull/184)
+- `golang`: Fixed issue where listing a non-existent data set pattern resulted in a panic and abrupt termination of `zowed`. [#200](https://github.com/zowe/zowex/issues/200)
+- `golang`: Fixed issue where a newline was present in the job ID when returning a response for the "submitJcl" command. [#211](https://github.com/zowe/zowex/pull/211)
+- `c`: Added conflict detection for USS and Data Set write operations through use of the `--etag` option. [#144](https://github.com/zowe/zowex/issues/144)
+- `golang`: Added `Etag` property to request and response types for both USS and Data Set write operations. [#144](https://github.com/zowe/zowex/issues/144)
 
 ## [Unreleased]
 

--- a/native/c/commands/core.cpp
+++ b/native/c/commands/core.cpp
@@ -206,7 +206,7 @@ int execute_command(int argc, char *argv[])
 
 Command &setup_root_command(char *argv[])
 {
-  g_arg_parser = std::make_shared<ArgumentParser>(argv[0], "Zowe Native CLI");
+  g_arg_parser = std::make_shared<ArgumentParser>(argv[0], "Zowe Remote SSH CLI");
   auto &root_command = g_arg_parser->get_root_command();
 
   root_command.add_keyword_arg("interactive",

--- a/native/c/commands/core.cpp
+++ b/native/c/commands/core.cpp
@@ -95,7 +95,7 @@ int interactive_mode(const plugin::InvocationContext &context)
 
 int handle_version(plugin::InvocationContext &context)
 {
-  context.output_stream() << "Zowe Native Protocol CLI (zowex)" << std::endl;
+  context.output_stream() << "Zowe Remote SSH CLI (zowex)" << std::endl;
   context.output_stream() << "Version: " << g_version << std::endl;
   context.output_stream() << "Build Date: " << BUILD_DATE << " " << BUILD_TIME << std::endl;
   context.output_stream() << "Copyright Contributors to the Zowe Project." << std::endl;

--- a/native/c/commands/server.cpp
+++ b/native/c/commands/server.cpp
@@ -254,7 +254,7 @@ static int handle_server(plugin::InvocationContext &context)
 
 void register_commands(Command &root_command)
 {
-  auto server_cmd = std::make_shared<Command>("server", "start the Zowe native IO server");
+  auto server_cmd = std::make_shared<Command>("server", "start the Zowe Remote SSH I/O server");
   server_cmd->add_keyword_arg("num-workers",
                               make_aliases("-w", "--num-workers"),
                               "number of worker threads",

--- a/native/c/server/builder.cpp
+++ b/native/c/server/builder.cpp
@@ -259,7 +259,7 @@ void CommandBuilder::apply_input_transforms(MiddlewareContext &context) const
           }
           long long stream_id = *stream_id_ptr;
 
-          // Create pipe path: /tmp/zowe-native-proto_{uid}_{pid}_{stream_id}_fifo
+          // Create pipe path: /tmp/zowex_{uid}_{pid}_{stream_id}_fifo
           const char *tmp_dir = std::getenv("TMPDIR");
           if (tmp_dir == nullptr || tmp_dir[0] == '\0')
           {
@@ -267,7 +267,7 @@ void CommandBuilder::apply_input_transforms(MiddlewareContext &context) const
           }
 
           std::ostringstream pipe_path_stream;
-          pipe_path_stream << tmp_dir << "/zowe-native-proto_"
+          pipe_path_stream << tmp_dir << "/zowex_"
                            << geteuid() << "_"
                            << getpid() << "_"
                            << stream_id << "_fifo";

--- a/native/c/test/zjb.test.cpp
+++ b/native/c/test/zjb.test.cpp
@@ -126,7 +126,7 @@ void zjb_tests()
                   ExpectWithContext(rc, zjb.diag.e_msg).ToBe(RTNCD_SUCCESS); 
                 });
               
-              // https://github.com/zowe/zowe-native-proto/issues/641
+              // https://github.com/zowe/zowex/issues/641
               xit("should be able to list and view SYSOUT files for INPUT jobs", [&]() -> void
                 {
                   ZJB zjb = {0};

--- a/native/c/test/zowex.ds.test.cpp
+++ b/native/c/test/zowex.ds.test.cpp
@@ -147,7 +147,7 @@ void zowex_ds_tests()
                            });
 
                         // NOTE: This test may fail if we don't save/clear/restore registers for PDSMAN/IEBCOPY
-                        // See https://github.com/zowe/zowe-native-proto/issues/790
+                        // See https://github.com/zowe/zowex/issues/790
                         it("should compress a data set", [&]() -> void
                            {
                              std::string ds = _ds.back();
@@ -160,7 +160,7 @@ void zowex_ds_tests()
                              Expect(response).ToContain("Data set");
                              Expect(response).ToContain("compressed"); });
 
-                        // TODO: https://github.com/zowe/zowe-native-proto/issues/666
+                        // TODO: https://github.com/zowe/zowex/issues/666
                         xit("should error when the data set is VSAM", []() -> void {});
                         xit("should error when the data set is GDG", []() -> void {});
                         xit("should error when the data set is ALIAS", []() -> void {});
@@ -249,7 +249,7 @@ void zowex_ds_tests()
                              Expect(tokens[4]).ToBe("VB");
                            });
 
-                        // TODO: https://github.com/zowe/zowe-native-proto/pull/625
+                        // TODO: https://github.com/zowe/zowex/pull/625
                         it("should create a data set - dsorg: PO, primary: 10, secondary: 2, lrecl: 20, blksize:10, dirblk: 5, alcunit: CYL",
                            [&]() -> void
                            {
@@ -497,7 +497,7 @@ void zowex_ds_tests()
                              Expect(response).ToContain("Data set and/or member created");
                            });
 
-                        // TODO: https://github.com/zowe/zowe-native-proto/issues/643
+                        // TODO: https://github.com/zowe/zowex/issues/643
                         xit("should not overwrite existing members",
                             [&]() -> void
                             {
@@ -664,20 +664,20 @@ void zowex_ds_tests()
                         // TODO: What do?
                         xit("should fail to delete a data set that is currently in use", []() -> void {});
 
-                        // TODO: https://github.com/zowe/zowe-native-proto/issues/665
+                        // TODO: https://github.com/zowe/zowex/issues/665
                         xit("should delete multiple data sets specified in a list", []() -> void {});
 
-                        // TODO: https://github.com/zowe/zowe-native-proto/issues/664
+                        // TODO: https://github.com/zowe/zowex/issues/664
                         xit("should delete a data set using the force option even if it has members", []() -> void {});
                         xit("should not delete a data set with the force option if it is in use", []() -> void {});
 
-                        // TODO: https://github.com/zowe/zowe-native-proto/issues/666
+                        // TODO: https://github.com/zowe/zowex/issues/666
                         xit("should delete a VSAM KSDS data set", []() -> void {});
                         xit("should delete a VSAM ESDS data set", []() -> void {});
                         xit("should delete a VSAM RRDS data set", []() -> void {});
                         xit("should delete a VSAM LDS data set", []() -> void {});
 
-                        // TODO: https://github.com/zowe/zowe-native-proto/issues/666
+                        // TODO: https://github.com/zowe/zowex/issues/666
                         xit("should delete a generation data group (GDG) base when empty", []() -> void {});
                         xit("should delete a generation data group (GDG) base and all its generations", []() -> void {});
                         xit("should delete a specific generation of a GDG", []() -> void {});
@@ -760,13 +760,13 @@ void zowex_ds_tests()
                              Expect(response).ToContain("Error: data set pattern exceeds 44 character length limit");
                            });
 
-                        // TODO: https://github.com/zowe/zowe-native-proto/issues/666
+                        // TODO: https://github.com/zowe/zowex/issues/666
                         xit("should list information for a VSAM KSDS data set", []() -> void {});
                         xit("should list information for a VSAM ESDS data set", []() -> void {});
                         xit("should list information for a VSAM RRDS data set", []() -> void {});
                         xit("should list information for a VSAM LDS data set", []() -> void {});
 
-                        // TODO: https://github.com/zowe/zowe-native-proto/issues/666
+                        // TODO: https://github.com/zowe/zowex/issues/666
                         xit("should list generations of a generation data group (GDG) base", []() -> void {});
                         xit("should list specific generation of a GDG", []() -> void {});
                       });
@@ -859,7 +859,7 @@ void zowex_ds_tests()
                              Expect(response).ToContain("N");
                            });
                       });
-             // TODO: https://github.com/zowe/zowe-native-proto/issues/380
+             // TODO: https://github.com/zowe/zowex/issues/380
              xdescribe("restore",
                        [&]() -> void
                        {
@@ -988,7 +988,7 @@ void zowex_ds_tests()
                         // What do?
                         xit("should fail to view a data set if not authorized", []() -> void {});
 
-                        // TODO: https://github.com/zowe/zowe-native-proto/issues/666
+                        // TODO: https://github.com/zowe/zowex/issues/666
                         xit("should view the content of a VSAM KSDS data set", []() -> void {});
                         xit("should view the content of a VSAM ESDS data set", []() -> void {});
                         xit("should view the content of a VSAM RRDS data set", []() -> void {});

--- a/native/c/test/zusf.test.cpp
+++ b/native/c/test/zusf.test.cpp
@@ -246,9 +246,9 @@ void zusf_tests()
                   rc = zusf_list_uss_file_path(&zusf, dest_dir, list_response, all_long_list_opts, false);
                   Expect(rc).ToBe(0);
                   // chmod hack won't work here, can't modify symlink permissions
-                  // Expect(list_response).ToContain("lrwxr-xr-x"); //TODO: https://github.com/zowe/zowe-native-proto/issues/791
+                  // Expect(list_response).ToContain("lrwxr-xr-x"); //TODO: https://github.com/zowe/zowex/issues/791
                   // rc = zusf_delete_uss_item(&zusf, dest_dir, true);
-                  // Expect(rc).ToBe(-1); // TODO: https://github.com/zowe/zowe-native-proto/issues/792
+                  // Expect(rc).ToBe(-1); // TODO: https://github.com/zowe/zowex/issues/792
 
                   execute_command_with_output("rm -rf " + dest_dir, cmd_output);
 

--- a/native/c/toolchain.mk
+++ b/native/c/toolchain.mk
@@ -6,7 +6,7 @@
 #
 #  SPDX-License-Identifier: EPL-2.0
 #
-#  Shared toolchain definitions for Zowe native components.
+#  Shared toolchain definitions for the native Zowe Remote SSH components.
 #
 
 CXX=ibm-clang++64

--- a/native/python/bindings/Makefile
+++ b/native/python/bindings/Makefile
@@ -1,4 +1,4 @@
-# Makefile for building Python bindings for zowe-native-proto
+# Makefile for building Python bindings for zowex
 
 # Default target
 all: swig-extenders build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "zowe-native-proto",
+  "name": "zowex",
   "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "zowe-native-proto",
+      "name": "zowex",
       "version": "0.4.0",
       "license": "EPL-2.0",
       "workspaces": [
@@ -10178,31 +10178,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/zowe-native-proto-cli": {
+    "node_modules/zowex-cli": {
       "resolved": "packages/cli",
       "link": true
     },
-    "node_modules/zowe-native-proto-sdk": {
+    "node_modules/zowex-sdk": {
       "resolved": "packages/sdk",
       "link": true
     },
-    "node_modules/zowe-native-proto-vsce": {
+    "node_modules/zowex-vsce": {
       "resolved": "packages/vsce",
       "link": true
     },
     "packages/cli": {
-      "name": "zowe-native-proto-cli",
+      "name": "zowex-cli",
       "version": "0.4.0",
       "bundleDependencies": [
         "@zowe/zos-uss-for-zowe-sdk",
         "terminal-kit",
-        "zowe-native-proto-sdk"
+        "zowex-sdk"
       ],
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/zos-uss-for-zowe-sdk": "^8.24.0",
         "terminal-kit": "^3.1.2",
-        "zowe-native-proto-sdk": "0.4.0"
+        "zowex-sdk": "0.4.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.7",
@@ -10214,7 +10214,7 @@
       }
     },
     "packages/sdk": {
-      "name": "zowe-native-proto-sdk",
+      "name": "zowex-sdk",
       "version": "0.4.0",
       "license": "EPL-2.0",
       "dependencies": {
@@ -10241,14 +10241,14 @@
       }
     },
     "packages/vsce": {
-      "name": "zowe-native-proto-vsce",
+      "name": "zowex-vsce",
       "version": "0.4.0",
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/core-for-zowe-sdk": "^8.11.0",
         "@zowe/zowe-explorer-api": "^3.3.0",
         "ssh2": "^1.16.0",
-        "zowe-native-proto-sdk": "0.4.0"
+        "zowex-sdk": "0.4.0"
       },
       "devDependencies": {
         "@rspack/cli": "^1.7.6",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zowe-native-proto",
+  "name": "zowex",
   "version": "0.4.0",
   "private": true,
   "scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,78 +1,78 @@
 # Change Log
 
-All notable changes to the Client code for "zowe-native-proto-cli" are documented in this file.
+All notable changes to the Client code for "zowex-cli" are documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## `0.4.0`
 
-- Added an `--attributes` flag to list ISPF statistics for member attributes. [#630](https://github.com/zowe/zowe-native-proto/issues/630)
-- Added the `zssh uss copy` command to the CLI. [#379](https://github.com/zowe/zowe-native-proto/pull/379).
-- Updated `stream` fields to match new requirements from the SDK. [#548](https://github.com/zowe/zowe-native-proto/issues/548)
+- Added an `--attributes` flag to list ISPF statistics for member attributes. [#630](https://github.com/zowe/zowex/issues/630)
+- Added the `zssh uss copy` command to the CLI. [#379](https://github.com/zowe/zowex/pull/379).
+- Updated `stream` fields to match new requirements from the SDK. [#548](https://github.com/zowe/zowex/issues/548)
 
 ## `0.3.0`
 
-- Used new SDK groupings that align with zowex. [#807](https://github.com/zowe/zowe-native-proto/pull/808)
-- Added the `pattern` option to the `list data-set-members` command to filter the returned members. [#817](https://github.com/zowe/zowe-native-proto/pull/817)
+- Used new SDK groupings that align with zowex. [#807](https://github.com/zowe/zowex/pull/808)
+- Added the `pattern` option to the `list data-set-members` command to filter the returned members. [#817](https://github.com/zowe/zowex/pull/817)
 
 ## `0.2.4`
 
-- Added the `zssh rename data-set-member` command to the CLI. [#765] (https://github.com/zowe/zowe-native-proto/pull/765).
-- Added `+` suffix after volser for multi-volume data sets when listing data sets with attributes. [#782](https://github.com/zowe/zowe-native-proto/pull/782)
+- Added the `zssh rename data-set-member` command to the CLI. [#765] (https://github.com/zowe/zowex/pull/765).
+- Added `+` suffix after volser for multi-volume data sets when listing data sets with attributes. [#782](https://github.com/zowe/zowex/pull/782)
 
 ## `0.2.3`
 
-- Added the `zssh rename data-set` command to the CLI. [#376](https://github.com/zowe/zowe-native-proto/issues/376).
-- Added `owner` field to the table returned by the `zssh list jobs` and `zssh view job-status` commands. [#749](https://github.com/zowe/zowe-native-proto/pull/749)
-- Updated the `zssh server install` command to locate server PAX bundled in the SDK package. [#760](https://github.com/zowe/zowe-native-proto/pull/760)
-- The user is now warned if their data is truncated when uploading to a data set. Users can avoid truncation by keeping records within the maximum record length. [#751](https://github.com/zowe/zowe-native-proto/pull/751)
+- Added the `zssh rename data-set` command to the CLI. [#376](https://github.com/zowe/zowex/issues/376).
+- Added `owner` field to the table returned by the `zssh list jobs` and `zssh view job-status` commands. [#749](https://github.com/zowe/zowex/pull/749)
+- Updated the `zssh server install` command to locate server PAX bundled in the SDK package. [#760](https://github.com/zowe/zowex/pull/760)
+- The user is now warned if their data is truncated when uploading to a data set. Users can avoid truncation by keeping records within the maximum record length. [#751](https://github.com/zowe/zowex/pull/751)
 
 ## `0.2.1`
 
-- When listing data sets with attributes, a comprehensive set is now retrieved that is similar to what ISPF displays. [#629](https://github.com/zowe/zowe-native-proto/issues/629)
+- When listing data sets with attributes, a comprehensive set is now retrieved that is similar to what ISPF displays. [#629](https://github.com/zowe/zowex/issues/629)
 
 ## `0.2.0`
 
-- Updated `CliPromptApi` class to gracefully handle unused functions from the `AbstractConfigManager` class. [#605](https://github.com/zowe/zowe-native-proto/pull/605)
-- Added a `--depth` option to the `zssh list uss` command for listing USS directories recursively. [#575](https://github.com/zowe/zowe-native-proto/pull/575)
-- Added `zssh issue tso-command` command. [#595](https://github.com/zowe/zowe-native-proto/pull/595)
+- Updated `CliPromptApi` class to gracefully handle unused functions from the `AbstractConfigManager` class. [#605](https://github.com/zowe/zowex/pull/605)
+- Added a `--depth` option to the `zssh list uss` command for listing USS directories recursively. [#575](https://github.com/zowe/zowex/pull/575)
+- Added `zssh issue tso-command` command. [#595](https://github.com/zowe/zowex/pull/595)
 
 ## `0.1.10`
 
-- Added a `storeServerPath` function as placeholder for future CLI functionality to persist deploy directory paths from user input. [#527](https://github.com/zowe/zowe-native-proto/issues/527)
+- Added a `storeServerPath` function as placeholder for future CLI functionality to persist deploy directory paths from user input. [#527](https://github.com/zowe/zowex/issues/527)
 
 ## `0.1.9`
 
-- Added support for the `local-encoding` option to data set, USS file, and job file commands (view, download, upload) to specify the source encoding of content (defaults to UTF-8). [#511](https://github.com/zowe/zowe-native-proto/issues/511)
-- Added support for `--volume-serial` option when uploading/downloading data sets. [#439](https://github.com/zowe/zowe-native-proto/issues/439)
-- Fixed an issue where the `zssh config setup` command did not prompt the user for a password if the given private key was not recognized by the host. [#524](https://github.com/zowe/zowe-native-proto/issues/524)
-- Added a new prompt that shows if the user has an invalid private key on an existing profile when running the `zssh config setup` command. Now, if an invalid private key is detected, it is moved to a new comment in the JSON file and the user is given options to proceed. They can undo the comment action, delete the comment entirely, or preserve the comment and succeed with setup. [#524](https://github.com/zowe/zowe-native-proto/issues/524)
-- Added a `translateCliError` function to provide more user-friendly messages for an encountered error. If a user-friendly translation is unavailable, the original error is returned. [#533](https://github.com/zowe/zowe-native-proto/pull/533)
-- Updated the `zssh server install` command to display more user-friendly error messages if an issue was encountered during the installation process. [#228](https://github.com/zowe/zowe-native-proto/issues/228)
+- Added support for the `local-encoding` option to data set, USS file, and job file commands (view, download, upload) to specify the source encoding of content (defaults to UTF-8). [#511](https://github.com/zowe/zowex/issues/511)
+- Added support for `--volume-serial` option when uploading/downloading data sets. [#439](https://github.com/zowe/zowex/issues/439)
+- Fixed an issue where the `zssh config setup` command did not prompt the user for a password if the given private key was not recognized by the host. [#524](https://github.com/zowe/zowex/issues/524)
+- Added a new prompt that shows if the user has an invalid private key on an existing profile when running the `zssh config setup` command. Now, if an invalid private key is detected, it is moved to a new comment in the JSON file and the user is given options to proceed. They can undo the comment action, delete the comment entirely, or preserve the comment and succeed with setup. [#524](https://github.com/zowe/zowex/issues/524)
+- Added a `translateCliError` function to provide more user-friendly messages for an encountered error. If a user-friendly translation is unavailable, the original error is returned. [#533](https://github.com/zowe/zowex/pull/533)
+- Updated the `zssh server install` command to display more user-friendly error messages if an issue was encountered during the installation process. [#228](https://github.com/zowe/zowex/issues/228)
 
 ## `0.1.5`
 
-- Added support for progress messages for USS files downloaded and uploaded via the CLI plug-in. [#426](https://github.com/zowe/zowe-native-proto/pull/426)
-- Added support for listing the long format for USS files with the `long` request option. When provided, the CLI plug-in prints additional file attributes, including permissions, file tag, file size, number of links, owner, and group. [#346](https://github.com/zowe/zowe-native-proto/issues/346)
-- Added support for listing all USS files with the `all` request option. When provided, the CLI plug-in includes hidden files in the list response. [#421](https://github.com/zowe/zowe-native-proto/pull/421)
-- Added support for the `encoding` option to the `zssh upload uss` and the `zssh upload ds` commands. When the `encoding` option is provided, the command uses the option value as the target encoding for the uploaded content. [#427](https://github.com/zowe/zowe-native-proto/issues/427)
-- Added support for the `file` option to the `zssh download uss` and `zssh download ds` commands. When the `file` option is provided, the command uses the option value as the destination file path for the downloaded content. [#428](https://github.com/zowe/zowe-native-proto/issues/428)
-- Adopted streaming for commands that upload/download data sets and USS files. [#358](https://github.com/zowe/zowe-native-proto/pull/358)
+- Added support for progress messages for USS files downloaded and uploaded via the CLI plug-in. [#426](https://github.com/zowe/zowex/pull/426)
+- Added support for listing the long format for USS files with the `long` request option. When provided, the CLI plug-in prints additional file attributes, including permissions, file tag, file size, number of links, owner, and group. [#346](https://github.com/zowe/zowex/issues/346)
+- Added support for listing all USS files with the `all` request option. When provided, the CLI plug-in includes hidden files in the list response. [#421](https://github.com/zowe/zowex/pull/421)
+- Added support for the `encoding` option to the `zssh upload uss` and the `zssh upload ds` commands. When the `encoding` option is provided, the command uses the option value as the target encoding for the uploaded content. [#427](https://github.com/zowe/zowex/issues/427)
+- Added support for the `file` option to the `zssh download uss` and `zssh download ds` commands. When the `file` option is provided, the command uses the option value as the destination file path for the downloaded content. [#428](https://github.com/zowe/zowex/issues/428)
+- Adopted streaming for commands that upload/download data sets and USS files. [#358](https://github.com/zowe/zowex/pull/358)
 
 ## `0.1.1`
 
-- Fixed issue where a jobs list request returns unexpected results whenever a search query does not match any jobs. [#217](https://github.com/zowe/zowe-native-proto/pull/217)
+- Fixed issue where a jobs list request returns unexpected results whenever a search query does not match any jobs. [#217](https://github.com/zowe/zowex/pull/217)
 
 ## `0.1.0`
 
-- Added `zssh restore dataset` command. [#38](https://github.com/zowe/zowe-native-proto/pull/38)
-- Added `zssh view uss-file` command. [#38](https://github.com/zowe/zowe-native-proto/pull/38)
-- Added `zssh list spool-files` command. [#38](https://github.com/zowe/zowe-native-proto/pull/38)
-- Added support for cancelling jobs. [#138](https://github.com/zowe/zowe-native-proto/pull/138)
-- Added support for holding and releasing jobs. [#182](https://github.com/zowe/zowe-native-proto/pull/182)
-- Updated error handling for listing data sets. [#185](https://github.com/zowe/zowe-native-proto/pull/185)
-- Added `zssh submit uss-file|local-file|data-set` commands. [#184](https://github.com/zowe/zowe-native-proto/pull/184)
-- Added support for conflict detection through use of e-tags. When a data set or USS file is viewed, the e-tag is displayed to the user and can be passed for future write requests to prevent overwriting new changes on the target system. [#144](https://github.com/zowe/zowe-native-proto/issues/144)
+- Added `zssh restore dataset` command. [#38](https://github.com/zowe/zowex/pull/38)
+- Added `zssh view uss-file` command. [#38](https://github.com/zowe/zowex/pull/38)
+- Added `zssh list spool-files` command. [#38](https://github.com/zowe/zowex/pull/38)
+- Added support for cancelling jobs. [#138](https://github.com/zowe/zowex/pull/138)
+- Added support for holding and releasing jobs. [#182](https://github.com/zowe/zowex/pull/182)
+- Updated error handling for listing data sets. [#185](https://github.com/zowe/zowex/pull/185)
+- Added `zssh submit uss-file|local-file|data-set` commands. [#184](https://github.com/zowe/zowex/pull/184)
+- Added support for conflict detection through use of e-tags. When a data set or USS file is viewed, the e-tag is displayed to the user and can be passed for future write requests to prevent overwriting new changes on the target system. [#144](https://github.com/zowe/zowex/issues/144)
 
 ## [Unreleased]
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
-# Zowe Native Protocol plug-in for Zowe CLI
+# Zowe Remote SSH plug-in for Zowe CLI
 
-The Zowe Native Protocol plug-in for Zowe CLI interacts with the Zowe Native Protocol, enabling developers to work with mainframe resources from their command line.
+The Zowe Remote SSH plug-in for Zowe CLI enables developers to work with mainframe resources over SSH from their command line.
 
 ## Features
 
@@ -41,7 +41,7 @@ Install the plug-in by running the following Zowe CLI command:
 zowe plugins install dist/zowex-cli-*.tgz
 ```
 
-Zowe Native Protocol plug-in commands are accessible through the `zowe zssh` command group.
+Zowe Remote SSH plug-in commands are accessible through the `zowe zssh` command group.
 
 ```
 zowe zssh --help

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,14 +19,14 @@ Access the latest version of the CLI plug-in from the GitHub Releases page.
 Install the CLI plug-in from the tarball:
 
 ```
-zowe plugins install zowe-native-proto-cli-*.tgz
+zowe plugins install zowex-cli-*.tgz
 ```
 
 Once complete, the Zowe CLI plug-in is installed and ready to use.
 
 ## Usage
 
-Run the `zowe plugins show-first-steps zowe-native-proto-cli` command to see the first steps for using the plug-in.
+Run the `zowe plugins show-first-steps zowex-cli` command to see the first steps for using the plug-in.
 
 ## Building from source
 
@@ -38,7 +38,7 @@ The plug-in is created and saved in the `dist` folder.
 Install the plug-in by running the following Zowe CLI command:
 
 ```
-zowe plugins install dist/zowe-native-proto-cli-*.tgz
+zowe plugins install dist/zowex-cli-*.tgz
 ```
 
 Zowe Native Protocol plug-in commands are accessible through the `zowe zssh` command group.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zowe-native-proto-cli",
+  "name": "zowex-cli",
   "version": "0.4.0",
   "main": "lib/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   "dependencies": {
     "@zowe/zos-uss-for-zowe-sdk": "^8.24.0",
     "terminal-kit": "^3.1.2",
-    "zowe-native-proto-sdk": "0.4.0"
+    "zowex-sdk": "0.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "author": "Zowe",
   "license": "EPL-2.0",
-  "description": "Zowe Native Proto plug-in for Zowe CLI",
+  "description": "Zowe Remote SSH plug-in for Zowe CLI",
   "files": [
     "lib",
     "npm-shrinkwrap.json"

--- a/packages/cli/src/CliErrorUtils.ts
+++ b/packages/cli/src/CliErrorUtils.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { type ISshErrorDefinition, SshErrors } from "zowe-native-proto-sdk";
+import { type ISshErrorDefinition, SshErrors } from "zowex-sdk";
 
 /**
  * Translates known CLI errors into more user-friendly messages.

--- a/packages/cli/src/Constants.ts
+++ b/packages/cli/src/Constants.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ICommandOptionDefinition } from "@zowe/imperative";
-import { ZSshClient } from "zowe-native-proto-sdk";
+import { ZSshClient } from "zowex-sdk";
 
 // biome-ignore lint/complexity/noStaticOnlyClass: Constants class has static properties
 export class Constants {

--- a/packages/cli/src/Constants.ts
+++ b/packages/cli/src/Constants.ts
@@ -17,7 +17,7 @@ export class Constants {
     public static readonly OPT_SERVER_PATH: ICommandOptionDefinition = {
         name: "server-path",
         aliases: ["sp"],
-        description: `The remote path of the Zowe SSH server. Defaults to '${ZSshClient.DEFAULT_SERVER_PATH}'.`,
+        description: `The path to the deployed Zowe Remote SSH server instance. Defaults to '${ZSshClient.DEFAULT_SERVER_PATH}'.`,
         type: "string",
         required: false,
     };

--- a/packages/cli/src/SshBaseHandler.ts
+++ b/packages/cli/src/SshBaseHandler.ts
@@ -11,7 +11,7 @@
 
 import { type ICommandHandler, type IHandlerParameters, TextUtils } from "@zowe/imperative";
 import { SshSession } from "@zowe/zos-uss-for-zowe-sdk";
-import { type CommandResponse, type ISshErrorDefinition, ZSshClient, ZSshUtils } from "zowe-native-proto-sdk";
+import { type CommandResponse, type ISshErrorDefinition, ZSshClient, ZSshUtils } from "zowex-sdk";
 import { translateCliError } from "./CliErrorUtils";
 
 export abstract class SshBaseHandler implements ICommandHandler {

--- a/packages/cli/src/cancel/job/Job.handler.ts
+++ b/packages/cli/src/cancel/job/Job.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { jobs, ZSshClient } from "zowe-native-proto-sdk";
+import type { jobs, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class CancelJobHandler extends SshBaseHandler {

--- a/packages/cli/src/config/setup/Setup.handler.ts
+++ b/packages/cli/src/config/setup/Setup.handler.ts
@@ -31,7 +31,7 @@ import {
     type ProgressCallback,
     type qpItem,
     type qpOpts,
-} from "zowe-native-proto-sdk";
+} from "zowex-sdk";
 
 export default class ServerInstallHandler implements ICommandHandler {
     public async process(params: IHandlerParameters): Promise<void> {

--- a/packages/cli/src/create/data-set-member/DataSetMember.handler.ts
+++ b/packages/cli/src/create/data-set-member/DataSetMember.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { ds, ZSshClient } from "zowe-native-proto-sdk";
+import type { ds, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class CreateDatasetMemberHandler extends SshBaseHandler {

--- a/packages/cli/src/create/data-set/DataSet.handler.ts
+++ b/packages/cli/src/create/data-set/DataSet.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { DatasetAttributes, ds, ZSshClient } from "zowe-native-proto-sdk";
+import type { DatasetAttributes, ds, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 import { CreateDefaults } from "../CreateDefaults";
 

--- a/packages/cli/src/create/uss/Directory.handler.ts
+++ b/packages/cli/src/create/uss/Directory.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { uss, ZSshClient } from "zowe-native-proto-sdk";
+import type { uss, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class CreateDirectoryHandler extends SshBaseHandler {

--- a/packages/cli/src/create/uss/File.handler.ts
+++ b/packages/cli/src/create/uss/File.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { uss, ZSshClient } from "zowe-native-proto-sdk";
+import type { uss, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class CreateFileHandler extends SshBaseHandler {

--- a/packages/cli/src/delete/data-set/DataSet.handler.ts
+++ b/packages/cli/src/delete/data-set/DataSet.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { ds, ZSshClient } from "zowe-native-proto-sdk";
+import type { ds, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class DeleteDatasetHandler extends SshBaseHandler {

--- a/packages/cli/src/delete/job/Job.handler.ts
+++ b/packages/cli/src/delete/job/Job.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { jobs, ZSshClient } from "zowe-native-proto-sdk";
+import type { jobs, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class DeleteJobHandler extends SshBaseHandler {

--- a/packages/cli/src/delete/uss/Item.handler.ts
+++ b/packages/cli/src/delete/uss/Item.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { uss, ZSshClient } from "zowe-native-proto-sdk";
+import type { uss, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class DeleteItemHandler extends SshBaseHandler {

--- a/packages/cli/src/download/data-set/DataSet.handler.ts
+++ b/packages/cli/src/download/data-set/DataSet.handler.ts
@@ -13,7 +13,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { IHandlerParameters } from "@zowe/imperative";
 import { IO } from "@zowe/imperative";
-import type { ds, ZSshClient } from "zowe-native-proto-sdk";
+import type { ds, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class DownloadDataSetHandler extends SshBaseHandler {

--- a/packages/cli/src/download/job-file/JobFile.handler.ts
+++ b/packages/cli/src/download/job-file/JobFile.handler.ts
@@ -13,7 +13,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { IHandlerParameters } from "@zowe/imperative";
 import { IO } from "@zowe/imperative";
-import { B64String, type jobs, type ZSshClient } from "zowe-native-proto-sdk";
+import { B64String, type jobs, type ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class DownloadJobJclHandler extends SshBaseHandler {

--- a/packages/cli/src/download/uss-file/UssFile.handler.ts
+++ b/packages/cli/src/download/uss-file/UssFile.handler.ts
@@ -12,7 +12,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { type IHandlerParameters, IO, type ITaskWithStatus, TaskStage } from "@zowe/imperative";
-import type { uss, ZSshClient } from "zowe-native-proto-sdk";
+import type { uss, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class DownloadUssFileHandler extends SshBaseHandler {

--- a/packages/cli/src/hold/job/Job.handler.ts
+++ b/packages/cli/src/hold/job/Job.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { jobs, ZSshClient } from "zowe-native-proto-sdk";
+import type { jobs, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class HoldJobHandler extends SshBaseHandler {

--- a/packages/cli/src/imperative.ts
+++ b/packages/cli/src/imperative.ts
@@ -15,7 +15,7 @@ const config: IImperativeConfig = {
     commandModuleGlobs: ["*/*.definition!(.d).*s"],
     rootCommandDescription: "Zowe Native Proto Plug-in for Zowe CLI",
     productDisplayName: "z/OS SSH Plug-in",
-    name: "zowe-native-proto",
+    name: "zowex",
     pluginAliases: ["zssh"],
     pluginSummary: "z/OS Files and jobs via SSH",
     pluginFirstSteps: `

--- a/packages/cli/src/imperative.ts
+++ b/packages/cli/src/imperative.ts
@@ -13,7 +13,7 @@ import type { IImperativeConfig } from "@zowe/imperative";
 
 const config: IImperativeConfig = {
     commandModuleGlobs: ["*/*.definition!(.d).*s"],
-    rootCommandDescription: "Zowe Native Proto Plug-in for Zowe CLI",
+    rootCommandDescription: "Zowe Remote SSH Plug-in for Zowe CLI",
     productDisplayName: "z/OS SSH Plug-in",
     name: "zowex",
     pluginAliases: ["zssh"],
@@ -21,7 +21,7 @@ const config: IImperativeConfig = {
     pluginFirstSteps: `
 If you do not have a Zowe team configuration, run the \`zowe config init\` command to create one.
 Edit the team configuration file to add a SSH profile, including the hostname, port, and credentials. We recommend using a private key for authentication.
-Run the \`zowe zssh server install\` command to install the Zowe Native Protocol server.
+Run the \`zowe zssh server install\` command to install the Zowe Remote SSH server.
     `,
 };
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,4 +9,4 @@
  *
  */
 
-export * from "zowe-native-proto-sdk";
+export * from "zowex-sdk";

--- a/packages/cli/src/issue/console/ConsoleCommand.handler.ts
+++ b/packages/cli/src/issue/console/ConsoleCommand.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { console, ZSshClient } from "zowe-native-proto-sdk";
+import type { console, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ConsoleCommandHandler extends SshBaseHandler {

--- a/packages/cli/src/issue/tso/TsoCommand.handler.ts
+++ b/packages/cli/src/issue/tso/TsoCommand.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { tso, ZSshClient } from "zowe-native-proto-sdk";
+import type { tso, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class TsoCommandHandler extends SshBaseHandler {

--- a/packages/cli/src/list/data-set-members/DataSetMembers.handler.ts
+++ b/packages/cli/src/list/data-set-members/DataSetMembers.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { ds, ZSshClient } from "zowe-native-proto-sdk";
+import type { ds, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ListDataSetMembersHandler extends SshBaseHandler {

--- a/packages/cli/src/list/data-set/DataSet.handler.ts
+++ b/packages/cli/src/list/data-set/DataSet.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import { type IHandlerParameters, ImperativeError, TextUtils } from "@zowe/imperative";
-import type { Dataset, ds, ZSshClient } from "zowe-native-proto-sdk";
+import type { Dataset, ds, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ListDataSetsHandler extends SshBaseHandler {

--- a/packages/cli/src/list/jobs/Jobs.handler.ts
+++ b/packages/cli/src/list/jobs/Jobs.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { jobs, ZSshClient } from "zowe-native-proto-sdk";
+import type { jobs, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ListJobsHandler extends SshBaseHandler {

--- a/packages/cli/src/list/spool-files/SpoolFiles.handler.ts
+++ b/packages/cli/src/list/spool-files/SpoolFiles.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { jobs, ZSshClient } from "zowe-native-proto-sdk";
+import type { jobs, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ListSpoolsHandler extends SshBaseHandler {

--- a/packages/cli/src/list/uss-files/UssFiles.handler.ts
+++ b/packages/cli/src/list/uss-files/UssFiles.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { uss, ZSshClient } from "zowe-native-proto-sdk";
+import type { uss, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ListUssFilesHandler extends SshBaseHandler {

--- a/packages/cli/src/recall/data-set/DataSet.handler.ts
+++ b/packages/cli/src/recall/data-set/DataSet.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { ds, ZSshClient } from "zowe-native-proto-sdk";
+import type { ds, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class RestoreDatasetHandler extends SshBaseHandler {

--- a/packages/cli/src/release/job/Job.handler.ts
+++ b/packages/cli/src/release/job/Job.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { jobs, ZSshClient } from "zowe-native-proto-sdk";
+import type { jobs, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ReleaseJobHandler extends SshBaseHandler {

--- a/packages/cli/src/rename/data-set-members/DataSetMembers.handler.ts
+++ b/packages/cli/src/rename/data-set-members/DataSetMembers.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { ds, ZSshClient } from "zowe-native-proto-sdk";
+import type { ds, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class RenameMemberHandler extends SshBaseHandler {

--- a/packages/cli/src/rename/data-set/DataSet.handler.ts
+++ b/packages/cli/src/rename/data-set/DataSet.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { ds, ZSshClient } from "zowe-native-proto-sdk";
+import type { ds, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class RenameDataSetHandler extends SshBaseHandler {

--- a/packages/cli/src/server/Server.definition.ts
+++ b/packages/cli/src/server/Server.definition.ts
@@ -18,8 +18,8 @@ import { ServerUninstallDefinition } from "./uninstall/Uninstall.definition";
 const ServerDefinition: ICommandDefinition = {
     name: "server",
     aliases: ["srv"],
-    summary: "Manage the Zowe SSH server",
-    description: "Manage the Zowe SSH server",
+    summary: "Manage the Zowe Remote SSH server",
+    description: "Manage the Zowe Remote SSH server",
     type: "group",
     children: [ServerInstallDefinition, ServerUninstallDefinition],
     passOn: [

--- a/packages/cli/src/server/install/Install.definition.ts
+++ b/packages/cli/src/server/install/Install.definition.ts
@@ -16,15 +16,15 @@ export const ServerInstallDefinition: ICommandDefinition = {
     type: "command",
     name: "install",
     aliases: ["up"],
-    summary: "Install Zowe SSH server on z/OS host",
-    description: "Install Zowe SSH server on z/OS host",
+    summary: "Install Zowe Remote SSH server on z/OS host",
+    description: "Install Zowe Remote SSH server on z/OS host",
     examples: [
         {
-            description: "Install Zowe SSH server in the default location",
+            description: "Install Zowe Remote SSH server in the default location",
             options: "",
         },
         {
-            description: 'Install Zowe SSH server in the directory "/tmp/zowe-server"',
+            description: 'Install Zowe Remote SSH server in the directory "/tmp/zowe-server"',
             options: '--server-path "/tmp/zowe-server"',
         },
     ],

--- a/packages/cli/src/server/install/Install.handler.ts
+++ b/packages/cli/src/server/install/Install.handler.ts
@@ -27,7 +27,7 @@ export default class ServerInstallHandler implements ICommandHandler {
 
         const task: ITaskWithStatus = {
             percentComplete: 0,
-            statusMessage: "Deploying Zowe SSH server...",
+            statusMessage: "Deploying Zowe Remote SSH server...",
             stageName: TaskStage.IN_PROGRESS,
         };
 
@@ -62,7 +62,7 @@ export default class ServerInstallHandler implements ICommandHandler {
             params.response.progress.endBar();
         }
         params.response.console.log(
-            `Installed Zowe SSH server on ${ConfigUtils.getActiveProfileName("ssh", params.arguments)}`,
+            `Installed Zowe Remote SSH server on ${ConfigUtils.getActiveProfileName("ssh", params.arguments)}`,
         );
     }
 }

--- a/packages/cli/src/server/install/Install.handler.ts
+++ b/packages/cli/src/server/install/Install.handler.ts
@@ -16,7 +16,7 @@ import {
     type ITaskWithStatus,
     TaskStage,
 } from "@zowe/imperative";
-import { ZSshClient, ZSshUtils } from "zowe-native-proto-sdk";
+import { ZSshClient, ZSshUtils } from "zowex-sdk";
 import { translateCliError } from "../../CliErrorUtils";
 import { SshBaseHandler } from "../../SshBaseHandler";
 

--- a/packages/cli/src/server/uninstall/Uninstall.definition.ts
+++ b/packages/cli/src/server/uninstall/Uninstall.definition.ts
@@ -16,15 +16,15 @@ export const ServerUninstallDefinition: ICommandDefinition = {
     type: "command",
     name: "uninstall",
     aliases: ["rm"],
-    summary: "Uninstall Zowe SSH server on z/OS host",
-    description: "Uninstall Zowe SSH server on z/OS host",
+    summary: "Uninstall Zowe Remote SSH server on z/OS host",
+    description: "Uninstall Zowe Remote SSH server on z/OS host",
     examples: [
         {
-            description: "Uninstall Zowe SSH server from the default location",
+            description: "Uninstall Zowe Remote SSH server from the default location",
             options: "",
         },
         {
-            description: 'Uninstall Zowe SSH server from the directory "/tmp/zowe-server"',
+            description: 'Uninstall Zowe Remote SSH server from the directory "/tmp/zowe-server"',
             options: '--server-path "/tmp/zowe-server"',
         },
     ],

--- a/packages/cli/src/server/uninstall/Uninstall.handler.ts
+++ b/packages/cli/src/server/uninstall/Uninstall.handler.ts
@@ -18,7 +18,7 @@ export default class ServerUninstallHandler implements ICommandHandler {
         const serverPath = params.arguments.serverPath ?? ZSshClient.DEFAULT_SERVER_PATH;
         await ZSshUtils.uninstallServer(session, serverPath);
         params.response.console.log(
-            `Uninstalled Zowe SSH server from ${ConfigUtils.getActiveProfileName("ssh", params.arguments)}`,
+            `Uninstalled Zowe Remote SSH server from ${ConfigUtils.getActiveProfileName("ssh", params.arguments)}`,
         );
     }
 }

--- a/packages/cli/src/server/uninstall/Uninstall.handler.ts
+++ b/packages/cli/src/server/uninstall/Uninstall.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import { ConfigUtils, type ICommandHandler, type IHandlerParameters } from "@zowe/imperative";
-import { ZSshClient, ZSshUtils } from "zowe-native-proto-sdk";
+import { ZSshClient, ZSshUtils } from "zowex-sdk";
 
 export default class ServerUninstallHandler implements ICommandHandler {
     public async process(params: IHandlerParameters): Promise<void> {

--- a/packages/cli/src/submit/ds/Dataset.handler.ts
+++ b/packages/cli/src/submit/ds/Dataset.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { jobs, ZSshClient } from "zowe-native-proto-sdk";
+import type { jobs, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class SubmitDsHandler extends SshBaseHandler {

--- a/packages/cli/src/submit/local-file/LocalFile.handler.ts
+++ b/packages/cli/src/submit/local-file/LocalFile.handler.ts
@@ -11,7 +11,7 @@
 
 import { readFileSync } from "node:fs";
 import { type IHandlerParameters, ImperativeError } from "@zowe/imperative";
-import { B64String, type jobs, type ZSshClient } from "zowe-native-proto-sdk";
+import { B64String, type jobs, type ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class SubmitLocalFileHandler extends SshBaseHandler {

--- a/packages/cli/src/submit/stdin/Stdin.handler.ts
+++ b/packages/cli/src/submit/stdin/Stdin.handler.ts
@@ -11,7 +11,7 @@
 
 import { buffer } from "node:stream/consumers";
 import type { IHandlerParameters } from "@zowe/imperative";
-import { B64String, type jobs, type ZSshClient } from "zowe-native-proto-sdk";
+import { B64String, type jobs, type ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class SubmitJclHandler extends SshBaseHandler {

--- a/packages/cli/src/submit/uss/Uss.handler.ts
+++ b/packages/cli/src/submit/uss/Uss.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { jobs, ZSshClient } from "zowe-native-proto-sdk";
+import type { jobs, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class SubmitUssHandler extends SshBaseHandler {

--- a/packages/cli/src/unix/chmod/Chmod.handler.ts
+++ b/packages/cli/src/unix/chmod/Chmod.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { uss, ZSshClient } from "zowe-native-proto-sdk";
+import type { uss, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ChmodHandler extends SshBaseHandler {

--- a/packages/cli/src/unix/chown/Chown.handler.ts
+++ b/packages/cli/src/unix/chown/Chown.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { uss, ZSshClient } from "zowe-native-proto-sdk";
+import type { uss, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ChownHandler extends SshBaseHandler {

--- a/packages/cli/src/unix/chtag/Chtag.handler.ts
+++ b/packages/cli/src/unix/chtag/Chtag.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { uss, ZSshClient } from "zowe-native-proto-sdk";
+import type { uss, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ChtagHandler extends SshBaseHandler {

--- a/packages/cli/src/unix/copy/Copy.handler.ts
+++ b/packages/cli/src/unix/copy/Copy.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { uss, ZSshClient } from "zowe-native-proto-sdk";
+import type { uss, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class CopyHandler extends SshBaseHandler {

--- a/packages/cli/src/upload/file-to-data-set/FileToDataSet.handler.ts
+++ b/packages/cli/src/upload/file-to-data-set/FileToDataSet.handler.ts
@@ -11,8 +11,8 @@
 
 import * as fs from "node:fs";
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { ZSshClient } from "zowe-native-proto-sdk";
-import type { ds } from "zowe-native-proto-sdk/src/doc";
+import type { ZSshClient } from "zowex-sdk";
+import type { ds } from "zowex-sdk/src/doc";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class UploadFileToDataSetHandler extends SshBaseHandler {

--- a/packages/cli/src/upload/file-to-uss/FileToUss.handler.ts
+++ b/packages/cli/src/upload/file-to-uss/FileToUss.handler.ts
@@ -11,7 +11,7 @@
 
 import * as fs from "node:fs";
 import { type IHandlerParameters, type ITaskWithStatus, TaskStage } from "@zowe/imperative";
-import type { uss, ZSshClient } from "zowe-native-proto-sdk";
+import type { uss, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class UploadFileToUssFileHandler extends SshBaseHandler {

--- a/packages/cli/src/view/data-set/DataSet.handler.ts
+++ b/packages/cli/src/view/data-set/DataSet.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import { B64String, type ds, type ZSshClient } from "zowe-native-proto-sdk";
+import { B64String, type ds, type ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ViewDataSetHandler extends SshBaseHandler {

--- a/packages/cli/src/view/job-file/JobFile.handler.ts
+++ b/packages/cli/src/view/job-file/JobFile.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import { B64String, type jobs, type ZSshClient } from "zowe-native-proto-sdk";
+import { B64String, type jobs, type ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ViewJobJclHandler extends SshBaseHandler {

--- a/packages/cli/src/view/job-jcl/JobJcl.handler.ts
+++ b/packages/cli/src/view/job-jcl/JobJcl.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { jobs, ZSshClient } from "zowe-native-proto-sdk";
+import type { jobs, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ViewJobJclHandler extends SshBaseHandler {

--- a/packages/cli/src/view/job-status/JobStatus.handler.ts
+++ b/packages/cli/src/view/job-status/JobStatus.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import type { jobs, ZSshClient } from "zowe-native-proto-sdk";
+import type { jobs, ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ViewJobStatusHandler extends SshBaseHandler {

--- a/packages/cli/src/view/uss-file/UssFile.handler.ts
+++ b/packages/cli/src/view/uss-file/UssFile.handler.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IHandlerParameters } from "@zowe/imperative";
-import { B64String, type uss, type ZSshClient } from "zowe-native-proto-sdk";
+import { B64String, type uss, type ZSshClient } from "zowex-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 
 export default class ViewUssFileHandler extends SshBaseHandler {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,127 +1,127 @@
 # Change Log
 
-All notable changes to the Client code for "zowe-native-proto-sdk" are documented in this file.
+All notable changes to the Client code for "zowex-sdk" are documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## Recent Changes
 
-- Added support for invoking the `getInfo` server command, which allows the client SDK to get version and build information from the server. [#922](https://github.com/zowe/zowe-native-proto/pull/922)
-- Added warning to `AbstractConfigManager.validateDeployPath` method when server path ends in `/c/build-out`, preventing developers from accidentally overwriting a dev deployment. [#912](https://github.com/zowe/zowe-native-proto/pull/912)
+- Added support for invoking the `getInfo` server command, which allows the client SDK to get version and build information from the server. [#922](https://github.com/zowe/zowex/pull/922)
+- Added warning to `AbstractConfigManager.validateDeployPath` method when server path ends in `/c/build-out`, preventing developers from accidentally overwriting a dev deployment. [#912](https://github.com/zowe/zowex/pull/912)
 
 ## `0.4.0`
 
-- **Breaking:** `ZSshClient` (the SSH-based client for communicating with the z/OS server) now connects to `zowex server` (the embedded server subcommand of the `zowex` z/OS backend binary) instead of the standalone `zowed` binary. Users must re-deploy the server to update the binaries at their `serverPath` (the z/OS path where server binaries are deployed). [#846](https://github.com/zowe/zowe-native-proto/issues/846)
-- Updated `ZSshClient` so callers can now safely collect and replay in-flight requests when they detect an unrecoverable error. [#548](https://github.com/zowe/zowe-native-proto/issues/548)
-- Added support for issuing USS shell commands via `uss.issueCmd` (backed by the new `unixCommand` RPC). [#867](https://github.com/zowe/zowe-native-proto/pull/867)
-- Added expired password detection (`FOTS1668`/`FOTS1669`) in `installServer` and `uninstallServer`, throwing an `ImperativeError` with `errorCode: "EPASSWD_EXPIRED"` instead of returning a generic failure. [#867](https://github.com/zowe/zowe-native-proto/pull/867)
-- Added support for listing member attributes to `DsMember` type [#630](https://github.com/zowe/zowe-native-proto/issues/630)
+- **Breaking:** `ZSshClient` (the SSH-based client for communicating with the z/OS server) now connects to `zowex server` (the embedded server subcommand of the `zowex` z/OS backend binary) instead of the standalone `zowed` binary. Users must re-deploy the server to update the binaries at their `serverPath` (the z/OS path where server binaries are deployed). [#846](https://github.com/zowe/zowex/issues/846)
+- Updated `ZSshClient` so callers can now safely collect and replay in-flight requests when they detect an unrecoverable error. [#548](https://github.com/zowe/zowex/issues/548)
+- Added support for issuing USS shell commands via `uss.issueCmd` (backed by the new `unixCommand` RPC). [#867](https://github.com/zowe/zowex/pull/867)
+- Added expired password detection (`FOTS1668`/`FOTS1669`) in `installServer` and `uninstallServer`, throwing an `ImperativeError` with `errorCode: "EPASSWD_EXPIRED"` instead of returning a generic failure. [#867](https://github.com/zowe/zowex/pull/867)
+- Added support for listing member attributes to `DsMember` type [#630](https://github.com/zowe/zowex/issues/630)
 - Added support for invoking the `toolSearch` server command, which allows the client SDK to search for data sets.
-- Added support for copying USS files in the `RpcClientApi` class. [#379](https://github.com/zowe/zowe-native-proto/issues/379)
-- Added support for USS Move operations. [#789](https://github.com/zowe/zowe-native-proto/pull/789)
-- Fixed `user` property not defined as secure when new team configuration profile is created. [#845](https://github.com/zowe/zowe-native-proto/pull/845)
-- Fixed check for outdated server always returning true which could trigger unnecessary re-deploy. [#862](https://github.com/zowe/zowe-native-proto/pull/862)
-- Added experimental native client for improved performance. To enable it, pass the `useNativeSsh` option to the `ZSshClient.create` method. [#833](https://github.com/zowe/zowe-native-proto/pull/833)
+- Added support for copying USS files in the `RpcClientApi` class. [#379](https://github.com/zowe/zowex/issues/379)
+- Added support for USS Move operations. [#789](https://github.com/zowe/zowex/pull/789)
+- Fixed `user` property not defined as secure when new team configuration profile is created. [#845](https://github.com/zowe/zowex/pull/845)
+- Fixed check for outdated server always returning true which could trigger unnecessary re-deploy. [#862](https://github.com/zowe/zowex/pull/862)
+- Added experimental native client for improved performance. To enable it, pass the `useNativeSsh` option to the `ZSshClient.create` method. [#833](https://github.com/zowe/zowex/pull/833)
 
 ## `0.3.0`
 
-- Changed SDK groupings to align with zowex. [#807](https://github.com/zowe/zowe-native-proto/issues/807)
+- Changed SDK groupings to align with zowex. [#807](https://github.com/zowe/zowex/issues/807)
 
 ## `0.2.4`
 
-- Added support for renaming data set members in the `RpcClientApi` class. [#765](https://github.com/zowe/zowe-native-proto/pull/765)
-- Made the `recursive` property optional for USS request types. [#648](https://github.com/zowe/zowe-native-proto/issues/648)
-- Fixed an issue where deploying to the `/tmp` directory would result in an error. [#781](https://github.com/zowe/zowe-native-proto/pull/781)
-- Added `multivolume` property to the `Dataset` type for listing data sets with attributes. [#782](https://github.com/zowe/zowe-native-proto/pull/782)
-- Exported `ISshSession` and `SshSession` types from the Zowe USS SDK. [#799](https://github.com/zowe/zowe-native-proto/pull/799)
-- Added `verbose` property to the `ClientOptions` interface used by the `ZSshClient.create` method. [#801](https://github.com/zowe/zowe-native-proto/issues/801)
-- Enhanced the `ZSshClient.create` method to return `ImperativeError` containing error details when `zowed` fails to start. [#802](https://github.com/zowe/zowe-native-proto/issues/802)
+- Added support for renaming data set members in the `RpcClientApi` class. [#765](https://github.com/zowe/zowex/pull/765)
+- Made the `recursive` property optional for USS request types. [#648](https://github.com/zowe/zowex/issues/648)
+- Fixed an issue where deploying to the `/tmp` directory would result in an error. [#781](https://github.com/zowe/zowex/pull/781)
+- Added `multivolume` property to the `Dataset` type for listing data sets with attributes. [#782](https://github.com/zowe/zowex/pull/782)
+- Exported `ISshSession` and `SshSession` types from the Zowe USS SDK. [#799](https://github.com/zowe/zowex/pull/799)
+- Added `verbose` property to the `ClientOptions` interface used by the `ZSshClient.create` method. [#801](https://github.com/zowe/zowex/issues/801)
+- Enhanced the `ZSshClient.create` method to return `ImperativeError` containing error details when `zowed` fails to start. [#802](https://github.com/zowe/zowex/issues/802)
 
 ## `0.2.3`
 
-- Added support for renaming data sets in the `RpcClientApi` class. [#376](https://github.com/zowe/zowe-native-proto/issues/376)
-- Fixed an issue where connecting to the host with an expired password resulted in an ambiguous error. [#732](https://github.com/zowe/zowe-native-proto/issues/732)
-- The `submitJcl` and `submitJob` functions in the `SshJesApi` class now return the job name as a property (`jobname`) within the response object. [#733](https://github.com/zowe/zowe-native-proto/issues/733)
-- Enhanced the `Job` type to include more properties such as `subsystem`, `owner`, `type`, and `class` when listing jobs. [#749](https://github.com/zowe/zowe-native-proto/pull/749)
-- Added `bin` folder that bundles server binaries in the SDK package. [#760](https://github.com/zowe/zowe-native-proto/pull/760)
-- Data set truncation warnings are now included in the response object for write operations. [#751](https://github.com/zowe/zowe-native-proto/pull/751)
+- Added support for renaming data sets in the `RpcClientApi` class. [#376](https://github.com/zowe/zowex/issues/376)
+- Fixed an issue where connecting to the host with an expired password resulted in an ambiguous error. [#732](https://github.com/zowe/zowex/issues/732)
+- The `submitJcl` and `submitJob` functions in the `SshJesApi` class now return the job name as a property (`jobname`) within the response object. [#733](https://github.com/zowe/zowex/issues/733)
+- Enhanced the `Job` type to include more properties such as `subsystem`, `owner`, `type`, and `class` when listing jobs. [#749](https://github.com/zowe/zowex/pull/749)
+- Added `bin` folder that bundles server binaries in the SDK package. [#760](https://github.com/zowe/zowex/pull/760)
+- Data set truncation warnings are now included in the response object for write operations. [#751](https://github.com/zowe/zowex/pull/751)
 
 ## `0.2.2`
 
-- Fixed an issue where the deploy directory was not created recursively when a non-existent multi-level directory was submitted. [#705](https://github.com/zowe/zowe-native-proto/pull/705)
-- Fixed an issue where global team config was created rather than storing profile in existing team config in the active workspace directory. [#710](https://github.com/zowe/zowe-native-proto/pull/710)
+- Fixed an issue where the deploy directory was not created recursively when a non-existent multi-level directory was submitted. [#705](https://github.com/zowe/zowex/pull/705)
+- Fixed an issue where global team config was created rather than storing profile in existing team config in the active workspace directory. [#710](https://github.com/zowe/zowex/pull/710)
 
 ## `0.2.1`
 
-- Fixed an issue where `validateConfig` function would not fallback to password when both an invalid `privateKey` and `password` exist on a profile. [#525](https://github.com/zowe/zowe-native-proto/issues/525)
-- Updated the `num-workers` option in the `ZSshClient` class to reflect the new format used for parsing `zowed` options. [#655](https://github.com/zowe/zowe-native-proto/issues/655)
-- Filtered out `Include` and `Host *` directives from SSH config files when creating new profiles. [#678](https://github.com/zowe/zowe-native-proto/pull/678)
-- Added missing properties to the `Dataset` type for listing data sets with attributes. [#629](https://github.com/zowe/zowe-native-proto/issues/629)
+- Fixed an issue where `validateConfig` function would not fallback to password when both an invalid `privateKey` and `password` exist on a profile. [#525](https://github.com/zowe/zowex/issues/525)
+- Updated the `num-workers` option in the `ZSshClient` class to reflect the new format used for parsing `zowed` options. [#655](https://github.com/zowe/zowex/issues/655)
+- Filtered out `Include` and `Host *` directives from SSH config files when creating new profiles. [#678](https://github.com/zowe/zowex/pull/678)
+- Added missing properties to the `Dataset` type for listing data sets with attributes. [#629](https://github.com/zowe/zowex/issues/629)
 
 ## `0.2.0`
 
-- Added unit tests for `SshConfigUtils` class. [#614](https://github.com/zowe/zowe-native-proto/pull/614)
-- Addressed an issue where `~` was not being resolved to the home directory within ssh configuration files. [#614](https://github.com/zowe/zowe-native-proto/pull/614)
-- Added additional error messages to the `AbstractConfigManager` class to provide better feedback during connection attempts. [#605](https://github.com/zowe/zowe-native-proto/pull/605)
-- Added `depth` property to the `ListFilesRequest` type for listing USS directories recursively. [#575](https://github.com/zowe/zowe-native-proto/pull/575)
-- Replaced `this.uninstallServer` with the class reference `ZSshUtils.uninstallServer` in `ZSshUtils.ts`. [#586](https://github.com/zowe/zowe-native-proto/pull/586)
-- Added `recfm` property to the `Dataset` type for listing data sets with attributes. [#558](https://github.com/zowe/zowe-native-proto/pull/558)
-- Restructured RPC request and response types to be human-maintained rather than auto-generated to improve maintainability. [#590](https://github.com/zowe/zowe-native-proto/pull/590)
-- Made attribute properties optional in the `Dataset` and `UssItem` types. [#608](https://github.com/zowe/zowe-native-proto/pull/608)
-- Fixed an issue where the input validation logic in the `AbstractConfigManager.promptForDeployDirectory` function would falsely detect paths as invalid. [#609](https://github.com/zowe/zowe-native-proto/issues/609)
+- Added unit tests for `SshConfigUtils` class. [#614](https://github.com/zowe/zowex/pull/614)
+- Addressed an issue where `~` was not being resolved to the home directory within ssh configuration files. [#614](https://github.com/zowe/zowex/pull/614)
+- Added additional error messages to the `AbstractConfigManager` class to provide better feedback during connection attempts. [#605](https://github.com/zowe/zowex/pull/605)
+- Added `depth` property to the `ListFilesRequest` type for listing USS directories recursively. [#575](https://github.com/zowe/zowex/pull/575)
+- Replaced `this.uninstallServer` with the class reference `ZSshUtils.uninstallServer` in `ZSshUtils.ts`. [#586](https://github.com/zowe/zowex/pull/586)
+- Added `recfm` property to the `Dataset` type for listing data sets with attributes. [#558](https://github.com/zowe/zowex/pull/558)
+- Restructured RPC request and response types to be human-maintained rather than auto-generated to improve maintainability. [#590](https://github.com/zowe/zowex/pull/590)
+- Made attribute properties optional in the `Dataset` and `UssItem` types. [#608](https://github.com/zowe/zowex/pull/608)
+- Fixed an issue where the input validation logic in the `AbstractConfigManager.promptForDeployDirectory` function would falsely detect paths as invalid. [#609](https://github.com/zowe/zowex/issues/609)
 
 ## `0.1.10`
 
-- Added a `promptForDeployDirectory` function to prompt the users to choose a deploy directory aside from the default. [#527](https://github.com/zowe/zowe-native-proto/issues/527)
+- Added a `promptForDeployDirectory` function to prompt the users to choose a deploy directory aside from the default. [#527](https://github.com/zowe/zowex/issues/527)
 
 ## `0.1.9`
 
-- Updated the `ZSshUtils.uninstallServer` function to remove the deploy directory and all of its contents. [#484](https://github.com/zowe/zowe-native-proto/issues/484)
-- Changed default number of `zowex` worker threads from 10 to 3 to reduce resource usage on z/OS. [#514](https://github.com/zowe/zowe-native-proto/pull/514)
-- Added support for `localEncoding` option in data set, USS file, and job file operations to specify the source encoding of content (defaults to UTF-8). [#511](https://github.com/zowe/zowe-native-proto/issues/511)
-- Added support for `volume` option when reading/writing data sets. [#439](https://github.com/zowe/zowe-native-proto/issues/439)
-- Added a new `ConfigFileUtils` class with helper functions for commenting out properties, removing comments after the `properties` section of a profile, and restoring properties from comments to their original values. [#534](https://github.com/zowe/zowe-native-proto/issues/534)
-- Added an `onError` callback to the `installServer` and `uninstallServer` functions, allowing applications to implement custom error handling and retry logic during server deployment. [#533](https://github.com/zowe/zowe-native-proto/pull/533)
+- Updated the `ZSshUtils.uninstallServer` function to remove the deploy directory and all of its contents. [#484](https://github.com/zowe/zowex/issues/484)
+- Changed default number of `zowex` worker threads from 10 to 3 to reduce resource usage on z/OS. [#514](https://github.com/zowe/zowex/pull/514)
+- Added support for `localEncoding` option in data set, USS file, and job file operations to specify the source encoding of content (defaults to UTF-8). [#511](https://github.com/zowe/zowex/issues/511)
+- Added support for `volume` option when reading/writing data sets. [#439](https://github.com/zowe/zowex/issues/439)
+- Added a new `ConfigFileUtils` class with helper functions for commenting out properties, removing comments after the `properties` section of a profile, and restoring properties from comments to their original values. [#534](https://github.com/zowe/zowex/issues/534)
+- Added an `onError` callback to the `installServer` and `uninstallServer` functions, allowing applications to implement custom error handling and retry logic during server deployment. [#533](https://github.com/zowe/zowex/pull/533)
 
 ## `0.1.7`
 
-- Fixed inconsistent type of the `data` property between the `ReadDatasetResponse` and `ReadFileResponse` types. [#488](https://github.com/zowe/zowe-native-proto/pull/488)
+- Fixed inconsistent type of the `data` property between the `ReadDatasetResponse` and `ReadFileResponse` types. [#488](https://github.com/zowe/zowex/pull/488)
 
 ## `0.1.6`
 
-- Fixed a TypeError in `ZSshClient.request` that caused stream operations to fail if a callback was not provided for progress updates. [#482](https://github.com/zowe/zowe-native-proto/issues/482)
+- Fixed a TypeError in `ZSshClient.request` that caused stream operations to fail if a callback was not provided for progress updates. [#482](https://github.com/zowe/zowex/issues/482)
 
 ## `0.1.5`
 
-- Added support for progress messages for USS files downloaded and uploaded via the CLI plug-in. [#426](https://github.com/zowe/zowe-native-proto/pull/426)
-- Added support for listing the long format for USS files with the `long` request option. When provided, the SDK returns additional file attributes, including permissions, file tag, file size, number of links, owner, and group. [#346](https://github.com/zowe/zowe-native-proto/issues/346)
-- Added support for listing all USS files with the `all` request option. When provided, the SDK includes hidden files in the list response. [#421](https://github.com/zowe/zowe-native-proto/pull/421)
-- Refactored handling of RPC notifications to be managed by a separate class `RpcNotificationManager`. [#358](https://github.com/zowe/zowe-native-proto/pull/358)
-- Added content length validation for streamed requests. [#358](https://github.com/zowe/zowe-native-proto/pull/358)
-- Removed unnecessary prompt to unlock keyring on MacOS when connecting to a new host with a private key. [#453](https://github.com/zowe/zowe-native-proto/issues/453)
+- Added support for progress messages for USS files downloaded and uploaded via the CLI plug-in. [#426](https://github.com/zowe/zowex/pull/426)
+- Added support for listing the long format for USS files with the `long` request option. When provided, the SDK returns additional file attributes, including permissions, file tag, file size, number of links, owner, and group. [#346](https://github.com/zowe/zowex/issues/346)
+- Added support for listing all USS files with the `all` request option. When provided, the SDK includes hidden files in the list response. [#421](https://github.com/zowe/zowex/pull/421)
+- Refactored handling of RPC notifications to be managed by a separate class `RpcNotificationManager`. [#358](https://github.com/zowe/zowex/pull/358)
+- Added content length validation for streamed requests. [#358](https://github.com/zowe/zowex/pull/358)
+- Removed unnecessary prompt to unlock keyring on MacOS when connecting to a new host with a private key. [#453](https://github.com/zowe/zowex/issues/453)
 
 ## `0.1.3`
 
-- The `mode` property for a list files response now contains the UNIX permissions of the corresponding file/folder. [#341](https://github.com/zowe/zowe-native-proto/pull/341)
+- The `mode` property for a list files response now contains the UNIX permissions of the corresponding file/folder. [#341](https://github.com/zowe/zowex/pull/341)
 - Fixed an issue where a non-fatal `chdir` error (OpenSSH code `FOTS1681`) prevented the clients from handling the middleware's ready message. Now, the SSH client waits for the ready message from the `zowed` middleware before returning the new client connection.
 
 ## `0.1.2`
 
-- Improved error handling when SSH client connects to throw `ENOTFOUND` if server binary is missing. [#44](https://github.com/zowe/zowe-native-proto/issues/44)
-- Added `ZSshUtils.checkIfOutdated` method to check if deployed server is out of date. [#44](https://github.com/zowe/zowe-native-proto/issues/44)
-- Added `keepAliveInterval` option when creating an instance of the `ZSshClient` class that defaults to 30 seconds. [#260](https://github.com/zowe/zowe-native-proto/issues/260)
-- Added support for streaming data in chunks to handle large requests and responses in the `ZSshClient` class. This allows streaming USS file contents for read and write operations (`ReadDatasetRequest`, `ReadFileRequest`, `WriteDatasetRequest`, `WriteFileRequest`). [#311](https://github.com/zowe/zowe-native-proto/pull/311)
+- Improved error handling when SSH client connects to throw `ENOTFOUND` if server binary is missing. [#44](https://github.com/zowe/zowex/issues/44)
+- Added `ZSshUtils.checkIfOutdated` method to check if deployed server is out of date. [#44](https://github.com/zowe/zowex/issues/44)
+- Added `keepAliveInterval` option when creating an instance of the `ZSshClient` class that defaults to 30 seconds. [#260](https://github.com/zowe/zowex/issues/260)
+- Added support for streaming data in chunks to handle large requests and responses in the `ZSshClient` class. This allows streaming USS file contents for read and write operations (`ReadDatasetRequest`, `ReadFileRequest`, `WriteDatasetRequest`, `WriteFileRequest`). [#311](https://github.com/zowe/zowex/pull/311)
 
 ## `0.1.1`
 
-- Improved unclear error message when uploading PAX file fails. [#220](https://github.com/zowe/zowe-native-proto/pull/220)
+- Improved unclear error message when uploading PAX file fails. [#220](https://github.com/zowe/zowex/pull/220)
 
 ## `0.1.0`
 
-- Added `ds.restoreDataset` function. [#38](https://github.com/zowe/zowe-native-proto/pull/38)
-- Added support for cancelling jobs. [#138](https://github.com/zowe/zowe-native-proto/pull/138)
-- Added support for holding and releasing jobs. [#182](https://github.com/zowe/zowe-native-proto/pull/182)
-- Added `jobs.submitUss` function. [#184](https://github.com/zowe/zowe-native-proto/pull/184)
+- Added `ds.restoreDataset` function. [#38](https://github.com/zowe/zowex/pull/38)
+- Added support for cancelling jobs. [#138](https://github.com/zowe/zowex/pull/138)
+- Added support for holding and releasing jobs. [#182](https://github.com/zowe/zowex/pull/182)
+- Added `jobs.submitUss` function. [#184](https://github.com/zowe/zowex/pull/184)
 
 ## [Unreleased]
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,6 @@
-# Zowe Native Protocol SDK
+# Zowe Remote SSH SDK
 
-The Zowe Native Protocol SDK is a TypeScript library to interact with the Zowe Native Protocol, enabling developers to interact with mainframe resources directly from their custom Node.js application.
+The Zowe Remote SSH SDK is a TypeScript library that enables developers to interact with mainframe resources over SSH, directly from their custom Node.js application.
 
 ## Building from source
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zowe-native-proto-sdk",
+  "name": "zowex-sdk",
   "version": "0.4.0",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,7 +15,7 @@
   "keywords": [],
   "author": "Zowe",
   "license": "EPL-2.0",
-  "description": "Zowe Native Proto APIs for Zowe SDK",
+  "description": "Zowe Remote SSH APIs for Zowe SDK",
   "files": [
     "bin",
     "lib"

--- a/packages/sdk/src/doc/client.ts
+++ b/packages/sdk/src/doc/client.ts
@@ -47,7 +47,7 @@ export interface ClientOptions {
     responseTimeout?: number;
 
     /**
-     * Remote path of the Zowe Native Proto server
+     * Remote path of the Zowe Remote SSH server
      * (default: `~/.zowe-server`)
      */
     serverPath?: string;

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "zowex-vsce" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- **Breaking:** Renamed contributed setting IDs from `zowe-native-proto` to `zowex`. All references to `zowe-native-proto` should be replaced with `zowex` in VS Code `settings.json` files. [#831](https://github.com/zowe/zowex/issues/831)
+
 ## `0.4.0`
 
 - Added error correlation for expired z/OS password (`FOTS1668`/`FOTS1669`), surfacing actionable tips and documentation links in Zowe Explorer when SSH commands fail due to an expired password. [#867](https://github.com/zowe/zowex/pull/867)

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -1,102 +1,102 @@
 # Change Log
 
-All notable changes to the "zowe-native-proto-vsce" extension will be documented in this file.
+All notable changes to the "zowex-vsce" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## `0.4.0`
 
-- Added error correlation for expired z/OS password (`FOTS1668`/`FOTS1669`), surfacing actionable tips and documentation links in Zowe Explorer when SSH commands fail due to an expired password. [#867](https://github.com/zowe/zowe-native-proto/pull/867)
-- Updated **Show Attributes** to display member ISPF statistics [#630](https://github.com/zowe/zowe-native-proto/issues/630)
-- Improved Error Message handling and actions when encountering unrecoverable errors in `zowex`. [#548](https://github.com/zowe/zowe-native-proto/issues/548)
-- Added the functionality for the **Rename** option in the USS tree. [#820](https://github.com/zowe/zowe-native-proto/pull/820)
-- Added the functionality to move files in the USS tree. [#820](https://github.com/zowe/zowe-native-proto/pull/820)
-- Added the functionality to copy USS files and directories. [#379](https://github.com/zowe/zowe-native-proto/pull/379).
-- Added experimental native client for improved performance which can be enabled via a VS Code setting. [#833](https://github.com/zowe/zowe-native-proto/pull/833)
+- Added error correlation for expired z/OS password (`FOTS1668`/`FOTS1669`), surfacing actionable tips and documentation links in Zowe Explorer when SSH commands fail due to an expired password. [#867](https://github.com/zowe/zowex/pull/867)
+- Updated **Show Attributes** to display member ISPF statistics [#630](https://github.com/zowe/zowex/issues/630)
+- Improved Error Message handling and actions when encountering unrecoverable errors in `zowex`. [#548](https://github.com/zowe/zowex/issues/548)
+- Added the functionality for the **Rename** option in the USS tree. [#820](https://github.com/zowe/zowex/pull/820)
+- Added the functionality to move files in the USS tree. [#820](https://github.com/zowe/zowex/pull/820)
+- Added the functionality to copy USS files and directories. [#379](https://github.com/zowe/zowex/pull/379).
+- Added experimental native client for improved performance which can be enabled via a VS Code setting. [#833](https://github.com/zowe/zowex/pull/833)
 
 ## `0.3.0`
 
-- Used new SDK groupings that align with zowex. [#807](https://github.com/zowe/zowe-native-proto/issues/807)
-- Added support for passing member patterns when filtering data sets. [#817](https://github.com/zowe/zowe-native-proto/pull/817)
+- Used new SDK groupings that align with zowex. [#807](https://github.com/zowe/zowex/issues/807)
+- Added support for passing member patterns when filtering data sets. [#817](https://github.com/zowe/zowex/pull/817)
 
 ## `0.2.4`
 
-- Added the functionality for the **Rename Member** option. [#765] (https://github.com/zowe/zowe-native-proto/pull/765).
-- Added the `multivolume` (`mvol`) property when displaying data set attributes. [#782](https://github.com/zowe/zowe-native-proto/pull/782)
-- Fixed an issue where using the "Upload Member" option with an SSH profile in Zowe Explorer caused an error. Now, the member name is provided to the back end for each member that is uploaded. [#785](https://github.com/zowe/zowe-native-proto/issues/785)
+- Added the functionality for the **Rename Member** option. [#765] (https://github.com/zowe/zowex/pull/765).
+- Added the `multivolume` (`mvol`) property when displaying data set attributes. [#782](https://github.com/zowe/zowex/pull/782)
+- Fixed an issue where using the "Upload Member" option with an SSH profile in Zowe Explorer caused an error. Now, the member name is provided to the back end for each member that is uploaded. [#785](https://github.com/zowe/zowex/issues/785)
 
 ## `0.2.3`
 
-- Added the functionality for the **Rename Data Set** option. [#376](https://github.com/zowe/zowe-native-proto/issues/376)
-- Fixed an issue where the Zowe Explorer "Submit as JCL" command displayed `undefined` as the job name within the "Job submitted" notification. Now, the job name and ID are present in the information message. [#733](https://github.com/zowe/zowe-native-proto/issues/733)
-- Updated the server installation process to locate server PAX bundled in the SDK package. [#760](https://github.com/zowe/zowe-native-proto/pull/760)
+- Added the functionality for the **Rename Data Set** option. [#376](https://github.com/zowe/zowex/issues/376)
+- Fixed an issue where the Zowe Explorer "Submit as JCL" command displayed `undefined` as the job name within the "Job submitted" notification. Now, the job name and ID are present in the information message. [#733](https://github.com/zowe/zowex/issues/733)
+- Updated the server installation process to locate server PAX bundled in the SDK package. [#760](https://github.com/zowe/zowex/pull/760)
 
 ## `0.2.2`
 
-- Fixed an issue where prompts could disappear when VS Code window loses focus while connecting to a new host. [#710](https://github.com/zowe/zowe-native-proto/pull/710)
-- Fixed an issue where `usedp` attribute was not hidden in "Show Attributes" webview when its value is undefined. [#712](https://github.com/zowe/zowe-native-proto/pull/712)
-- Fixed an issue where listing data sets could silently fail when there is an authentication error. [#721](https://github.com/zowe/zowe-native-proto/pull/721)
+- Fixed an issue where prompts could disappear when VS Code window loses focus while connecting to a new host. [#710](https://github.com/zowe/zowex/pull/710)
+- Fixed an issue where `usedp` attribute was not hidden in "Show Attributes" webview when its value is undefined. [#712](https://github.com/zowe/zowex/pull/712)
+- Fixed an issue where listing data sets could silently fail when there is an authentication error. [#721](https://github.com/zowe/zowex/pull/721)
 
 ## `0.2.1`
 
-- Updated error handling to format request timeout errors. When a timeout error is received, the request is cancelled and the user receives a notification with context of where the error occurred. [#416](https://github.com/zowe/zowe-native-proto/issues/416)
-- When listing data sets with attributes, a comprehensive set is now retrieved that is similar to what ISPF displays. [#629](https://github.com/zowe/zowe-native-proto/issues/629)
-- Fixed profile validation hanging after deployment error. [#691](https://github.com/zowe/zowe-native-proto/pull/691)
+- Updated error handling to format request timeout errors. When a timeout error is received, the request is cancelled and the user receives a notification with context of where the error occurred. [#416](https://github.com/zowe/zowex/issues/416)
+- When listing data sets with attributes, a comprehensive set is now retrieved that is similar to what ISPF displays. [#629](https://github.com/zowe/zowex/issues/629)
+- Fixed profile validation hanging after deployment error. [#691](https://github.com/zowe/zowex/pull/691)
 
 ## `0.2.0`
 
-- Renamed `SshConfigUtils` class to `ConfigUtils` to avoid naming conflicts with SDK files [#614](https://github.com/zowe/zowe-native-proto/pull/614)
-- Added new `defaultHandshakeTimeout` VS Code setting to allow users to customize the handshake timeout when not specified in the profile. [#605](https://github.com/zowe/zowe-native-proto/pull/605)
-- Fixed SSH client caching to be per profile instead of per hostname, allowing multiple server instances on the same system. [#558](https://github.com/zowe/zowe-native-proto/pull/558)
-- Updated RPC response types for data set operations to align with SDK changes. [#590](https://github.com/zowe/zowe-native-proto/pull/590)
-- Added support for issuing TSO commands. [#595](https://github.com/zowe/zowe-native-proto/pull/595)
-- Fixed an issue where the input validation for the deploy directory prompt would falsely detect paths as invalid. [#609](https://github.com/zowe/zowe-native-proto/issues/609)
+- Renamed `SshConfigUtils` class to `ConfigUtils` to avoid naming conflicts with SDK files [#614](https://github.com/zowe/zowex/pull/614)
+- Added new `defaultHandshakeTimeout` VS Code setting to allow users to customize the handshake timeout when not specified in the profile. [#605](https://github.com/zowe/zowex/pull/605)
+- Fixed SSH client caching to be per profile instead of per hostname, allowing multiple server instances on the same system. [#558](https://github.com/zowe/zowex/pull/558)
+- Updated RPC response types for data set operations to align with SDK changes. [#590](https://github.com/zowe/zowex/pull/590)
+- Added support for issuing TSO commands. [#595](https://github.com/zowe/zowex/pull/595)
+- Fixed an issue where the input validation for the deploy directory prompt would falsely detect paths as invalid. [#609](https://github.com/zowe/zowex/issues/609)
 
 ## `0.1.10`
 
-- Updated the `Zowe-SSH: Connect to Host...` command to prompt the user to choose a deploy directory. [#527](https://github.com/zowe/zowe-native-proto/issues/527)
+- Updated the `Zowe-SSH: Connect to Host...` command to prompt the user to choose a deploy directory. [#527](https://github.com/zowe/zowex/issues/527)
 
 ## `0.1.9`
 
-- Moved `showSessionInTree` call to before `uninstallServer` is called to ensure the session is displayed in the tree before the uninstall removes it. [#484](https://github.com/zowe/zowe-native-proto/issues/484)
-- Filtered out certain information messages to display a clear and concise error message for when creating a data set with an invalid management class. [#502](https://github.com/zowe/zowe-native-proto/issues/502)
-- Added "Worker Count" setting to configure number of `zowex` worker threads. [#514](https://github.com/zowe/zowe-native-proto/pull/514)
-- Fixed error when using SSH profiles in Zowe Explorer 3.3.0. [#540](https://github.com/zowe/zowe-native-proto/issues/540)
-- Fixed an issue where the `Zowe-SSH: Connect to Host...` command did not prompt the user for a password if the given private key was not recognized by the host. [#524](https://github.com/zowe/zowe-native-proto/issues/524)
-- Added a new prompt that shows if the user has an invalid private key on an existing profile when running the `Zowe-SSH: Connect to Host...` command. Now, if an invalid private key is detected, it is moved to a new comment in the JSON file and the user is given options to proceed. They can undo the comment action, delete the comment entirely, or preserve the comment and succeed with setup. [#524](https://github.com/zowe/zowe-native-proto/issues/524)
-- Added a new error handler that integrates with Zowe Explorer to provide detailed troubleshooting information for connection failures, authentication issues, and server deployment problems. When an error occurs, a dialog is now displayed with a summary of the problem, actionable tips, and links to relevant documentation. [#228](https://github.com/zowe/zowe-native-proto/issues/228)
+- Moved `showSessionInTree` call to before `uninstallServer` is called to ensure the session is displayed in the tree before the uninstall removes it. [#484](https://github.com/zowe/zowex/issues/484)
+- Filtered out certain information messages to display a clear and concise error message for when creating a data set with an invalid management class. [#502](https://github.com/zowe/zowex/issues/502)
+- Added "Worker Count" setting to configure number of `zowex` worker threads. [#514](https://github.com/zowe/zowex/pull/514)
+- Fixed error when using SSH profiles in Zowe Explorer 3.3.0. [#540](https://github.com/zowe/zowex/issues/540)
+- Fixed an issue where the `Zowe-SSH: Connect to Host...` command did not prompt the user for a password if the given private key was not recognized by the host. [#524](https://github.com/zowe/zowex/issues/524)
+- Added a new prompt that shows if the user has an invalid private key on an existing profile when running the `Zowe-SSH: Connect to Host...` command. Now, if an invalid private key is detected, it is moved to a new comment in the JSON file and the user is given options to proceed. They can undo the comment action, delete the comment entirely, or preserve the comment and succeed with setup. [#524](https://github.com/zowe/zowex/issues/524)
+- Added a new error handler that integrates with Zowe Explorer to provide detailed troubleshooting information for connection failures, authentication issues, and server deployment problems. When an error occurs, a dialog is now displayed with a summary of the problem, actionable tips, and links to relevant documentation. [#228](https://github.com/zowe/zowex/issues/228)
 
 ## `0.1.7`
 
-- Fixed regression in performance where opening data sets and USS files in the editor could be slow. [#488](https://github.com/zowe/zowe-native-proto/pull/488)
+- Fixed regression in performance where opening data sets and USS files in the editor could be slow. [#488](https://github.com/zowe/zowex/pull/488)
 
 ## `0.1.6`
 
-- Fixed regression where USS download operations would fail because of a missing callback function. [#482](https://github.com/zowe/zowe-native-proto/issues/482)
+- Fixed regression where USS download operations would fail because of a missing callback function. [#482](https://github.com/zowe/zowex/issues/482)
 
 ## `0.1.5`
 
-- Implemented the `getTag` function in the `SshUssApi` class to return the tag of a UNIX file. Now, the VS Code extension automatically detects the file tag before the file is opened, and the detected encoding is shown in the "Open with Encoding" menu in Zowe Explorer. [#346](https://github.com/zowe/zowe-native-proto/issues/346)
-- Adopted streaming for API methods that upload/download data sets and USS files. [#358](https://github.com/zowe/zowe-native-proto/pull/358)
+- Implemented the `getTag` function in the `SshUssApi` class to return the tag of a UNIX file. Now, the VS Code extension automatically detects the file tag before the file is opened, and the detected encoding is shown in the "Open with Encoding" menu in Zowe Explorer. [#346](https://github.com/zowe/zowex/issues/346)
+- Adopted streaming for API methods that upload/download data sets and USS files. [#358](https://github.com/zowe/zowex/pull/358)
 
 ## `0.1.2`
 
-- Enhanced SSH profile validation to auto-deploy server when it is missing or out of date. [#44](https://github.com/zowe/zowe-native-proto/issues/44)
-- Added keep-alive messages to keep SSH connection active. Their frequency can be controlled with the "Keep Alive Interval" option. [#260](https://github.com/zowe/zowe-native-proto/issues/260)
+- Enhanced SSH profile validation to auto-deploy server when it is missing or out of date. [#44](https://github.com/zowe/zowex/issues/44)
+- Added keep-alive messages to keep SSH connection active. Their frequency can be controlled with the "Keep Alive Interval" option. [#260](https://github.com/zowe/zowex/issues/260)
 
 ## `0.1.1`
 
-- Fixed issue where a jobs list request returns unexpected results whenever a search query does not match any jobs. [#217](https://github.com/zowe/zowe-native-proto/pull/217)
-- Fixed issue where data set save requests sometimes resulted in an unexpected conflict error. [#219](https://github.com/zowe/zowe-native-proto/pull/219)
-- Fixed issue where Server Install Path setting did not work. [#220](https://github.com/zowe/zowe-native-proto/pull/220)
+- Fixed issue where a jobs list request returns unexpected results whenever a search query does not match any jobs. [#217](https://github.com/zowe/zowex/pull/217)
+- Fixed issue where data set save requests sometimes resulted in an unexpected conflict error. [#219](https://github.com/zowe/zowex/pull/219)
+- Fixed issue where Server Install Path setting did not work. [#220](https://github.com/zowe/zowex/pull/220)
 
 ## `0.1.0`
 
-- Fixed issue where `Open with Encoding: Binary` for MVS and USS files did not pass the correct encoding value to the server. [#61](https://github.com/zowe/zowe-native-proto/pull/61)
-- Added support for cancelling jobs. [#138](https://github.com/zowe/zowe-native-proto/pull/138)
-- Added support for running MVS commands. [#138](https://github.com/zowe/zowe-native-proto/pull/138)
-- Updated error handling for listing data sets. [#185](https://github.com/zowe/zowe-native-proto/pull/185)
-- Added support for conflict detection through use of e-tags. When a data set or USS file is opened, the e-tag is received by the VS Code extension and used in future write requests to prevent overwriting new changes on the target system. [#144](https://github.com/zowe/zowe-native-proto/issues/144)
+- Fixed issue where `Open with Encoding: Binary` for MVS and USS files did not pass the correct encoding value to the server. [#61](https://github.com/zowe/zowex/pull/61)
+- Added support for cancelling jobs. [#138](https://github.com/zowe/zowex/pull/138)
+- Added support for running MVS commands. [#138](https://github.com/zowe/zowex/pull/138)
+- Updated error handling for listing data sets. [#185](https://github.com/zowe/zowex/pull/185)
+- Added support for conflict detection through use of e-tags. When a data set or USS file is opened, the e-tag is received by the VS Code extension and used in future write requests to prevent overwriting new changes on the target system. [#144](https://github.com/zowe/zowex/issues/144)
 
 ## [Unreleased]
 

--- a/packages/vsce/README.md
+++ b/packages/vsce/README.md
@@ -1,6 +1,6 @@
-# Zowe Native Protocol for Zowe Explorer
+# Zowe Remote SSH for Zowe Explorer
 
-The Zowe Native Protocol extension for Zowe Explorer offers several features powered by the Zowe Native Protocol, enabling developers to interact with mainframe resources directly from their IDE.
+The Zowe Remote SSH extension for Zowe Explorer offers several features, enabling developers to interact with mainframe resources over SSH directly from their IDE.
 
 ## Features
 
@@ -28,7 +28,7 @@ The extension is installed and ready to use.
 
 ## Usage
 
-To deploy an instance of the Zowe Native Protocol server, run the `Zowe-SSH: Connect to Host...` command from the command palette. Select an SSH profile from the list of profiles to start the deployment and connection process. Once complete, the SSH profile is added to the Zowe Explorer tree views.
+To deploy an instance of the Zowe Remote SSH server, run the `Zowe-SSH: Connect to Host...` command from the command palette. Select an SSH profile from the list of profiles to start the deployment and connection process. Once complete, the SSH profile is added to the Zowe Explorer tree views.
 
 In the event that the server is unresponsive, you can restart the server with the `Zowe-SSH: Restart Zowe Server on Host...` command. 
 

--- a/packages/vsce/benchmarks/README.md
+++ b/packages/vsce/benchmarks/README.md
@@ -1,4 +1,4 @@
-# Zowe Native Proto VSCE Benchmarks
+# Zowe Remote SSH VSCE Benchmarks
 
 This directory contains performance benchmarks comparing the traditional z/OSMF REST APIs against the new native SSH APIs.
 

--- a/packages/vsce/log4jsconfig.json
+++ b/packages/vsce/log4jsconfig.json
@@ -23,20 +23,26 @@
                     "type": "pattern",
                     "pattern": "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m"
                 },
-                "filename": "logs/zowe-native-proto.log"
+                "filename": "logs/zowex.log"
             }
         },
         "categories": {
             "default": {
-                "appenders": ["default"],
+                "appenders": [
+                    "default"
+                ],
                 "level": "DEBUG"
             },
             "imperative": {
-                "appenders": ["imperative"],
+                "appenders": [
+                    "imperative"
+                ],
                 "level": "DEBUG"
             },
             "app": {
-                "appenders": ["app"],
+                "appenders": [
+                    "app"
+                ],
                 "level": "DEBUG"
             }
         }

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -59,7 +59,7 @@
         "zowex-vsce.serverAutoUpdate": {
           "type": "boolean",
           "default": true,
-          "description": "Automatically re-deploys the Zowe SSH server if out of date."
+          "description": "Automatically re-deploys the Zowe Remote SSH server if out of date."
         },
         "zowex-vsce.serverInstallPath": {
           "type": "object",
@@ -73,7 +73,7 @@
           "default": 3,
           "minimum": 1,
           "maximum": 50,
-          "description": "Number of worker threads for the Zowe SSH server. Each worker runs as a separate process in its own address space."
+          "description": "Number of worker threads for the Zowe Remote SSH server. Each worker runs as a separate process in its own address space."
         },
         "zowex-vsce.responseTimeout": {
           "type": "number",

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "zowe-native-proto-vsce",
+  "name": "zowex-vsce",
   "displayName": "Zowe Remote SSH",
   "description": "Zowe Native Proto VS Code Extension for Zowe Explorer",
   "version": "0.4.0",
   "publisher": "Zowe",
-  "repository": "https://github.com/zowe/zowe-native-proto-vsce/tree/main/packages/vsce",
+  "repository": "https://github.com/zowe/zowex-vsce/tree/main/packages/vsce",
   "engines": {
     "vscode": "^1.79.0"
   },
@@ -19,31 +19,31 @@
   "contributes": {
     "commands": [
       {
-        "command": "zowe-native-proto-vsce.connect",
+        "command": "zowex-vsce.connect",
         "title": "Zowe-SSH: Connect to Host..."
       },
       {
-        "command": "zowe-native-proto-vsce.restart",
+        "command": "zowex-vsce.restart",
         "title": "Zowe-SSH: Restart Zowe Server on Host..."
       },
       {
-        "command": "zowe-native-proto-vsce.showLog",
+        "command": "zowex-vsce.showLog",
         "title": "Zowe-SSH: Show Log"
       },
       {
-        "command": "zowe-native-proto-vsce.uninstall",
+        "command": "zowex-vsce.uninstall",
         "title": "Zowe-SSH: Uninstall Zowe Server from Host..."
       }
     ],
     "configuration": {
-      "title": "zowe-native-proto-vsce",
+      "title": "zowex-vsce",
       "properties": {
-        "zowe-native-proto-vsce.keepAliveInterval": {
+        "zowex-vsce.keepAliveInterval": {
           "type": "number",
           "default": 30,
           "description": "Number of seconds between keep-alive messages to keep connection active. Set to 0 to disable keep-alive."
         },
-        "zowe-native-proto-vsce.logLevel": {
+        "zowex-vsce.logLevel": {
           "type": "string",
           "default": "INFO",
           "description": "Sets logging level of the extension. Requires extension restart to take effect.",
@@ -56,45 +56,45 @@
             "FATAL"
           ]
         },
-        "zowe-native-proto-vsce.serverAutoUpdate": {
+        "zowex-vsce.serverAutoUpdate": {
           "type": "boolean",
           "default": true,
           "description": "Automatically re-deploys the Zowe SSH server if out of date."
         },
-        "zowe-native-proto-vsce.serverInstallPath": {
+        "zowex-vsce.serverInstallPath": {
           "type": "object",
           "description": "Mapping of SSH hostname to server install path for that host. Defaults to '~/.zowe-server'.",
           "additionalProperties": {
             "type": "string"
           }
         },
-        "zowe-native-proto-vsce.workerCount": {
+        "zowex-vsce.workerCount": {
           "type": "number",
           "default": 3,
           "minimum": 1,
           "maximum": 50,
           "description": "Number of worker threads for the Zowe SSH server. Each worker runs as a separate process in its own address space."
         },
-        "zowe-native-proto-vsce.responseTimeout": {
+        "zowex-vsce.responseTimeout": {
           "type": "number",
           "default": 60,
           "minimum": 1,
           "maximum": 600,
           "description": "Response timeout in seconds before the originating request is forcibly timed out. Set to a higher value if responses are expected to take longer to complete."
         },
-        "zowe-native-proto-vsce.requestTimeout": {
+        "zowex-vsce.requestTimeout": {
           "type": "number",
           "default": 60,
           "minimum": 1,
           "maximum": 600,
           "description": "Request timeout in seconds before a worker is restarted. Set to a higher value if requests are expected to take longer to complete."
         },
-        "zowe-native-proto-vsce.experimentalNativeSsh": {
+        "zowex-vsce.experimentalNativeSsh": {
           "type": "boolean",
           "default": false,
           "description": "Use an experimental native SSH client for improved performance. Not yet fully tested."
         },
-        "zowe-native-proto-vsce.defaultHandshakeTimeout": {
+        "zowex-vsce.defaultHandshakeTimeout": {
           "type": "number",
           "description": "Time in milliseconds to wait for the SSH handshake to complete.",
           "default": 30000,
@@ -124,7 +124,7 @@
     "@zowe/core-for-zowe-sdk": "^8.11.0",
     "@zowe/zowe-explorer-api": "^3.3.0",
     "ssh2": "^1.16.0",
-    "zowe-native-proto-sdk": "0.4.0"
+    "zowex-sdk": "0.4.0"
   },
   "devDependencies": {
     "@rspack/cli": "^1.7.6",

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zowex-vsce",
   "displayName": "Zowe Remote SSH",
-  "description": "Zowe Native Proto VS Code Extension for Zowe Explorer",
+  "description": "Zowe Remote SSH VS Code Extension for Zowe Explorer",
   "version": "0.4.0",
   "publisher": "Zowe",
   "repository": "https://github.com/zowe/zowex-vsce/tree/main/packages/vsce",

--- a/packages/vsce/rspack.config.js
+++ b/packages/vsce/rspack.config.js
@@ -40,7 +40,7 @@ module.exports = (_env, argv) => {
       // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
       extensions: ['.ts', '.js'],
       alias: {
-        'zowe-native-proto-sdk': path.resolve(__dirname, '..', 'sdk', 'src'),
+        'zowex-sdk': path.resolve(__dirname, '..', 'sdk', 'src'),
         'cpu-features': false,
         './crypto/build/Release/sshcrypto.node': false,
       }

--- a/packages/vsce/src/ConfigUtils.ts
+++ b/packages/vsce/src/ConfigUtils.ts
@@ -23,7 +23,7 @@ import {
     type qpItem,
     type qpOpts,
     ZSshClient,
-} from "zowe-native-proto-sdk";
+} from "zowex-sdk";
 import { getVsceConfig } from "./Utilities";
 
 // biome-ignore lint/complexity/noStaticOnlyClass: Utilities class has static methods

--- a/packages/vsce/src/NativeSshHelper.ts
+++ b/packages/vsce/src/NativeSshHelper.ts
@@ -90,7 +90,7 @@ export function watchNativeSshSetting(context: vscode.ExtensionContext): vscode.
     handleEnabled();
 
     return vscode.workspace.onDidChangeConfiguration((e) => {
-        if (e.affectsConfiguration("zowe-native-proto-vsce.experimentalNativeSsh")) {
+        if (e.affectsConfiguration("zowex-vsce.experimentalNativeSsh")) {
             handleEnabled();
         }
     });

--- a/packages/vsce/src/SshClientCache.ts
+++ b/packages/vsce/src/SshClientCache.ts
@@ -12,7 +12,7 @@
 import type { SshSession } from "@zowe/zos-uss-for-zowe-sdk";
 import { imperative, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
 import * as vscode from "vscode";
-import { type ClientOptions, type ExistingClientRequest, ZSshClient, ZSshUtils } from "zowe-native-proto-sdk";
+import { type ClientOptions, type ExistingClientRequest, ZSshClient, ZSshUtils } from "zowex-sdk";
 import { ConfigUtils } from "./ConfigUtils";
 import { deployWithProgress, getVsceConfig } from "./Utilities";
 

--- a/packages/vsce/src/SshErrorCorrelations.ts
+++ b/packages/vsce/src/SshErrorCorrelations.ts
@@ -10,7 +10,7 @@
  */
 
 import { ZoweExplorerApiType, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
-import { SshErrors } from "zowe-native-proto-sdk";
+import { SshErrors } from "zowex-sdk";
 
 /**
  * Registers all SSH-specific error correlations with the Zowe Explorer ErrorCorrelator

--- a/packages/vsce/src/SshErrorHandler.ts
+++ b/packages/vsce/src/SshErrorHandler.ts
@@ -64,7 +64,7 @@ export class SshErrorHandler {
         const response = await vscode.window.showErrorMessage(`${contextPrefix}${errorMessage}`, ...actions);
 
         if (response === "Show Details") {
-            const outputChannel = vscode.window.createOutputChannel("Zowe SSH");
+            const outputChannel = vscode.window.createOutputChannel("Zowe Remote SSH");
             outputChannel.appendLine(`Error: ${errorMessage}`);
             if (error instanceof Error && error.stack) {
                 outputChannel.appendLine(`Stack: ${error.stack}`);

--- a/packages/vsce/src/SshErrorHandler.ts
+++ b/packages/vsce/src/SshErrorHandler.ts
@@ -12,7 +12,7 @@
 import { ImperativeError } from "@zowe/imperative";
 import { type ZoweExplorerApiType, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
 import * as vscode from "vscode";
-import { RpcErrorCode, SshErrors } from "zowe-native-proto-sdk";
+import { RpcErrorCode, SshErrors } from "zowex-sdk";
 
 /**
  * Enhanced error handling utility for SSH operations using Zowe Explorer's ErrorCorrelator

--- a/packages/vsce/src/Utilities.ts
+++ b/packages/vsce/src/Utilities.ts
@@ -14,12 +14,12 @@ import * as path from "node:path";
 import type { SshSession } from "@zowe/zos-uss-for-zowe-sdk";
 import { Gui, imperative, ZoweExplorerApiType, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
 import * as vscode from "vscode";
-import { ZSshUtils } from "zowe-native-proto-sdk";
+import { ZSshUtils } from "zowex-sdk";
 import { ConfigUtils, VscePromptApi } from "./ConfigUtils";
 import { SshClientCache } from "./SshClientCache";
 import { SshErrorHandler } from "./SshErrorHandler";
 
-const EXTENSION_NAME = "zowe-native-proto-vsce";
+const EXTENSION_NAME = "zowex-vsce";
 
 export function deployWithProgress(session: SshSession, serverPath: string): Thenable<boolean> {
     return Gui.withProgress(
@@ -112,7 +112,7 @@ export function registerCommands(context: vscode.ExtensionContext): vscode.Dispo
             imperative.Logger.getAppLogger().trace("Running showLog command");
             await vscode.commands.executeCommand(
                 "vscode.open",
-                vscode.Uri.file(path.join(context.logUri.fsPath, "zowe-native-proto.log")),
+                vscode.Uri.file(path.join(context.logUri.fsPath, "zowex.log")),
             );
             await vscode.commands.executeCommand("workbench.action.files.setActiveEditorReadonlyInSession");
         }),

--- a/packages/vsce/src/Utilities.ts
+++ b/packages/vsce/src/Utilities.ts
@@ -25,7 +25,7 @@ export function deployWithProgress(session: SshSession, serverPath: string): The
     return Gui.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
-            title: "Deploying Zowe SSH server...",
+            title: "Deploying Zowe Remote SSH server...",
         },
         async (progress) => {
             // Create error callback that uses error correlations
@@ -90,7 +90,7 @@ export function registerCommands(context: vscode.ExtensionContext): vscode.Dispo
             }
 
             await ConfigUtils.showSessionInTree(profile.name!, true);
-            const infoMsg = `Installed Zowe SSH server on ${profile.profile.host ?? profile.name}`;
+            const infoMsg = `Installed Zowe Remote SSH server on ${profile.profile.host ?? profile.name}`;
             imperative.Logger.getAppLogger().info(infoMsg);
             await Gui.showMessage(infoMsg);
         }),
@@ -103,9 +103,9 @@ export function registerCommands(context: vscode.ExtensionContext): vscode.Dispo
             await SshClientCache.inst.connect(profile, { restart: true, retryRequests: false });
 
             imperative.Logger.getAppLogger().info(
-                `Restarted Zowe SSH server on ${profile.profile?.host ?? profile.name}`,
+                `Restarted Zowe Remote SSH server on ${profile.profile?.host ?? profile.name}`,
             );
-            const statusMsg = Gui.setStatusBarMessage("Restarted Zowe SSH server");
+            const statusMsg = Gui.setStatusBarMessage("Restarted Zowe Remote SSH server");
             setTimeout(() => statusMsg.dispose(), 5000);
         }),
         vscode.commands.registerCommand(`${EXTENSION_NAME}.showLog`, async () => {
@@ -135,7 +135,7 @@ export function registerCommands(context: vscode.ExtensionContext): vscode.Dispo
                 onError: errorCallback,
             });
 
-            const infoMsg = `Uninstalled Zowe SSH server from ${profile.profile.host ?? profile.name}`;
+            const infoMsg = `Uninstalled Zowe Remote SSH server from ${profile.profile.host ?? profile.name}`;
             imperative.Logger.getAppLogger().info(infoMsg);
             await Gui.showMessage(infoMsg);
         }),

--- a/packages/vsce/src/api/SshCommonApi.ts
+++ b/packages/vsce/src/api/SshCommonApi.ts
@@ -20,7 +20,7 @@ import {
     ZoweVsCodeExtension,
 } from "@zowe/zowe-explorer-api";
 import * as vscode from "vscode";
-import { type ZSshClient, ZSshUtils } from "zowe-native-proto-sdk";
+import { type ZSshClient, ZSshUtils } from "zowex-sdk";
 import { SshClientCache } from "../SshClientCache";
 import { SshErrorHandler } from "../SshErrorHandler";
 

--- a/packages/vsce/src/api/SshJesApi.ts
+++ b/packages/vsce/src/api/SshJesApi.ts
@@ -11,7 +11,7 @@
 
 import type * as zosjobs from "@zowe/zos-jobs-for-zowe-sdk";
 import type { MainframeInteraction } from "@zowe/zowe-explorer-api";
-import { B64String } from "zowe-native-proto-sdk";
+import { B64String } from "zowex-sdk";
 import { SshCommonApi } from "./SshCommonApi";
 
 export class SshJesApi extends SshCommonApi implements MainframeInteraction.IJes {

--- a/packages/vsce/src/api/SshMvsApi.ts
+++ b/packages/vsce/src/api/SshMvsApi.ts
@@ -22,7 +22,7 @@ import {
     imperative,
     type MainframeInteraction,
 } from "@zowe/zowe-explorer-api";
-import { B64String, type Dataset, type DatasetAttributes, type ds } from "zowe-native-proto-sdk";
+import { B64String, type Dataset, type DatasetAttributes, type ds } from "zowex-sdk";
 import { SshCommonApi } from "./SshCommonApi";
 
 class SshAttributesProvider implements IAttributesProvider {

--- a/packages/vsce/src/api/SshUssApi.ts
+++ b/packages/vsce/src/api/SshUssApi.ts
@@ -12,7 +12,7 @@
 import { createReadStream, createWriteStream } from "node:fs";
 import type * as zosfiles from "@zowe/zos-files-for-zowe-sdk";
 import { imperative, type MainframeInteraction, type Types } from "@zowe/zowe-explorer-api";
-import { B64String, type uss } from "zowe-native-proto-sdk";
+import { B64String, type uss } from "zowex-sdk";
 import { SshCommonApi } from "./SshCommonApi";
 
 export class SshUssApi extends SshCommonApi implements MainframeInteraction.IUss {

--- a/packages/vsce/tests/ConfigUtils.test.ts
+++ b/packages/vsce/tests/ConfigUtils.test.ts
@@ -19,7 +19,7 @@ import {
     MESSAGE_TYPE,
     type PrivateKeyWarningOptions,
     ZSshClient,
-} from "zowe-native-proto-sdk";
+} from "zowex-sdk";
 import { ConfigUtils, VscePromptApi } from "../src/ConfigUtils";
 import { getVsceConfig } from "../src/Utilities";
 

--- a/packages/vsce/tests/ConfigUtils.test.ts
+++ b/packages/vsce/tests/ConfigUtils.test.ts
@@ -14,12 +14,7 @@ import type { IProfile } from "@zowe/imperative";
 import { Gui, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import * as vscode from "vscode";
-import {
-    type AbstractConfigManager,
-    MESSAGE_TYPE,
-    type PrivateKeyWarningOptions,
-    ZSshClient,
-} from "zowex-sdk";
+import { type AbstractConfigManager, MESSAGE_TYPE, type PrivateKeyWarningOptions, ZSshClient } from "zowex-sdk";
 import { ConfigUtils, VscePromptApi } from "../src/ConfigUtils";
 import { getVsceConfig } from "../src/Utilities";
 

--- a/packages/vsce/tests/SSHClientCache.test.ts
+++ b/packages/vsce/tests/SSHClientCache.test.ts
@@ -12,7 +12,7 @@
 import { imperative, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as vscode from "vscode";
-import { ZSshClient, ZSshUtils } from "zowe-native-proto-sdk";
+import { ZSshClient, ZSshUtils } from "zowex-sdk";
 import { SshClientCache } from "../src/SshClientCache";
 import { deployWithProgress, getVsceConfig } from "../src/Utilities";
 
@@ -61,7 +61,7 @@ vi.mock("@zowe/zowe-explorer-api", () => {
     };
 });
 
-vi.mock("zowe-native-proto-sdk", () => {
+vi.mock("zowex-sdk", () => {
     return {
         ZSshClient: {
             create: vi.fn(),

--- a/packages/vsce/tests/SshErrorHandler.test.ts
+++ b/packages/vsce/tests/SshErrorHandler.test.ts
@@ -179,7 +179,7 @@ describe("SshErrorHandler", () => {
 
             await errorHandler.handleError(testError, ZoweExplorerApiType.All, "Operation");
 
-            expect(mockCreateOutputChannel).toHaveBeenCalledWith("Zowe SSH");
+            expect(mockCreateOutputChannel).toHaveBeenCalledWith("Zowe Remote SSH");
             expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("Error: Detailed error");
             expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
                 "Stack: Error: Detailed error\n    at test.js:1:1",

--- a/scripts/bundleCliTgz.js
+++ b/scripts/bundleCliTgz.js
@@ -15,7 +15,7 @@ const path = require("path");
 
 const outDir = path.resolve(process.argv[2]);
 process.chdir(__dirname + "/..");
-fs.mkdirSync(outDir, {recursive: true});
+fs.mkdirSync(outDir, { recursive: true });
 const tempDir = fs.mkdtempSync("build-");
 
 try {
@@ -24,7 +24,7 @@ try {
     fs.copyFileSync("package-lock.json", path.join(tempDir, "npm-shrinkwrap.json"));
     execSync("npm install --ignore-scripts", execOptions);
 
-    const sdkDir = path.join("node_modules", "zowe-native-proto-sdk");
+    const sdkDir = path.join("node_modules", "zowex-sdk");
     fs.unlinkSync(path.join(tempDir, sdkDir));
     fs.cpSync(fs.realpathSync(sdkDir), path.join(tempDir, sdkDir), { recursive: true });
     fs.rmSync(path.join(tempDir, "node_modules", "cpu-features"), { recursive: true, force: true });


### PR DESCRIPTION
**What It Does**

- Changed all references of "Zowe Native", "Zowe Native Proto", "Zowe SSH" -> "Zowe Remote SSH"
- Changed technical/dev references of "zowe-native-proto" -> "zowex"
- Updated setting IDs from "zowe-native-proto" namespace to "zowex" namespace

**How to Test**

Read over the changes and make sure that there aren't any more references to Zowe Native Proto, Zowe SSH, or Zowe Native 😋 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)