### PR TITLE
whoops: fix number of saved registers :yum:

### DIFF
--- a/native/c/zmetal.h
+++ b/native/c/zmetal.h
@@ -338,7 +338,8 @@ static void *PTR64 load_module(const char *name)
 
   auth_off(); // NOTE(Kelosky): force auth off before loading any module
 
-  unsigned long long save_registers[11] = {0}; // Save 8 bytes for each register 2-13 for PDSMAN/IEBCOPY
+  // Save 8 bytes for each register 2-13 (including 13) for PDSMAN/IEBCOPY
+  unsigned long long save_registers[12] = {0};
   LOAD(name_truncated, ep, rc, rsn, save_registers[0]);
   if (0 != rc)
   {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Include register 13 in the array to avoid writing over some unknown piece of memory 😅 

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

You can trigger an S0C3 (`exrl 0,*`) before and after the saved registers and notice register 13 will likely be garbage 😓 

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
