### PR TITLE
Add --overwrite option to creation commands

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -11,6 +11,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c`: Added the `getInfo` RPC to retrieve the middleware version and build information. [#922](https://github.com/zowe/zowex/pull/922)
 - `c`: Added a DCB abend exit for handling edge cases around PDS member open, write, and close operations. When an abend is encountered, it is either delayed or ignored (when applicable) and an error is returned gracefully via the diagnostic structure (`ZDIAG`) rather than terminating the process. Refer to [DCB abend exits](doc/dcb-abend-exit.md) for more information on how and when abends are handled. **Note:** In the event of an end-of-space (end-of-volume) abend, the operating system closes the DCB if the ignore request is honored from the abend exit. However, the abend might still percolate during end-of-volume `CLOSE` routines. An ESTAE/ESTAEX recovery routine should be used to gracefully handle these cases. [#839](https://github.com/zowe/zowex/issues/839)
 - `c`: Fixed an issue where listing the members of a protected, partitioned data set resulted in an unclear error message. Now, the error messages are more specific and include information about insufficient permissions when applicable. [#297](https://github.com/zowe/zowex/issues/297)
+- `c`: Fixed an issue where `zowex ds create-member` command would overwrite an existing member. Added an `--overwrite` flag to the command that defaults to false. [#642](https://github.com/zowe/zowex/issues/642)
 
 ## `0.4.0`
 

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -12,7 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - `c`: Added the `getInfo` RPC to retrieve the middleware version and build information. [#922](https://github.com/zowe/zowex/pull/922)
 - `c`: Added a DCB abend exit for handling edge cases around PDS member open, write, and close operations. When an abend is encountered, it is either delayed or ignored (when applicable) and an error is returned gracefully via the diagnostic structure (`ZDIAG`) rather than terminating the process. Refer to [DCB abend exits](doc/dcb-abend-exit.md) for more information on how and when abends are handled. **Note:** In the event of an end-of-space (end-of-volume) abend, the operating system closes the DCB if the ignore request is honored from the abend exit. However, the abend might still percolate during end-of-volume `CLOSE` routines. An ESTAE/ESTAEX recovery routine should be used to gracefully handle these cases. [#839](https://github.com/zowe/zowex/issues/839)
 - `c`: Fixed an issue where listing the members of a protected, partitioned data set resulted in an unclear error message. Now, the error messages are more specific and include information about insufficient permissions when applicable. [#297](https://github.com/zowe/zowex/issues/297)
-- `c`: Fixed an issue where `zowex ds create-member` command would overwrite an existing member. Added an `--overwrite` flag to the command that defaults to false. [#642](https://github.com/zowe/zowex/issues/642)
+- `c`: Fixed an issue where the `zowex ds create-member` command would overwrite an existing member. Added an `--overwrite` flag to the command that defaults to false. [#642](https://github.com/zowe/zowex/issues/642)
 
 ## `0.4.0`
 

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -47,8 +47,8 @@ int process_data_set_create_result(InvocationContext &context, ZDS *zds, int rc,
     rc = zds_write_to_dsn(zds, dsn, data);
     if (0 != rc)
     {
-      context.output_stream() << "Error: could not write to data set: '" << dsn << "' rc: '" << rc << "'" << std::endl;
-      context.output_stream() << "  Details: " << zds->diag.e_msg << std::endl;
+      context.error_stream() << "Error: could not write to data set: '" << dsn << "' rc: '" << rc << "'" << std::endl;
+      context.error_stream() << "  Details: " << zds->diag.e_msg << std::endl;
       return RTNCD_FAILURE;
     }
     context.output_stream() << "Data set and/or member created: '" << dsn << "'" << std::endl;
@@ -304,9 +304,16 @@ int handle_data_set_create_member(InvocationContext &context)
     rc = zds_list_data_sets(&zds, dataset_name, entries);
     if (RTNCD_WARNING < rc || entries.size() == 0)
     {
-      context.output_stream() << "Error: could not create data set member: '" << dataset_name << "' rc: '" << rc << "'" << std::endl;
-      context.output_stream() << "  Details:\n"
-                              << zds.diag.e_msg << std::endl;
+      context.error_stream() << "Error: could not create data set member: '" << dataset_name << "' rc: '" << rc << "'" << std::endl;
+      context.error_stream() << "  Details: " << zds.diag.e_msg << std::endl;
+      return RTNCD_FAILURE;
+    }
+
+    bool overwrite = context.get<bool>("overwrite", false);
+    if (!overwrite && zds_member_exists(dataset_name, member_name))
+    {
+      context.error_stream() << "Error: could not create data set member: '" << member_name << "' rc: '" << RTNCD_FAILURE << "'" << std::endl;
+      context.error_stream() << "  Details: Data set member already exists: '" << dsn << "'" << std::endl;
       return RTNCD_FAILURE;
     }
 
@@ -314,15 +321,15 @@ int handle_data_set_create_member(InvocationContext &context)
     rc = zds_write_to_dsn(&zds, dsn, data);
     if (0 != rc)
     {
-      context.output_stream() << "Error: could not write to data set: '" << dsn << "' rc: '" << rc << "'" << std::endl;
-      context.output_stream() << "  Details: " << zds.diag.e_msg << std::endl;
+      context.error_stream() << "Error: could not write to data set: '" << dsn << "' rc: '" << rc << "'" << std::endl;
+      context.error_stream() << "  Details: " << zds.diag.e_msg << std::endl;
       return RTNCD_FAILURE;
     }
     context.output_stream() << "Data set and/or member created: '" << dsn << "'" << std::endl;
   }
   else
   {
-    context.output_stream() << "Error: could not find member name in dsn: '" << dsn << "'" << std::endl;
+    context.error_stream() << "Error: could not find member name in dsn: '" << dsn << "'" << std::endl;
     return RTNCD_FAILURE;
   }
 
@@ -1066,6 +1073,7 @@ void register_commands(parser::Command &root_command)
   auto ds_create_member_cmd = command_ptr(new Command("create-member", "create member in data set"));
   ds_create_member_cmd->add_alias("cre-m");
   ds_create_member_cmd->add_positional_arg("dsn", "data set name with member specified", ArgType_Single, true);
+  ds_create_member_cmd->add_keyword_arg("overwrite", make_aliases("--overwrite", "--ow"), "overwrite existing member", ArgType_Flag, false, ArgValue(false));
   ds_create_member_cmd->set_handler(handle_data_set_create_member);
   data_set_cmd->add_command(ds_create_member_cmd);
 

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -312,9 +312,8 @@ int handle_data_set_create_member(InvocationContext &context)
     bool overwrite = context.get<bool>("overwrite", false);
     if (!overwrite && zds_member_exists(dataset_name, member_name))
     {
-      context.error_stream() << "Error: could not create data set member: '" << member_name << "' rc: '" << RTNCD_FAILURE << "'" << std::endl;
-      context.error_stream() << "  Details: Data set member already exists: '" << dsn << "'" << std::endl;
-      return RTNCD_FAILURE;
+      context.error_stream() << "Warning: Data set member already exists: '" << dsn << "'" << std::endl;
+      return RTNCD_WARNING;
     }
 
     std::string data = "";

--- a/native/c/commands/uss.cpp
+++ b/native/c/commands/uss.cpp
@@ -79,7 +79,7 @@ int handle_uss_create_file(InvocationContext &context)
   }
 
   ZUSF zusf{};
-  rc = zusf_create_uss_file_or_dir(&zusf, file_path, cf_mode, false, overwrite);
+  rc = zusf_create_uss_file_or_dir(&zusf, file_path, cf_mode, CreateOptions(false, overwrite));
   if (0 != rc)
   {
     context.error_stream() << "Error: could not create USS file: '" << file_path << "' rc: '" << rc << "'" << std::endl;
@@ -120,7 +120,7 @@ int handle_uss_create_dir(InvocationContext &context)
   }
 
   ZUSF zusf{};
-  rc = zusf_create_uss_file_or_dir(&zusf, file_path, cf_mode, true);
+  rc = zusf_create_uss_file_or_dir(&zusf, file_path, cf_mode, CreateOptions(true));
   if (0 != rc)
   {
     context.error_stream() << "Error: could not create USS directory: '" << file_path << "' rc: '" << rc << "'" << std::endl;

--- a/native/c/commands/uss.cpp
+++ b/native/c/commands/uss.cpp
@@ -80,7 +80,12 @@ int handle_uss_create_file(InvocationContext &context)
 
   ZUSF zusf{};
   rc = zusf_create_uss_file_or_dir(&zusf, file_path, cf_mode, CreateOptions(false, overwrite));
-  if (0 != rc)
+  if (RTNCD_WARNING == rc)
+  {
+    context.error_stream() << "Warning: " << zusf.diag.e_msg << std::endl;
+    return RTNCD_WARNING;
+  }
+  else if (0 != rc)
   {
     context.error_stream() << "Error: could not create USS file: '" << file_path << "' rc: '" << rc << "'" << std::endl;
     context.error_stream() << "  Details: " << zusf.diag.e_msg << std::endl;

--- a/native/c/commands/uss.cpp
+++ b/native/c/commands/uss.cpp
@@ -56,6 +56,7 @@ int handle_uss_create_file(InvocationContext &context)
   std::string file_path = context.get<std::string>("file-path", "");
 
   long long mode = context.get<long long>("mode", 644);
+  bool overwrite = context.get<bool>("overwrite", false);
 
   if (mode == 0)
   {
@@ -78,12 +79,11 @@ int handle_uss_create_file(InvocationContext &context)
   }
 
   ZUSF zusf{};
-  rc = zusf_create_uss_file_or_dir(&zusf, file_path, cf_mode, false);
+  rc = zusf_create_uss_file_or_dir(&zusf, file_path, cf_mode, false, overwrite);
   if (0 != rc)
   {
     context.error_stream() << "Error: could not create USS file: '" << file_path << "' rc: '" << rc << "'" << std::endl;
-    context.error_stream() << "  Details:\n"
-                           << zusf.diag.e_msg << std::endl;
+    context.error_stream() << "  Details: " << zusf.diag.e_msg << std::endl;
     return RTNCD_FAILURE;
   }
 
@@ -124,8 +124,7 @@ int handle_uss_create_dir(InvocationContext &context)
   if (0 != rc)
   {
     context.error_stream() << "Error: could not create USS directory: '" << file_path << "' rc: '" << rc << "'" << std::endl;
-    context.error_stream() << "  Details:\n"
-                           << zusf.diag.e_msg << std::endl;
+    context.error_stream() << "  Details: " << zusf.diag.e_msg << std::endl;
     return RTNCD_FAILURE;
   }
 
@@ -145,8 +144,7 @@ int handle_uss_move(InvocationContext &context)
   if (0 != rc)
   {
     context.error_stream() << "Error: could not move USS file or directory: '" << source << "' to '" << target << "' rc: '" << rc << "'" << std::endl;
-    context.error_stream() << "  Details:\n"
-                           << zusf.diag.e_msg << std::endl;
+    context.error_stream() << "  Details: " << zusf.diag.e_msg << std::endl;
     return RTNCD_FAILURE;
   }
   context.output_stream() << "USS file or directory '" << source << "' moved to '" << target << "'" << std::endl;
@@ -457,8 +455,7 @@ int handle_uss_chmod(InvocationContext &context)
   if (0 != rc)
   {
     context.error_stream() << "Error: could not chmod USS path: '" << file_path << "' rc: '" << rc << "'" << std::endl;
-    context.error_stream() << "  Details:\n"
-                           << zusf.diag.e_msg << std::endl;
+    context.error_stream() << "  Details: " << zusf.diag.e_msg << std::endl;
     return RTNCD_FAILURE;
   }
 
@@ -479,8 +476,7 @@ int handle_uss_chown(InvocationContext &context)
   if (0 != rc)
   {
     context.error_stream() << "Error: could not chown USS path: '" << path << "' rc: '" << rc << "'" << std::endl;
-    context.error_stream() << "  Details:\n"
-                           << zusf.diag.e_msg << std::endl;
+    context.error_stream() << "  Details: " << zusf.diag.e_msg << std::endl;
     return RTNCD_FAILURE;
   }
 
@@ -512,8 +508,7 @@ int handle_uss_chtag(InvocationContext &context)
   if (0 != rc)
   {
     context.error_stream() << "Error: could not chtag USS path: '" << path << "' rc: '" << rc << "'" << std::endl;
-    context.error_stream() << "  Details:\n"
-                           << zusf.diag.e_msg << std::endl;
+    context.error_stream() << "  Details: " << zusf.diag.e_msg << std::endl;
     return RTNCD_FAILURE;
   }
 
@@ -568,6 +563,7 @@ void register_commands(parser::Command &root_command)
   auto uss_create_file_cmd = command_ptr(new Command("create-file", "create a USS file"));
   uss_create_file_cmd->add_positional_arg(FILE_PATH);
   uss_create_file_cmd->add_keyword_arg("mode", make_aliases("--mode"), "permissions", ArgType_Single, false);
+  uss_create_file_cmd->add_keyword_arg("overwrite", make_aliases("--overwrite", "--ow"), "overwrite existing file", ArgType_Flag, false, ArgValue(false));
   uss_create_file_cmd->set_handler(handle_uss_create_file);
   uss_group->add_command(uss_create_file_cmd);
 

--- a/native/c/server/schemas/requests.hpp
+++ b/native/c/server/schemas/requests.hpp
@@ -53,7 +53,8 @@ ZJSON_SCHEMA(CreateDatasetRequest,
 
 struct CreateMemberRequest {};
 ZJSON_SCHEMA(CreateMemberRequest,
-    FIELD_REQUIRED(dsname, STRING)
+    FIELD_REQUIRED(dsname, STRING),
+    FIELD_OPTIONAL(overwrite, BOOL)
 );
 
 struct DeleteDatasetRequest {};
@@ -234,7 +235,8 @@ struct CreateFileRequest {};
 ZJSON_SCHEMA(CreateFileRequest,
     FIELD_OPTIONAL(permissions, STRING),
     FIELD_REQUIRED(fspath, STRING),
-    FIELD_OPTIONAL(isDir, BOOL)
+    FIELD_OPTIONAL(isDir, BOOL),
+    FIELD_OPTIONAL(overwrite, BOOL)
 );
 
 struct DeleteFileRequest {};

--- a/native/c/test/zowex.ds.test.cpp
+++ b/native/c/test/zowex.ds.test.cpp
@@ -496,42 +496,74 @@ void zowex_ds_tests()
                              ExpectWithContext(rc, response).ToBe(0);
                              Expect(response).ToContain("Data set and/or member created");
                            });
+                        it("should not overwrite existing members",
+                           [&]() -> void
+                           {
+                             std::string ds = "'" + _ds.back() + "(TEST)'";
+                             std::string response;
+                             std::string command = zowex_command + " data-set create-member " + ds;
+                             int rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("Data set and/or member created");
 
-                        // TODO: https://github.com/zowe/zowex/issues/643
-                        xit("should not overwrite existing members",
-                            [&]() -> void
-                            {
-                              std::string ds = "'" + _ds.back() + "(TEST)'";
-                              std::string response;
-                              std::string command = zowex_command + " data-set create-member " + ds;
-                              int rc = execute_command_with_output(command, response);
-                              ExpectWithContext(rc, response).ToBe(0);
-                              Expect(response).ToContain("Data set and/or member created");
+                             // Write "test" data
+                             command = "echo test | " + zowex_command + " data-set write " + ds;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("Wrote data to");
 
-                              // Write "test" data
-                              command = "echo test | " + zowex_command + " data-set write " + ds;
-                              rc = execute_command_with_output(command, response);
-                              ExpectWithContext(rc, response).ToBe(0);
-                              Expect(response).ToContain("Wrote data to");
+                             // Read "test" data to confirm
+                             command = zowex_command + " data-set view " + ds;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("test");
 
-                              // Read "test" data to confirm
-                              command = "echo test | " + zowex_command + " data-set view " + ds;
-                              rc = execute_command_with_output(command, response);
-                              ExpectWithContext(rc, response).ToBe(0);
-                              Expect(response).ToContain("test");
+                             // Create the same TEST member
+                             command = zowex_command + " data-set create-member " + ds;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).Not().ToBe(0);
+                             Expect(response).ToContain("Warning");
 
-                              // Create the same TEST member
-                              command = "echo test | " + zowex_command + " data-set create-member " + ds;
-                              rc = execute_command_with_output(command, response);
-                              ExpectWithContext(rc, response).Not().ToBe(0);
-                              Expect(response).ToContain("ERROR");
+                             // Read "test" data to confirm
+                             command = zowex_command + " data-set view " + ds;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("test");
+                           });
+                        it("should overwrite existing members if --overwrite is specified",
+                           [&]() -> void
+                           {
+                             std::string ds = "'" + _ds.back() + "(TEST)'";
+                             std::string response;
+                             std::string command = zowex_command + " data-set create-member " + ds;
+                             int rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("Data set and/or member created");
 
-                              // Read "test" data to confirm
-                              command = "echo test | " + zowex_command + " data-set view " + ds;
-                              rc = execute_command_with_output(command, response);
-                              ExpectWithContext(rc, response).ToBe(0);
-                              Expect(response).ToContain("test");
-                            });
+                             // Write "test" data
+                             command = "echo test | " + zowex_command + " data-set write " + ds;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("Wrote data to");
+
+                             // Read "test" data to confirm
+                             command = zowex_command + " data-set view " + ds;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("test");
+
+                             // Create the same TEST member
+                             command = zowex_command + " data-set create-member " + ds + " --overwrite";
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("Data set and/or member created");
+
+                             // Read to confirm data was overwritten
+                             command = zowex_command + " data-set view " + ds;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).Not().ToContain("test");
+                           });
                       });
              describe("create-vb",
                       [&]() -> void

--- a/native/c/test/zowex.uss.test.cpp
+++ b/native/c/test/zowex.uss.test.cpp
@@ -580,7 +580,7 @@ void zowex_uss_tests()
                              ExpectWithContext(rc, response).ToBe(0);
                              Expect(response).ToContain("-rw-r--r--");
                            });
-                        it("should properly handle a creating a file in a non-existant directory",
+                        it("should properly handle a creating a file in a non-existent directory",
                            [&]() -> void
                            {
                              std::string uss_file = get_random_uss(ussTestDir) + "/does_not_exist";
@@ -591,6 +591,72 @@ void zowex_uss_tests()
                              }
                              ExpectWithContext(rc, response).ToBe(255);
                              Expect(response).ToContain("could not create USS file: '" + uss_file + "'");
+                           });
+                        it("should not overwrite existing files",
+                           [&]() -> void
+                           {
+                             std::string uss_file = get_random_uss(ussTestDir);
+                             std::string command = zowex_command + " uss create-file " + uss_file;
+                             int rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("USS file '" + uss_file + "' created");
+
+                             // Write "test" data
+                             command = "echo test | " + zowex_command + " uss write " + uss_file + " --ec binary";
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("Wrote data to");
+
+                             // Read "test" data to confirm
+                             command = zowex_command + " uss view " + uss_file + " --ec binary";
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("test");
+
+                             // Create the same file again
+                             command = zowex_command + " uss create-file " + uss_file;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).Not().ToBe(0);
+                             Expect(response).ToContain("Warning");
+
+                             // Read "test" data to confirm
+                             command = zowex_command + " uss view " + uss_file + " --ec binary";
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("test");
+                           });
+                        it("should overwrite existing files if --overwrite is specified",
+                           [&]() -> void
+                           {
+                             std::string uss_file = get_random_uss(ussTestDir);
+                             std::string command = zowex_command + " uss create-file " + uss_file;
+                             int rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("USS file '" + uss_file + "' created");
+
+                             // Write "test" data
+                             command = "echo test | " + zowex_command + " uss write " + uss_file + " --ec binary";
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("Wrote data to");
+
+                             // Read "test" data to confirm
+                             command = zowex_command + " uss view " + uss_file + " --ec binary";
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("test");
+
+                             // Create the same file again
+                             command = zowex_command + " uss create-file " + uss_file + " --overwrite";
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("USS file '" + uss_file + "' created");
+
+                             // Read to confirm data was overwritten
+                             command = zowex_command + " uss view " + uss_file + " --ec binary";
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).Not().ToContain("test");
                            });
                       });
              describe("delete",

--- a/native/c/test/zusf.test.cpp
+++ b/native/c/test/zusf.test.cpp
@@ -70,8 +70,8 @@ void zusf_tests()
                   const std::string source_file = file_a;
                   const std::string dest_file = file_b;
                   std::string list_response;
-                  zusf_create_uss_file_or_dir(&zusf, source_file, 0664, false);
-                  zusf_create_uss_file_or_dir(&zusf, dest_file, 0775, true);
+                  zusf_create_uss_file_or_dir(&zusf, source_file, 0664, CreateOptions());
+                  zusf_create_uss_file_or_dir(&zusf, dest_file, 0775, CreateOptions(true));
                   int rc;
                   rc = zusf_copy_file_or_dir(&zusf, source_file, dest_file, copts_preserve);
                   Expect(rc).ToBe(0);
@@ -113,8 +113,8 @@ void zusf_tests()
                   const std::string dest_dir = dir_b;
                   std::string list_response;
                   const std::string dest_copied_file = dest_dir + "/" + get_basename(source_file);
-                  zusf_create_uss_file_or_dir(&zusf, source_file, 0664, false);
-                  zusf_create_uss_file_or_dir(&zusf, dest_dir, 0775, true);
+                  zusf_create_uss_file_or_dir(&zusf, source_file, 0664, CreateOptions());
+                  zusf_create_uss_file_or_dir(&zusf, dest_dir, 0775, CreateOptions(true));
                   int rc;
                   rc = zusf_copy_file_or_dir(&zusf, source_file, dest_dir, copts_preserve);
                   Expect(rc).ToBe(0);
@@ -162,8 +162,8 @@ void zusf_tests()
                   const std::string source_dir = dir_a;
                   const std::string dest_file = file_b;
                   std::string list_response;
-                  zusf_create_uss_file_or_dir(&zusf, source_dir, 0775, true);
-                  zusf_create_uss_file_or_dir(&zusf, dest_file, 0664, false);
+                  zusf_create_uss_file_or_dir(&zusf, source_dir, 0775, CreateOptions(true));
+                  zusf_create_uss_file_or_dir(&zusf, dest_file, 0664, CreateOptions());
                   int rc;
 
                   // copy to an existing file: error and no change to file/dir
@@ -202,7 +202,7 @@ void zusf_tests()
                   int rc;
                   std::string list_response;
 
-                  zusf_create_uss_file_or_dir(&zusf, source_dir, 0775, true);
+                  zusf_create_uss_file_or_dir(&zusf, source_dir, 0775, CreateOptions(true));
 
                   // bad source
                   rc = zusf_copy_file_or_dir(&zusf, "/noway/src/noexist", dest_dir, copts_preserve);
@@ -231,8 +231,8 @@ void zusf_tests()
                   const std::string dest_link_filepath = dest_dir + "/find";
                   const std::string dest_symlink_nested_dir = dest_dir + "/find/me/with/symlink";
 
-                  zusf_create_uss_file_or_dir(&zusf, source_nested, 0775, true);
-                  zusf_create_uss_file_or_dir(&zusf, symlink_nested_dir, 0775, true);
+                  zusf_create_uss_file_or_dir(&zusf, source_nested, 0775, CreateOptions(true));
+                  zusf_create_uss_file_or_dir(&zusf, symlink_nested_dir, 0775, CreateOptions(true));
 
                   // symlink
                   std::string cmd_output;
@@ -279,11 +279,11 @@ void zusf_tests()
                   const std::string source_dir = dir_a;
                   const std::string target_dir = dir_b;
 
-                  ExpectWithContext(zusf_create_uss_file_or_dir(&zusf, source_file, 0664, false), zusf.diag.e_msg).ToBe(0);
-                  ExpectWithContext(zusf_create_uss_file_or_dir(&zusf, target_file, 0400, false), zusf.diag.e_msg).ToBe(0);
-                  ExpectWithContext(zusf_create_uss_file_or_dir(&zusf, source_dir, 0664, true), zusf.diag.e_msg).ToBe(0);
-                  ExpectWithContext(zusf_create_uss_file_or_dir(&zusf, target_dir, 0775, true), zusf.diag.e_msg).ToBe(0);
-                  ExpectWithContext(zusf_create_uss_file_or_dir(&zusf, target_dir + "/" + get_basename(source_dir), 0400, true), zusf.diag.e_msg).ToBe(0);
+                  ExpectWithContext(zusf_create_uss_file_or_dir(&zusf, source_file, 0664, CreateOptions()), zusf.diag.e_msg).ToBe(0);
+                  ExpectWithContext(zusf_create_uss_file_or_dir(&zusf, target_file, 0400, CreateOptions()), zusf.diag.e_msg).ToBe(0);
+                  ExpectWithContext(zusf_create_uss_file_or_dir(&zusf, source_dir, 0664, CreateOptions(true)), zusf.diag.e_msg).ToBe(0);
+                  ExpectWithContext(zusf_create_uss_file_or_dir(&zusf, target_dir, 0775, CreateOptions(true)), zusf.diag.e_msg).ToBe(0);
+                  ExpectWithContext(zusf_create_uss_file_or_dir(&zusf, target_dir + "/" + get_basename(source_dir), 0400, CreateOptions(true)), zusf.diag.e_msg).ToBe(0);
 
                   // can't overwrite 0400 target without force
                   zusf_chmod_uss_file_or_dir(&zusf, target_file, 0400, false);
@@ -295,8 +295,8 @@ void zusf_tests()
                   const std::string source_file = file_a;
                   const std::string dest_dir = dir_b;
 
-                  zusf_create_uss_file_or_dir(&zusf, source_file, 0664, false);
-                  zusf_create_uss_file_or_dir(&zusf, dest_dir, 0400, true); // TODO: this does not set permissions to 0400. why? `zowex uss create-dir test_dir --mode 0400` works!
+                  zusf_create_uss_file_or_dir(&zusf, source_file, 0664, CreateOptions());
+                  zusf_create_uss_file_or_dir(&zusf, dest_dir, 0400, CreateOptions(true)); // TODO: this does not set permissions to 0400. why? `zowex uss create-dir test_dir --mode 0400` works!
                   // chmod must succeed for copy to fail
                   ExpectWithContext(zusf_chmod_uss_file_or_dir(&zusf, dest_dir, 0400, true), zusf.diag.e_msg).ToBe(0);
                   int rc;
@@ -1624,7 +1624,7 @@ void zusf_tests()
 
                   // Test file creation with encoding options set
                   // This simulates what would happen during file write operations
-                  int result = zusf_create_uss_file_or_dir(&zusf, test_file, 0644, false);
+                  int result = zusf_create_uss_file_or_dir(&zusf, test_file, 0644, CreateOptions());
                   Expect(result).ToBe(RTNCD_SUCCESS);
 
                   // Verify file was created
@@ -1653,7 +1653,7 @@ void zusf_tests()
                   rmdir(test_dir.c_str());
 
                   // Test directory creation with encoding options set
-                  int result = zusf_create_uss_file_or_dir(&zusf, test_dir, 0755, true);
+                  int result = zusf_create_uss_file_or_dir(&zusf, test_dir, 0755, CreateOptions(true));
                   Expect(result).ToBe(RTNCD_SUCCESS);
 
                   // Verify directory was created

--- a/native/c/zds.hpp
+++ b/native/c/zds.hpp
@@ -145,6 +145,15 @@ int zds_copy_dsn(ZDS *zds, const std::string &dsn1, const std::string &dsn2, ZDS
 bool zds_dataset_exists(const std::string &dsn);
 
 /**
+ * @brief Check if a data set member exists
+ *
+ * @param dsn data set name
+ * @param member member name
+ * @return true if it exists; false otherwise
+ */
+bool zds_member_exists(const std::string &dsn, const std::string &member);
+
+/**
  * @brief Options for reading a z/OS data set or DD
  */
 struct ZDSReadOpts

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -941,7 +941,7 @@ int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode
     {
       zusf->diag.e_msg_len = sprintf(zusf->diag.e_msg, "Path '%s' already exists! Mode: '%08o'", file.c_str(), file_stats.st_mode);
     }
-    return RTNCD_FAILURE;
+    return RTNCD_WARNING;
   }
 
   if (options.create_dir)

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -921,13 +921,14 @@ int zusf_copy_file_or_dir(ZUSF *zusf, const std::string &source_path, const std:
  * @param file name of the USS file
  * @param mode mode of the file or directory
  * @param createDir flag indicating whether to create a directory
+ * @param overwrite flag indicating whether to overwrite existing file
  *
  * @return RTNCD_SUCCESS on success, RTNCD_FAILURE on failure
  */
-int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode, bool createDir)
+int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode, bool createDir, bool overwrite)
 {
   struct stat file_stats;
-  if (stat(file.c_str(), &file_stats) != -1)
+  if (stat(file.c_str(), &file_stats) != -1 && !overwrite)
   {
     if (S_ISREG(file_stats.st_mode))
     {

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -920,15 +920,14 @@ int zusf_copy_file_or_dir(ZUSF *zusf, const std::string &source_path, const std:
  * @param zusf pointer to a ZUSF object
  * @param file name of the USS file
  * @param mode mode of the file or directory
- * @param createDir flag indicating whether to create a directory
- * @param overwrite flag indicating whether to overwrite existing file
+ * @param options create options
  *
  * @return RTNCD_SUCCESS on success, RTNCD_FAILURE on failure
  */
-int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode, bool createDir, bool overwrite)
+int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode, const CreateOptions &options)
 {
   struct stat file_stats;
-  if (stat(file.c_str(), &file_stats) != -1 && !overwrite)
+  if (stat(file.c_str(), &file_stats) != -1 && !options.overwrite)
   {
     if (S_ISREG(file_stats.st_mode))
     {
@@ -945,7 +944,7 @@ int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode
     return RTNCD_FAILURE;
   }
 
-  if (createDir)
+  if (options.create_dir)
   {
     const auto last_trailing_slash = file.find_last_of("/");
     if (last_trailing_slash != std::string::npos)
@@ -954,7 +953,7 @@ int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode
       const auto exists = stat(parent_path.c_str(), &file_stats) == 0;
       if (!exists)
       {
-        const auto rc = zusf_create_uss_file_or_dir(zusf, parent_path, mode, true);
+        const auto rc = zusf_create_uss_file_or_dir(zusf, parent_path, mode, CreateOptions(true));
         if (0 != rc)
         {
           return rc;

--- a/native/c/zusf.hpp
+++ b/native/c/zusf.hpp
@@ -50,7 +50,7 @@ struct ListOptions
 };
 
 int zusf_copy_file_or_dir(ZUSF *zusf, const std::string &source_fs, const std::string &dest_fs, const CopyOptions &options);
-int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode, bool createDir);
+int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode, bool createDir, bool overwrite = false);
 int zusf_move_uss_file_or_dir(ZUSF *zusf, const std::string &source, const std::string &target, bool force = true);
 std::string zusf_format_file_entry(ZUSF *zusf, const struct stat &file_stats, const std::string &file_path, const std::string &display_name, ListOptions options, bool use_csv_format);
 int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &response, ListOptions options = ListOptions{}, bool use_csv_format = false);

--- a/native/c/zusf.hpp
+++ b/native/c/zusf.hpp
@@ -38,6 +38,16 @@ struct CopyOptions
   }
 };
 
+struct CreateOptions
+{
+  bool create_dir;
+  bool overwrite;
+  explicit CreateOptions(bool create_dir = false, bool overwrite = false)
+      : create_dir(create_dir), overwrite(overwrite)
+  {
+  }
+};
+
 struct ListOptions
 {
   bool all_files;
@@ -50,7 +60,7 @@ struct ListOptions
 };
 
 int zusf_copy_file_or_dir(ZUSF *zusf, const std::string &source_fs, const std::string &dest_fs, const CopyOptions &options);
-int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode, bool createDir, bool overwrite = false);
+int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode, const CreateOptions &options);
 int zusf_move_uss_file_or_dir(ZUSF *zusf, const std::string &source, const std::string &target, bool force = true);
 std::string zusf_format_file_entry(ZUSF *zusf, const struct stat &file_stats, const std::string &file_path, const std::string &display_name, ListOptions options, bool use_csv_format);
 int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &response, ListOptions options = ListOptions{}, bool use_csv_format = false);

--- a/native/python/bindings/zusf_py.cpp
+++ b/native/python/bindings/zusf_py.cpp
@@ -15,7 +15,7 @@ void create_uss_file(const std::string &file, const std::string &mode)
 {
   ZUSF ctx = {0};
   mode_t octal_mode = std::stoi(mode, nullptr, 8);
-  if (zusf_create_uss_file_or_dir(&ctx, file, octal_mode, false) != 0)
+  if (zusf_create_uss_file_or_dir(&ctx, file, octal_mode, CreateOptions(false)) != 0)
   {
     std::string error_msg = (ctx.diag.e_msg);
     throw std::runtime_error(error_msg);
@@ -26,7 +26,7 @@ void create_uss_dir(const std::string &file, const std::string &mode)
 {
   ZUSF ctx = {0};
   mode_t octal_mode = std::stoi(mode, nullptr, 8);
-  if (zusf_create_uss_file_or_dir(&ctx, file, octal_mode, true) != 0)
+  if (zusf_create_uss_file_or_dir(&ctx, file, octal_mode, CreateOptions(true)) != 0)
   {
     std::string error_msg = ctx.diag.e_msg;
     throw std::runtime_error(error_msg);

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Added support for invoking the `getInfo` server command, which allows the client SDK to get version and build information from the server. [#922](https://github.com/zowe/zowex/pull/922)
 - Added warning to `AbstractConfigManager.validateDeployPath` method when server path ends in `/c/build-out`, preventing developers from accidentally overwriting a dev deployment. [#912](https://github.com/zowe/zowex/pull/912)
+- Added `overwrite` property to the `CreateMemberRequest` and `CreateFileRequest` types. [#642](https://github.com/zowe/zowex/issues/642)
 
 ## `0.4.0`
 

--- a/packages/sdk/src/doc/rpc/ds.ts
+++ b/packages/sdk/src/doc/rpc/ds.ts
@@ -31,6 +31,10 @@ export interface CreateMemberRequest extends common.CommandRequest<"createMember
      * Dataset name
      */
     dsname: string;
+    /**
+     * Whether to overwrite existing member
+     */
+    overwrite?: boolean;
 }
 
 export type CreateMemberResponse = common.CommandResponse;

--- a/packages/sdk/src/doc/rpc/uss.ts
+++ b/packages/sdk/src/doc/rpc/uss.ts
@@ -118,6 +118,10 @@ export interface CreateFileRequest extends common.CommandRequest<"createFile"> {
      * Whether to create a directory (true) or a file (false)
      */
     isDir?: boolean;
+    /**
+     * Whether to overwrite existing file
+     */
+    overwrite?: boolean;
 }
 
 export type CreateFileResponse = common.CommandResponse;

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Recent Changes
 
 - **Breaking:** Renamed contributed setting IDs from `zowe-native-proto` to `zowex`. All references to `zowe-native-proto` should be replaced with `zowex` in VS Code `settings.json` files. [#831](https://github.com/zowe/zowex/issues/831)
+- Fixed an error when creating a member that already exists if the "Replace" option is selected. [#642](https://github.com/zowe/zowex/issues/642)
 
 ## `0.4.0`
 

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -7,7 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Recent Changes
 
 - **Breaking:** Renamed contributed setting IDs from `zowe-native-proto` to `zowex`. All references to `zowe-native-proto` should be replaced with `zowex` in VS Code `settings.json` files. [#831](https://github.com/zowe/zowex/issues/831)
-- Fixed an error when creating a member that already exists if the "Replace" option is selected. [#642](https://github.com/zowe/zowex/issues/642)
+- Fixed an error that would overwrite a member that already existed when creating a member with the "Replace" option. [#642](https://github.com/zowe/zowex/issues/642)
 
 ## `0.4.0`
 

--- a/packages/vsce/src/api/SshMvsApi.ts
+++ b/packages/vsce/src/api/SshMvsApi.ts
@@ -300,6 +300,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         try {
             response = await (await this.client).ds.createMember({
                 dsname: dataSetName,
+                overwrite: true, // Overwrite detection already handled on client side
             });
             if (!response.success) {
                 Gui.errorMessage(`Failed to create data set member: ${dataSetName}`);


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes #642

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run the following commands with and without the `--overwrite` flag:
- `zowex ds create-member {pdsWithMemberThatExists}`
- `zowex uss create-file {filePathThatExists}`

Also try with the VSCE to create PDS members and USS files that already exist. For data sets, you should be prompted to replace. For USS, you should see an error. This behavior matches z/OSMF.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
