### PR TITLE
zut_read_input simplification

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Updated `zut_read_input` so that all tests pass on `zowex`. Now there is no specific handling for line-based TTY input so that data is more consistently preserved.[#953](https://github.com/zowe/zowex/pull/953)
 - **Breaking:** `c`: Refactored the `zds_write` function to consolidate data set and DD write logic into a single entry point. [#908](https://github.com/zowe/zowe-native-proto/issues/908)
 - `c`: Changed `zowex --version` and `zowex -v` to return just the version number. [#925](https://github.com/zowe/zowex/pull/925)
 - `c`: Removed duplicate `-v` and `--version` aliases on the `zowex version` command. [#922](https://github.com/zowe/zowex/pull/922)

--- a/native/c/test/zut.test.cpp
+++ b/native/c/test/zut.test.cpp
@@ -308,6 +308,17 @@ void zut_tests()
                              expect(result).ToBe(input_data);
                            });
 
+                        it("should handle multiple lines without a trailing newline",
+                           []() -> void
+                           {
+                             std::string input_data = "line1\nline2\nline3";
+                             std::istringstream input_stream(input_data);
+
+                             std::string result = zut_read_input(input_stream);
+
+                             expect(result).ToBe(input_data);
+                           });
+
                         it("should handle multiple consecutive newlines",
                            []() -> void
                            {

--- a/native/c/zut.cpp
+++ b/native/c/zut.cpp
@@ -89,7 +89,7 @@ int zut_private_run_program(const std::string &program, const std::vector<std::s
     close(stdout_pipe[1]);
     close(stderr_pipe[0]);
     close(stderr_pipe[1]);
-    return RTNCD_FAILURE; 
+    return RTNCD_FAILURE;
   }
 
   std::vector<char *> argv_vec;
@@ -123,27 +123,31 @@ int zut_private_run_program(const std::string &program, const std::vector<std::s
   struct inheritance inherit = {};
 
   pid_t pid = spawnp(program.c_str(), fd_count, fd_map, &inherit, (const char **)argv_vec.data(), env_vec.data());
-  
+
   close(devnull_fd); // close /dev/null fd right away; child has a clone
 
   if (pid == -1)
   {
     int spawn_error = errno;
     std::string error_message;
-    if (spawn_error == ENOENT) 
+    if (spawn_error == ENOENT)
     {
       error_message = "zut_private_run_program: " + program + ": command not found";
-    } 
+    }
     else if (spawn_error == EACCES)
     {
       error_message = "zut_private_run_program: Permission denied when trying to execute '" + program + "'.";
     }
-    else {
+    else
+    {
       error_message = "zut_private_run_program: error running " + program + ": " + std::string(strerror(spawn_error));
     }
-    if (merge_streams) {
+    if (merge_streams)
+    {
       stdout_response = error_message;
-    } else {
+    }
+    else
+    {
       stderr_response = error_message;
     }
     close(stdout_pipe[0]);
@@ -299,14 +303,15 @@ static bool zut_private_command_requires_noshareas(const std::string &command)
   return false;
 }
 
-static std::string zut_private_get_shell() {
+static std::string zut_private_get_shell()
+{
   std::string shell_path = "/bin/sh";
 
   // Check if /bin/sh exists AND is executable by the current user
   if (access(shell_path.c_str(), X_OK) != 0)
   {
     // otherwise, try env. If it's empty, we leave shell_path=/bin/sh
-    const char* env_shell = std::getenv("SHELL");
+    const char *env_shell = std::getenv("SHELL");
     if (env_shell != nullptr && env_shell[0] != '\0')
     {
       shell_path = env_shell;
@@ -349,7 +354,7 @@ int zut_spawn_shell_command(const std::string &command, std::string &stdout_resp
   stderr_response.clear();
 
   if (0 == command.size())
-  {  
+  {
     stderr_response = "Error: You must specify a program to run.";
     return RTNCD_FAILURE;
   }
@@ -1044,26 +1049,9 @@ FileGuard::operator bool() const
 std::string zut_read_input(std::istream &input_stream)
 {
   std::string data;
-  if (!isatty(fileno(stdin)))
-  {
-    std::istreambuf_iterator<char> begin(input_stream);
-    std::istreambuf_iterator<char> end;
-    data.assign(begin, end);
-  }
-  else
-  {
-    std::string line;
-    bool first_line = true;
-    while (std::getline(input_stream, line))
-    {
-      if (!first_line)
-      {
-        data.push_back('\n');
-      }
-      first_line = false;
-      data += line;
-    }
-  }
+  std::istreambuf_iterator<char> begin(input_stream);
+  std::istreambuf_iterator<char> end;
+  data.assign(begin, end);
   return data;
 }
 


### PR DESCRIPTION
**What It Does**
Simplifies `zut_read_input` so that all tests pass when running direct through `zowex`  (attached issue shows at least 2 failing tests prior to this change)

now there is no specific handling for line-based TTY input. input is instead read raw which results in data preservation regardless of input type. 

**How to Test**
confirm all tests pass with both methods after building this branch:
- `npm run z:test`
- `<path-to-ur-zowex-build>/c/test: > ./build-out/ztest_runner`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
