### PR TITLE
Optimize profiles cache access in VscePromptApi

### DIFF
--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -41,7 +41,7 @@ import {
 import { type ISshConfigExt, SshConfigUtils } from "./SshConfigUtils";
 
 export abstract class AbstractConfigManager {
-    public constructor(private mProfilesCache: ProfileInfo) {}
+    public constructor(protected mProfilesCache: ProfileInfo) {}
 
     protected abstract showMessage(message: string, type: MESSAGE_TYPE): void;
     protected abstract showInputBox(opts: inputBoxOpts): Promise<string | undefined>;

--- a/packages/vsce/src/ConfigUtils.ts
+++ b/packages/vsce/src/ConfigUtils.ts
@@ -179,8 +179,7 @@ export class VscePromptApi extends AbstractConfigManager {
     }
 
     protected getProfileSchemas(): imperative.IProfileTypeConfiguration[] {
-        const zoweExplorerApi = ZoweVsCodeExtension.getZoweExplorerApi();
-        const profCache = zoweExplorerApi.getExplorerExtenderApi().getProfilesCache();
+        const profCache = this.mProfilesCache;
 
         return [
             // biome-ignore lint/suspicious/noExplicitAny: Accessing protected method


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Make `profilesCache` a protected property on the `AbstractConfigManager` class so that `VscePromptApi` can access it without calling `vscode.extensions.getExtension` which fails when run directly in ZE rather than the context of an extender.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
