### PR TITLE
sdk: add option for de-prioritizing project level configuration

### DIFF
--- a/native/c/zjb.cpp
+++ b/native/c/zjb.cpp
@@ -8,7 +8,6 @@
  * Copyright Contributors to the Zowe Project.
  *
  */
-
 #include <sstream>
 #include <string>
 #include <cstring>

--- a/native/c/zjb.cpp
+++ b/native/c/zjb.cpp
@@ -8,6 +8,7 @@
  * Copyright Contributors to the Zowe Project.
  *
  */
+
 #include <sstream>
 #include <string>
 #include <cstring>

--- a/packages/cli/src/config/setup/Setup.handler.ts
+++ b/packages/cli/src/config/setup/Setup.handler.ts
@@ -48,7 +48,7 @@ export default class ServerInstallHandler implements ICommandHandler {
             allBeforeMergedProf.push(profInfo.mergeArgsForProfile(profile));
         }
 
-        const profile = await cliPromptApi.promptForProfile(undefined, false);
+        const profile = await cliPromptApi.promptForProfile(undefined, { setExistingProfile: false });
 
         if (!profile) {
             params.response.console.error(

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Client code for "@zowe/zowex-for-zowe-sdk" are docume
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- Added `prioritizeProjectLevelConfig` parameter to `promptForProfile` function to allow toggling between project-level and global configuration creation when setting up new SSH profiles. [#964](https://github.com/zowe/zowex/pull/964)
+
 ## `0.5.0`
 
 - Added support for copying data sets and members files in the `RpcClientApi` class. [#932](https://github.com/zowe/zowex/issues/932)

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,7 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- Added `prioritizeProjectLevelConfig` parameter to `promptForProfile` function to allow toggling between project-level and global configuration creation when setting up new SSH profiles. [#964](https://github.com/zowe/zowex/pull/964)
+- **Breaking:** Modified `promptForProfile` function to use an options object for `setExistingProfile` and `prioritizeProjectLevelConfig` parameters. [#964](https://github.com/zowe/zowex/pull/964)
+- Added `prioritizeProjectLevelConfig` to the options parameter for `promptForProfile` function to allow toggling between project-level and global configuration creation when setting up new SSH profiles. [#964](https://github.com/zowe/zowex/pull/964)
 
 ## `0.5.0`
 

--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -65,9 +65,9 @@ export abstract class AbstractConfigManager {
 
     public async promptForProfile(
         profileName?: string,
-        options: PromptForProfileOptions = {},
+        options?: PromptForProfileOptions,
     ): Promise<IProfileLoaded | undefined> {
-        const { setExistingProfile = true, prioritizeProjectLevelConfig = true } = options;
+        const { setExistingProfile = true, prioritizeProjectLevelConfig = true } = options ?? {};
         this.validationResult = undefined;
         if (profileName) {
             return { profile: this.getMergedAttrs(profileName), message: "", failNotFound: false, type: "ssh" };

--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -65,6 +65,7 @@ export abstract class AbstractConfigManager {
     public async promptForProfile(
         profileName?: string,
         setExistingProfile = true,
+        priotizeProjectLevelConfig = true,
     ): Promise<IProfileLoaded | undefined> {
         this.validationResult = undefined;
         if (profileName) {
@@ -150,13 +151,9 @@ export abstract class AbstractConfigManager {
                 return { ...foundProfile, profile: { ...foundProfile.profile, ...validConfig } };
             }
         }
-
-        // Prioritize creating a team config in the local workspace if it exists even if a global config exists
-        // TODO: This behavior is only for the POC phase
-        ////////////////////////////////////////////////////////////////////////////////////////////////////////
-        const useProject = this.getCurrentDir() !== undefined;
+        
+        const useProject = priotizeProjectLevelConfig && this.getCurrentDir() !== undefined;
         await this.createZoweSchema(!useProject);
-        ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         // Prompt for a new profile name with the hostname (for adding a new config) or host value (for migrating from a config)
         this.selectedProfile = await this.getNewProfileName(this.selectedProfile!, this.mProfilesCache.getTeamConfig());

--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -151,7 +151,7 @@ export abstract class AbstractConfigManager {
                 return { ...foundProfile, profile: { ...foundProfile.profile, ...validConfig } };
             }
         }
-        
+
         const useProject = priotizeProjectLevelConfig && this.getCurrentDir() !== undefined;
         await this.createZoweSchema(!useProject);
 

--- a/packages/sdk/src/AbstractConfigManager.ts
+++ b/packages/sdk/src/AbstractConfigManager.ts
@@ -35,6 +35,7 @@ import {
     MESSAGE_TYPE,
     type PrivateKeyWarningOptions,
     type ProgressCallback,
+    type PromptForProfileOptions,
     type qpItem,
     type qpOpts,
 } from "./doc";
@@ -64,9 +65,9 @@ export abstract class AbstractConfigManager {
 
     public async promptForProfile(
         profileName?: string,
-        setExistingProfile = true,
-        priotizeProjectLevelConfig = true,
+        options: PromptForProfileOptions = {},
     ): Promise<IProfileLoaded | undefined> {
+        const { setExistingProfile = true, prioritizeProjectLevelConfig = true } = options;
         this.validationResult = undefined;
         if (profileName) {
             return { profile: this.getMergedAttrs(profileName), message: "", failNotFound: false, type: "ssh" };
@@ -152,7 +153,7 @@ export abstract class AbstractConfigManager {
             }
         }
 
-        const useProject = priotizeProjectLevelConfig && this.getCurrentDir() !== undefined;
+        const useProject = prioritizeProjectLevelConfig && this.getCurrentDir() !== undefined;
         await this.createZoweSchema(!useProject);
 
         // Prompt for a new profile name with the hostname (for adding a new config) or host value (for migrating from a config)

--- a/packages/sdk/src/doc/gui.ts
+++ b/packages/sdk/src/doc/gui.ts
@@ -44,3 +44,8 @@ export interface PrivateKeyWarningOptions {
 export interface IDisposable {
     dispose(): void;
 }
+
+export interface PromptForProfileOptions {
+    setExistingProfile?: boolean;
+    prioritizeProjectLevelConfig?: boolean;
+}

--- a/packages/sdk/tests/AbstractConfigManager.test.ts
+++ b/packages/sdk/tests/AbstractConfigManager.test.ts
@@ -322,7 +322,10 @@ describe("AbstractConfigManager", async () => {
                         const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
                         const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
 
-                        await testManager.promptForProfile(undefined, { setExistingProfile: true, prioritizeProjectLevelConfig: true });
+                        await testManager.promptForProfile(undefined, {
+                            setExistingProfile: true,
+                            prioritizeProjectLevelConfig: true,
+                        });
 
                         // When prioritizeProjectLevelConfig=true and getCurrentDir() returns a directory,
                         // createZoweSchema should be called with false (project-level, not global)
@@ -350,7 +353,10 @@ describe("AbstractConfigManager", async () => {
                         const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
                         const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
 
-                        await testManager.promptForProfile(undefined, { setExistingProfile: true, prioritizeProjectLevelConfig: false });
+                        await testManager.promptForProfile(undefined, {
+                            setExistingProfile: true,
+                            prioritizeProjectLevelConfig: false,
+                        });
 
                         // When prioritizeProjectLevelConfig=false, createZoweSchema should be called with true (global)
                         expect(createZoweSchemaSpy).toHaveBeenCalledWith(true);
@@ -377,7 +383,10 @@ describe("AbstractConfigManager", async () => {
                         const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
                         const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
 
-                        await testManager.promptForProfile(undefined, { setExistingProfile: true, prioritizeProjectLevelConfig: true });
+                        await testManager.promptForProfile(undefined, {
+                            setExistingProfile: true,
+                            prioritizeProjectLevelConfig: true,
+                        });
 
                         // When prioritizeProjectLevelConfig=true but getCurrentDir() returns undefined,
                         // createZoweSchema should be called with true (global)

--- a/packages/sdk/tests/AbstractConfigManager.test.ts
+++ b/packages/sdk/tests/AbstractConfigManager.test.ts
@@ -322,7 +322,7 @@ describe("AbstractConfigManager", async () => {
                         const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
                         const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
 
-                        await testManager.promptForProfile(undefined, true, true);
+                        await testManager.promptForProfile(undefined, { setExistingProfile: true, prioritizeProjectLevelConfig: true });
 
                         // When prioritizeProjectLevelConfig=true and getCurrentDir() returns a directory,
                         // createZoweSchema should be called with false (project-level, not global)
@@ -350,7 +350,7 @@ describe("AbstractConfigManager", async () => {
                         const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
                         const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
 
-                        await testManager.promptForProfile(undefined, true, false);
+                        await testManager.promptForProfile(undefined, { setExistingProfile: true, prioritizeProjectLevelConfig: false });
 
                         // When prioritizeProjectLevelConfig=false, createZoweSchema should be called with true (global)
                         expect(createZoweSchemaSpy).toHaveBeenCalledWith(true);
@@ -377,7 +377,7 @@ describe("AbstractConfigManager", async () => {
                         const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
                         const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
 
-                        await testManager.promptForProfile(undefined, true, true);
+                        await testManager.promptForProfile(undefined, { setExistingProfile: true, prioritizeProjectLevelConfig: true });
 
                         // When prioritizeProjectLevelConfig=true but getCurrentDir() returns undefined,
                         // createZoweSchema should be called with true (global)

--- a/packages/sdk/tests/AbstractConfigManager.test.ts
+++ b/packages/sdk/tests/AbstractConfigManager.test.ts
@@ -321,7 +321,7 @@ describe("AbstractConfigManager", async () => {
                         testManager.getCurrentDir.mockReturnValue("/mock/project/dir"); // Ensure current directory exists
                         const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
                         const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
-                        
+
                         await testManager.promptForProfile(undefined, true, true);
 
                         // When prioritizeProjectLevelConfig=true and getCurrentDir() returns a directory,
@@ -349,7 +349,7 @@ describe("AbstractConfigManager", async () => {
                         testManager.getCurrentDir.mockReturnValue("/mock/project/dir"); // Ensure current directory exists
                         const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
                         const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
-                        
+
                         await testManager.promptForProfile(undefined, true, false);
 
                         // When prioritizeProjectLevelConfig=false, createZoweSchema should be called with true (global)
@@ -376,7 +376,7 @@ describe("AbstractConfigManager", async () => {
                         testManager.getCurrentDir.mockReturnValue(undefined); // No current directory
                         const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
                         const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
-                        
+
                         await testManager.promptForProfile(undefined, true, true);
 
                         // When prioritizeProjectLevelConfig=true but getCurrentDir() returns undefined,

--- a/packages/sdk/tests/AbstractConfigManager.test.ts
+++ b/packages/sdk/tests/AbstractConfigManager.test.ts
@@ -302,6 +302,89 @@ describe("AbstractConfigManager", async () => {
                         expect(setSpy).toHaveBeenCalledWith(profileWithName);
                     });
 
+                    it("should use project-level config when prioritizeProjectLevelConfig is true and current directory exists", async () => {
+                        const profileWithName = {
+                            user: "user1",
+                            name: "nameValue",
+                            port: 222,
+                            privateKey: "/path/to/id_dsa",
+                            hostname: "example1.com",
+                        };
+                        vi.spyOn(testManager, "showCustomMenu").mockResolvedValueOnce({
+                            label: "$(plus) Add New SSH Host...",
+                        });
+                        vi.spyOn(testManager, "showInputBox").mockResolvedValue(
+                            `ssh ${profileWithName.user}@${profileWithName.hostname} -p ${profileWithName.port} -i ${profileWithName.privateKey}`,
+                        );
+                        vi.spyOn(testManager as any, "getNewProfileName").mockReturnValue(profileWithName);
+                        vi.spyOn(testManager as any, "attemptConnection").mockResolvedValue(true);
+                        testManager.getCurrentDir.mockReturnValue("/mock/project/dir"); // Ensure current directory exists
+                        const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
+                        const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
+                        
+                        await testManager.promptForProfile(undefined, true, true);
+
+                        // When prioritizeProjectLevelConfig=true and getCurrentDir() returns a directory,
+                        // createZoweSchema should be called with false (project-level, not global)
+                        expect(createZoweSchemaSpy).toHaveBeenCalledWith(false);
+                        expect(setSpy).toHaveBeenCalledWith(profileWithName);
+                    });
+
+                    it("should use global config when prioritizeProjectLevelConfig is false", async () => {
+                        const profileWithName = {
+                            user: "user1",
+                            name: "nameValue",
+                            port: 222,
+                            privateKey: "/path/to/id_dsa",
+                            hostname: "example1.com",
+                        };
+                        vi.spyOn(testManager, "showCustomMenu").mockResolvedValueOnce({
+                            label: "$(plus) Add New SSH Host...",
+                        });
+                        vi.spyOn(testManager, "showInputBox").mockResolvedValue(
+                            `ssh ${profileWithName.user}@${profileWithName.hostname} -p ${profileWithName.port} -i ${profileWithName.privateKey}`,
+                        );
+                        vi.spyOn(testManager as any, "getNewProfileName").mockReturnValue(profileWithName);
+                        vi.spyOn(testManager as any, "attemptConnection").mockResolvedValue(true);
+                        testManager.getCurrentDir.mockReturnValue("/mock/project/dir"); // Ensure current directory exists
+                        const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
+                        const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
+                        
+                        await testManager.promptForProfile(undefined, true, false);
+
+                        // When prioritizeProjectLevelConfig=false, createZoweSchema should be called with true (global)
+                        expect(createZoweSchemaSpy).toHaveBeenCalledWith(true);
+                        expect(setSpy).toHaveBeenCalledWith(profileWithName);
+                    });
+
+                    it("should use global config when prioritizeProjectLevelConfig is true but current directory is undefined", async () => {
+                        const profileWithName = {
+                            user: "user1",
+                            name: "nameValue",
+                            port: 222,
+                            privateKey: "/path/to/id_dsa",
+                            hostname: "example1.com",
+                        };
+                        vi.spyOn(testManager, "showCustomMenu").mockResolvedValueOnce({
+                            label: "$(plus) Add New SSH Host...",
+                        });
+                        vi.spyOn(testManager, "showInputBox").mockResolvedValue(
+                            `ssh ${profileWithName.user}@${profileWithName.hostname} -p ${profileWithName.port} -i ${profileWithName.privateKey}`,
+                        );
+                        vi.spyOn(testManager as any, "getNewProfileName").mockReturnValue(profileWithName);
+                        vi.spyOn(testManager as any, "attemptConnection").mockResolvedValue(true);
+                        testManager.getCurrentDir.mockReturnValue(undefined); // No current directory
+                        const createZoweSchemaSpy = vi.spyOn(testManager as any, "createZoweSchema");
+                        const setSpy = vi.spyOn(testManager as any, "setProfile").mockImplementation(() => {});
+                        
+                        await testManager.promptForProfile(undefined, true, true);
+
+                        // When prioritizeProjectLevelConfig=true but getCurrentDir() returns undefined,
+                        // createZoweSchema should be called with true (global)
+                        expect(createZoweSchemaSpy).toHaveBeenCalledWith(true);
+                        expect(setSpy).toHaveBeenCalledWith(profileWithName);
+                    });
+
                     it("should return undefined when profile creation fails", async () => {
                         vi.spyOn(testManager, "showCustomMenu").mockResolvedValueOnce({
                             label: "$(plus) Add New SSH Host...",


### PR DESCRIPTION
**What It Does**
When creating a new SSH profile via the `Connect to host...` command palette command, the function will prioritize creating a project level configuration rather than modifying the existing global configuration.

This allows VSCE/CLI implementations of the SDK to toggle this option off.

**How to Test**
1. Modify the options of `promptForProfile` in `/packages/vsce/src/Utilities:77` to be 
`const profile = await vscePromptApi.promptForProfile(profName,true,false);`
2. Run the vsce in Extension Dev Host
3. Open a workspace folder in the dev host
4. Use the `Connect to host...` command palette command to create a new SSH profile. The new profile should be placed inside an existing (or new) global configuration instead of prioritizing an existing (or new) project level configuration

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
`no-changelog` label for the CLI package
