### PR TITLE
chore: rename CLI plug-in to match upcoming pkg in ZE repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,8 @@ jobs:
         id: cli-artifact-upload
         if: ${{ matrix.os == 'ubuntu' }}
         with:
-          name: zowex-cli
-          path: dist/zowex-cli-*.tgz
+          name: zowex-for-zowe-cli
+          path: dist/zowex-for-zowe-cli-*.tgz
 
       - uses: actions/upload-artifact@v4
         id: vsce-artifact-upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Publish Snapshot to Artifactory
         if: ${{ !inputs.dry-run && env.TRAIN == 'Nightly' }}
         run: |
-          jfrog rt u --detailed-summary dist/*cli*.tgz libs-snapshot-local/org/zowe/zowex/CLI/$TRAIN/zowex-cli-$NEW_VERSION_SUFFIX.tgz
+          jfrog rt u --detailed-summary dist/*cli*.tgz libs-snapshot-local/org/zowe/zowex/CLI/$TRAIN/zowex-for-zowe-cli-$NEW_VERSION_SUFFIX.tgz
           jfrog rt u --detailed-summary dist/*sdk*.tgz libs-snapshot-local/org/zowe/zowex/SDK/$TRAIN/@zowe/zowex-for-zowe-sdk-$NEW_VERSION_SUFFIX.tgz
           jfrog rt u --detailed-summary dist/*.vsix libs-snapshot-local/org/zowe/zowex/VSCode/$TRAIN/zowex-vsce-$NEW_VERSION_SUFFIX.vsix
           jfrog rt u --detailed-summary dist/*.pax.Z libs-snapshot-local/org/zowe/zowex/Server/$TRAIN/zowe-server-$NEW_VERSION_SUFFIX.pax.Z
@@ -110,7 +110,7 @@ jobs:
       - name: Publish Release to Artifactory
         if: ${{ !inputs.dry-run && env.TRAIN == 'Release' }}
         run: |
-          jfrog rt u --detailed-summary dist/*cli*.tgz libs-release-local/org/zowe/zowex/$NEW_VERSION_SUFFIX/zowex-cli-$NEW_VERSION_SUFFIX.tgz
+          jfrog rt u --detailed-summary dist/*cli*.tgz libs-release-local/org/zowe/zowex/$NEW_VERSION_SUFFIX/zowex-for-zowe-cli-$NEW_VERSION_SUFFIX.tgz
           jfrog rt u --detailed-summary dist/*sdk*.tgz libs-release-local/org/zowe/zowex/$NEW_VERSION_SUFFIX/@zowe/zowex-for-zowe-sdk-$NEW_VERSION_SUFFIX.tgz
           jfrog rt u --detailed-summary dist/*.vsix libs-release-local/org/zowe/zowex/$NEW_VERSION_SUFFIX/zowex-vsce-$NEW_VERSION_SUFFIX.vsix
           jfrog rt u --detailed-summary dist/*.pax.Z libs-release-local/org/zowe/zowex/$NEW_VERSION_SUFFIX/zowe-server-$NEW_VERSION_SUFFIX.pax.Z

--- a/package-lock.json
+++ b/package-lock.json
@@ -10182,7 +10182,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/zowex-cli": {
+    "node_modules/zowex-for-zowe-cli": {
       "resolved": "packages/cli",
       "link": true
     },
@@ -10191,7 +10191,7 @@
       "link": true
     },
     "packages/cli": {
-      "name": "zowex-cli",
+      "name": "zowex-for-zowe-cli",
       "version": "0.5.0",
       "bundleDependencies": [
         "@zowe/zos-uss-for-zowe-sdk",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the Client code for "zowex-cli" are documented in this file.
+All notable changes to the Client code for "zowex-for-zowe-cli" are documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,14 +19,14 @@ Access the latest version of the CLI plug-in from the GitHub Releases page.
 Install the CLI plug-in from the tarball:
 
 ```
-zowe plugins install zowex-cli-*.tgz
+zowe plugins install zowex-for-zowe-cli-*.tgz
 ```
 
 Once complete, the Zowe CLI plug-in is installed and ready to use.
 
 ## Usage
 
-Run the `zowe plugins show-first-steps zowex-cli` command to see the first steps for using the plug-in.
+Run the `zowe plugins show-first-steps zowex-for-zowe-cli` command to see the first steps for using the plug-in.
 
 ## Building from source
 
@@ -38,7 +38,7 @@ The plug-in is created and saved in the `dist` folder.
 Install the plug-in by running the following Zowe CLI command:
 
 ```
-zowe plugins install dist/zowex-cli-*.tgz
+zowe plugins install dist/zowex-for-zowe-cli-*.tgz
 ```
 
 Zowe Remote SSH plug-in commands are accessible through the `zowe zssh` command group.
@@ -46,4 +46,3 @@ Zowe Remote SSH plug-in commands are accessible through the `zowe zssh` command 
 ```
 zowe zssh --help
 ```
-

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zowex-cli",
+  "name": "zowex-for-zowe-cli",
   "version": "0.5.0",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
**What It Does**

Replaced all references of `zowex-cli` ➡️ `zowex-for-zowe-cli` for consistency. I kept this separate from #956 as the SDK changes were higher priority.

Keeping VSCE as-is because @awharn is working on the extension merge into ZE (where this change is already in place).

**How to Test**

- `npm install && npm run build` should work
- Should still be able to install and use the CLI plug-in the same as before this PR

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)