### PR TITLE
refactor: Add pre-command hooks, disable APF auth for cmds outside of `console` group

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the native code for "zowex" are documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- `c`: Fixed an issue where `zoweax` could run the `server` command or `plugin` command group as APF-authorized. Now, `zoweax` disables APF authorization before commands are executed. Commands in the `console` group continue to run as APF authorized. [#958](https://github.com/zowe/zowex/issues/958)
+- `c`: Added support for pre-command hooks in the command-line parser utility. [#958](https://github.com/zowe/zowex/issues/958)
+
 ## `0.5.0`
 
 - `c`: Fixes wildcard search for listing data sets on multiple catalogs. [#947](https://github.com/zowe/zowex/issues/947)

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- `c`: Fixed an issue where `zoweax` could run the `server` command or `plugin` command group as APF-authorized. Now, `zoweax` disables APF authorization before commands are executed. Commands in the `console` group continue to run as APF authorized. [#958](https://github.com/zowe/zowex/issues/958)
+- `c`: Fixed an issue where `zoweax` could run the `server` command or `plugin` command group as privileged. Now, `zoweax` disables privileges before commands are executed. Commands in the `console` group continue to run as privileged. [#958](https://github.com/zowe/zowex/issues/958)
 - `c`: Added support for pre-command hooks in the command-line parser utility. [#958](https://github.com/zowe/zowex/issues/958)
 
 ## `0.5.0`

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- `c`: Fixed an issue where `zoweax` could run the `server` command or `plugin` command group as privileged. Now, `zoweax` disables privileges before commands are executed. Commands in the `console` group continue to run as privileged. [#958](https://github.com/zowe/zowex/issues/958)
+- `c`: Fixed an issue where the `zoweax` authorized CLI binary could run the `server` command or `plugin` command group as privileged. Now, `zoweax` disables privileges before commands are executed. Commands in the `console` group continue to run as privileged. [#958](https://github.com/zowe/zowex/issues/958)
 - `c`: Added support for pre-command hooks in the command-line parser utility. [#958](https://github.com/zowe/zowex/issues/958)
 
 ## `0.5.0`

--- a/native/c/commands/console.cpp
+++ b/native/c/commands/console.cpp
@@ -77,7 +77,7 @@ void register_commands(parser::Command &root_command)
 {
   auto console_group = command_ptr(new Command("console", "z/OS console operations"));
   console_group->add_alias("cn");
-  console_group->set_apf_authorized(true);
+  console_group->set_privileged(true);
   {
     auto issue_cmd = command_ptr(new Command("issue", "issue a console command"));
     issue_cmd->add_keyword_arg("console-name",

--- a/native/c/commands/console.cpp
+++ b/native/c/commands/console.cpp
@@ -77,6 +77,7 @@ void register_commands(parser::Command &root_command)
 {
   auto console_group = command_ptr(new Command("console", "z/OS console operations"));
   console_group->add_alias("cn");
+  console_group->set_apf_authorized(true);
   {
     auto issue_cmd = command_ptr(new Command("issue", "issue a console command"));
     issue_cmd->add_keyword_arg("console-name",

--- a/native/c/commands/core.cpp
+++ b/native/c/commands/core.cpp
@@ -216,7 +216,8 @@ Command &setup_root_command(char *argv[])
   g_arg_parser = std::make_shared<ArgumentParser>(argv[0], "Zowe Remote SSH CLI");
   g_arg_parser->add_pre_command_hook([](const Command &command, bool is_help_request)
                                      {
-    if (!is_help_request && command.is_apf_authorized()) {
+    if (!is_help_request && command.is_apf_authorized())
+    {
       return true;
     }
 

--- a/native/c/commands/core.cpp
+++ b/native/c/commands/core.cpp
@@ -219,7 +219,7 @@ Command &setup_root_command(char *argv[])
     if (!is_help_request && command.is_apf_authorized()) {
       return true;
     }
-  
+
     auth_off(); 
     return true; });
   auto &root_command = g_arg_parser->get_root_command();

--- a/native/c/commands/core.cpp
+++ b/native/c/commands/core.cpp
@@ -216,7 +216,7 @@ Command &setup_root_command(char *argv[])
   g_arg_parser = std::make_shared<ArgumentParser>(argv[0], "Zowe Remote SSH CLI");
   g_arg_parser->add_pre_command_hook([](const Command &command, bool is_help_request)
                                      {
-    if (!is_help_request && command.is_apf_authorized())
+    if (!is_help_request && command.is_privileged())
     {
       return true;
     }

--- a/native/c/commands/core.cpp
+++ b/native/c/commands/core.cpp
@@ -11,6 +11,7 @@
 
 #include "core.hpp"
 #include "../extend/plugin.hpp"
+#include "../zmetal.h"
 #include <dirent.h>
 #include <algorithm>
 #include <set>
@@ -213,6 +214,14 @@ int execute_command(int argc, char *argv[])
 Command &setup_root_command(char *argv[])
 {
   g_arg_parser = std::make_shared<ArgumentParser>(argv[0], "Zowe Remote SSH CLI");
+  g_arg_parser->add_pre_command_hook([](const Command &command, bool is_help_request)
+                                     {
+    if (!is_help_request && command.is_apf_authorized()) {
+      return true;
+    }
+  
+    auth_off(); 
+    return true; });
   auto &root_command = g_arg_parser->get_root_command();
 
   root_command.add_keyword_arg("interactive",

--- a/native/c/commands/core.cpp
+++ b/native/c/commands/core.cpp
@@ -12,6 +12,7 @@
 #include "core.hpp"
 #include "../extend/plugin.hpp"
 #include "../zmetal.h"
+#include "../zutm.h"
 #include <dirent.h>
 #include <algorithm>
 #include <set>
@@ -221,7 +222,7 @@ Command &setup_root_command(char *argv[])
       return true;
     }
 
-    auth_off(); 
+    ZUTNOAUT(); 
     return true; });
   auto &root_command = g_arg_parser->get_root_command();
 

--- a/native/c/parser.hpp
+++ b/native/c/parser.hpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -88,6 +89,8 @@ class ArgumentParser;
 class ParseResult;
 
 typedef plugin::Argument ArgValue;
+
+typedef std::function<void(const std::string &command_path)> PreCommandHook;
 
 enum ArgType
 {
@@ -542,7 +545,8 @@ public:
 
   ParseResult parse(const std::vector<lexer::Token> &tokens,
                     size_t &current_token_index,
-                    const std::string &command_path_prefix) const;
+                    const std::string &command_path_prefix,
+                    const std::vector<PreCommandHook> *pre_hooks = nullptr) const;
 
   // generate help text for this command and its subcommands
   void generate_help(std::ostream &os,
@@ -1181,7 +1185,8 @@ inline bool ParseResult::get_value<bool>(const std::string &name,
 inline ParseResult
 Command::parse(const std::vector<lexer::Token> &tokens,
                size_t &current_token_index,
-               const std::string &command_path_prefix) const
+               const std::string &command_path_prefix,
+               const std::vector<PreCommandHook> *pre_hooks) const
 {
   ZLOG_TRACE("Command::parse entry: command='%s', prefix='%s', tokens=%zu, current_index=%zu",
              m_name.c_str(), command_path_prefix.c_str(), tokens.size(), current_token_index);
@@ -1653,7 +1658,7 @@ Command::parse(const std::vector<lexer::Token> &tokens,
         ZLOG_TRACE("Subcommand '%s' matched, delegating parse", potential_subcommand_or_alias.c_str());
         current_token_index++; // consume the subcommand/alias token
         ParseResult sub_result = matched_subcommand->parse(
-            tokens, current_token_index, result.command_path + " ");
+            tokens, current_token_index, result.command_path + " ", pre_hooks);
 
         // propagate the result (success, error, or help request) from the
         // subcommand.
@@ -1889,6 +1894,15 @@ Command::parse(const std::vector<lexer::Token> &tokens,
   {
     ZLOG_TRACE("Executing handler for command '%s'", m_name.c_str());
 
+    // Execute pre-command hooks before the handler
+    if (pre_hooks)
+    {
+      for (const auto &hook : *pre_hooks)
+      {
+        hook(result.command_path);
+      }
+    }
+
     plugin::ArgumentMap invocation_args;
     for (const auto &kv : result.m_values)
     {
@@ -1961,6 +1975,19 @@ public:
   const std::string &get_program_name() const
   {
     return m_program_name;
+  }
+
+  /**
+   * @brief Register a pre-command hook to be called before any command handler executes.
+   *
+   * Hooks receive the full command path (e.g. "zowex console issue") and run
+   * in registration order. They cannot prevent handler execution.
+   *
+   * @param hook Callback invoked with the command path before the handler runs
+   */
+  void add_pre_command_hook(PreCommandHook hook)
+  {
+    m_pre_hooks.push_back(std::move(hook));
   }
 
   /**
@@ -2115,7 +2142,7 @@ public:
     }
 
     ZLOG_TRACE("Starting parse with %zu tokens", tokens.size());
-    ParseResult result = m_root_cmd->parse(tokens, token_index, "");
+    ParseResult result = m_root_cmd->parse(tokens, token_index, "", &m_pre_hooks);
     if (result.status == ParseResult::ParserStatus_Success &&
         token_index < tokens.size())
     {
@@ -2165,7 +2192,7 @@ public:
 
       ZLOG_TRACE("Lexer produced %zu tokens for string parse", tokens.size());
       size_t token_index = 0;
-      ParseResult result = m_root_cmd->parse(tokens, token_index, "");
+      ParseResult result = m_root_cmd->parse(tokens, token_index, "", &m_pre_hooks);
 
       // return early in the event of an error or help request from the parse
       // call
@@ -2227,6 +2254,7 @@ private:
   std::string m_program_name;
   std::string m_program_desc;
   command_ptr m_root_cmd;
+  std::vector<PreCommandHook> m_pre_hooks;
 }; // class ArgumentParser
 
 /**

--- a/native/c/parser.hpp
+++ b/native/c/parser.hpp
@@ -341,7 +341,7 @@ public:
   }
 
   // mark command as APF authorized (and propagate to children)
-  Command &set_apf_authorized(bool authorized = false)
+  Command &set_apf_authorized(bool authorized = true)
   {
     m_apf_authorized = authorized;
     for (auto &pair : m_commands)
@@ -357,6 +357,20 @@ public:
   bool is_apf_authorized() const
   {
     return m_apf_authorized;
+  }
+
+  // propagate pre_hooks recursively
+  Command &set_pre_hooks(std::shared_ptr<std::vector<PreCommandHook>> hooks)
+  {
+    m_pre_hooks = hooks;
+    for (auto &pair : m_commands)
+    {
+      if (pair.second)
+      {
+        pair.second->set_pre_hooks(hooks);
+      }
+    }
+    return *this;
   }
 
   // add an argument
@@ -477,11 +491,16 @@ public:
       return *this;
 
     sub->ensure_help_argument();
-    
+
     // Only propagate APF authorization if the parent is authorized
     if (m_apf_authorized)
     {
       sub->set_apf_authorized(true);
+    }
+
+    if (m_pre_hooks)
+    {
+      sub->set_pre_hooks(m_pre_hooks);
     }
 
     std::string sub_name = sub->get_name();
@@ -573,8 +592,7 @@ public:
 
   ParseResult parse(const std::vector<lexer::Token> &tokens,
                     size_t &current_token_index,
-                    const std::string &command_path_prefix,
-                    const std::vector<PreCommandHook> *pre_hooks = nullptr) const;
+                    const std::string &command_path_prefix) const;
 
   // generate help text for this command and its subcommands
   void generate_help(std::ostream &os,
@@ -825,6 +843,25 @@ private:
   bool m_allow_passthrough;
   bool m_apf_authorized;
   std::string m_passthrough_description;
+  std::shared_ptr<std::vector<PreCommandHook>> m_pre_hooks;
+
+  // helper to execute pre-command hooks
+  bool execute_pre_hooks(bool is_help_request, const char *context_msg) const
+  {
+    if (m_pre_hooks)
+    {
+      for (size_t i = 0; i < m_pre_hooks->size(); ++i)
+      {
+        const auto &hook = (*m_pre_hooks)[i];
+        if (!hook(*this, is_help_request))
+        {
+          ZLOG_TRACE("Pre-command hook aborted execution for %s '%s'", context_msg, m_name.c_str());
+          return false;
+        }
+      }
+    }
+    return true;
+  }
 
   // helper to check if the token at the given index is a flag/option token
   bool is_flag_token(const std::vector<lexer::Token> &tokens,
@@ -1214,8 +1251,7 @@ inline bool ParseResult::get_value<bool>(const std::string &name,
 inline ParseResult
 Command::parse(const std::vector<lexer::Token> &tokens,
                size_t &current_token_index,
-               const std::string &command_path_prefix,
-               const std::vector<PreCommandHook> *pre_hooks) const
+               const std::string &command_path_prefix) const
 {
   ZLOG_TRACE("Command::parse entry: command='%s', prefix='%s', tokens=%zu, current_index=%zu",
              m_name.c_str(), command_path_prefix.c_str(), tokens.size(), current_token_index);
@@ -1500,17 +1536,10 @@ Command::parse(const std::vector<lexer::Token> &tokens,
         ZLOG_TRACE("Help flag detected, showing help and exiting");
 
         // Execute pre-command hooks before the help runs
-        if (pre_hooks)
+        if (!execute_pre_hooks(true, "help command"))
         {
-          for (const auto &hook : *pre_hooks)
-          {
-            if (!hook(*this, true))
-            {
-              ZLOG_TRACE("Pre-command hook aborted execution for help command '%s'", m_name.c_str());
-              result.exit_code = 1;
-              return result;
-            }
-          }
+          result.exit_code = 1;
+          return result;
         }
 
         generate_help(std::cout, command_path_prefix);
@@ -1702,7 +1731,7 @@ Command::parse(const std::vector<lexer::Token> &tokens,
         ZLOG_TRACE("Subcommand '%s' matched, delegating parse", potential_subcommand_or_alias.c_str());
         current_token_index++; // consume the subcommand/alias token
         ParseResult sub_result = matched_subcommand->parse(
-            tokens, current_token_index, result.command_path + " ", pre_hooks);
+            tokens, current_token_index, result.command_path + " ");
 
         // propagate the result (success, error, or help request) from the
         // subcommand.
@@ -1939,17 +1968,10 @@ Command::parse(const std::vector<lexer::Token> &tokens,
     ZLOG_TRACE("Executing handler for command '%s'", m_name.c_str());
 
     // Execute pre-command hooks before the handler
-    if (pre_hooks)
+    if (!execute_pre_hooks(false, "command"))
     {
-      for (const auto &hook : *pre_hooks)
-      {
-        if (!hook(*this, false))
-        {
-          ZLOG_TRACE("Pre-command hook aborted execution for command '%s'", m_name.c_str());
-          result.exit_code = 1;
-          return result;
-        }
-      }
+      result.exit_code = 1;
+      return result;
     }
 
     plugin::ArgumentMap invocation_args;
@@ -1976,17 +1998,10 @@ Command::parse(const std::vector<lexer::Token> &tokens,
     ZLOG_TRACE("Command group with no handler, showing help");
 
     // Execute pre-command hooks before the help runs
-    if (pre_hooks)
+    if (!execute_pre_hooks(true, "help command group"))
     {
-      for (const auto &hook : *pre_hooks)
-      {
-        if (!hook(*this, true))
-        {
-          ZLOG_TRACE("Pre-command hook aborted execution for help command group '%s'", m_name.c_str());
-          result.exit_code = 1;
-          return result;
-        }
-      }
+      result.exit_code = 1;
+      return result;
     }
 
     generate_help(std::cout, command_path_prefix);
@@ -2005,8 +2020,10 @@ public:
   ArgumentParser() = default;
   explicit ArgumentParser(std::string prog_name, std::string description = "")
       : m_program_name(prog_name), m_program_desc(description),
-        m_root_cmd(command_ptr(new Command(prog_name, description)))
+        m_root_cmd(command_ptr(new Command(prog_name, description))),
+        m_pre_hooks(std::make_shared<std::vector<PreCommandHook>>())
   {
+    m_root_cmd->set_pre_hooks(m_pre_hooks);
   }
 
   ~ArgumentParser() = default;
@@ -2051,7 +2068,10 @@ public:
    */
   void add_pre_command_hook(PreCommandHook hook)
   {
-    m_pre_hooks.push_back(std::move(hook));
+    m_pre_hooks->push_back(std::move(hook));
+    if (m_root_cmd) {
+      m_root_cmd->set_pre_hooks(m_pre_hooks);
+    }
   }
 
   /**
@@ -2206,7 +2226,7 @@ public:
     }
 
     ZLOG_TRACE("Starting parse with %zu tokens", tokens.size());
-    ParseResult result = m_root_cmd->parse(tokens, token_index, "", &m_pre_hooks);
+    ParseResult result = m_root_cmd->parse(tokens, token_index, "");
     if (result.status == ParseResult::ParserStatus_Success &&
         token_index < tokens.size())
     {
@@ -2256,7 +2276,7 @@ public:
 
       ZLOG_TRACE("Lexer produced %zu tokens for string parse", tokens.size());
       size_t token_index = 0;
-      ParseResult result = m_root_cmd->parse(tokens, token_index, "", &m_pre_hooks);
+      ParseResult result = m_root_cmd->parse(tokens, token_index, "");
 
       // return early in the event of an error or help request from the parse
       // call
@@ -2318,7 +2338,7 @@ private:
   std::string m_program_name;
   std::string m_program_desc;
   command_ptr m_root_cmd;
-  std::vector<PreCommandHook> m_pre_hooks;
+  std::shared_ptr<std::vector<PreCommandHook>> m_pre_hooks;
 }; // class ArgumentParser
 
 /**

--- a/native/c/parser.hpp
+++ b/native/c/parser.hpp
@@ -90,7 +90,10 @@ class ParseResult;
 
 typedef plugin::Argument ArgValue;
 
-typedef std::function<void(const std::string &command_path)> PreCommandHook;
+class Command;
+
+// Return value signals whether the hook succeeded
+typedef std::function<bool(const Command &command, bool is_help_request)> PreCommandHook;
 
 enum ArgType
 {
@@ -326,7 +329,7 @@ public:
 
   Command(std::string name, std::string help)
       : m_name(name), m_help(help), m_handler(nullptr),
-        m_allow_dynamic_keywords(false), m_allow_passthrough(false)
+        m_allow_dynamic_keywords(false), m_allow_passthrough(false), m_apf_authorized(false)
   {
     ensure_help_argument();
   }
@@ -335,6 +338,25 @@ public:
   ~Command()
   {
     m_commands.clear();
+  }
+
+  // mark command as APF authorized (and propagate to children)
+  Command &set_apf_authorized(bool authorized = true)
+  {
+    m_apf_authorized = authorized;
+    for (auto &pair : m_commands)
+    {
+      if (pair.second)
+      {
+        pair.second->set_apf_authorized(authorized);
+      }
+    }
+    return *this;
+  }
+
+  bool is_apf_authorized() const
+  {
+    return m_apf_authorized;
   }
 
   // add an argument
@@ -455,6 +477,7 @@ public:
       return *this;
 
     sub->ensure_help_argument();
+    sub->set_apf_authorized(m_apf_authorized);
 
     std::string sub_name = sub->get_name();
     // check for conflicts with existing names and aliases
@@ -795,6 +818,7 @@ public:
 private:
   bool m_allow_dynamic_keywords;
   bool m_allow_passthrough;
+  bool m_apf_authorized;
   std::string m_passthrough_description;
 
   // helper to check if the token at the given index is a flag/option token
@@ -1469,6 +1493,21 @@ Command::parse(const std::vector<lexer::Token> &tokens,
       if (matched_arg->is_help_flag)
       {
         ZLOG_TRACE("Help flag detected, showing help and exiting");
+
+        // Execute pre-command hooks before the help runs
+        if (pre_hooks)
+        {
+          for (const auto &hook : *pre_hooks)
+          {
+            if (!hook(*this, true))
+            {
+              ZLOG_TRACE("Pre-command hook aborted execution for help command '%s'", m_name.c_str());
+              result.exit_code = 1;
+              return result;
+            }
+          }
+        }
+
         generate_help(std::cout, command_path_prefix);
         result.status = ParseResult::ParserStatus_HelpRequested;
         result.exit_code = 0; // help request is a successful exit
@@ -1899,7 +1938,12 @@ Command::parse(const std::vector<lexer::Token> &tokens,
     {
       for (const auto &hook : *pre_hooks)
       {
-        hook(result.command_path);
+        if (!hook(*this, false))
+        {
+          ZLOG_TRACE("Pre-command hook aborted execution for command '%s'", m_name.c_str());
+          result.exit_code = 1;
+          return result;
+        }
       }
     }
 
@@ -1925,6 +1969,21 @@ Command::parse(const std::vector<lexer::Token> &tokens,
       result.status == ParseResult::ParserStatus_Success)
   {
     ZLOG_TRACE("Command group with no handler, showing help");
+
+    // Execute pre-command hooks before the help runs
+    if (pre_hooks)
+    {
+      for (const auto &hook : *pre_hooks)
+      {
+        if (!hook(*this, true))
+        {
+          ZLOG_TRACE("Pre-command hook aborted execution for help command group '%s'", m_name.c_str());
+          result.exit_code = 1;
+          return result;
+        }
+      }
+    }
+
     generate_help(std::cout, command_path_prefix);
     result.status = ParseResult::ParserStatus_HelpRequested;
     result.exit_code = 0;

--- a/native/c/parser.hpp
+++ b/native/c/parser.hpp
@@ -341,7 +341,7 @@ public:
   }
 
   // mark command as APF authorized (and propagate to children)
-  Command &set_apf_authorized(bool authorized = true)
+  Command &set_apf_authorized(bool authorized = false)
   {
     m_apf_authorized = authorized;
     for (auto &pair : m_commands)
@@ -477,7 +477,12 @@ public:
       return *this;
 
     sub->ensure_help_argument();
-    sub->set_apf_authorized(m_apf_authorized);
+    
+    // Only propagate APF authorization if the parent is authorized
+    if (m_apf_authorized)
+    {
+      sub->set_apf_authorized(true);
+    }
 
     std::string sub_name = sub->get_name();
     // check for conflicts with existing names and aliases

--- a/native/c/parser.hpp
+++ b/native/c/parser.hpp
@@ -2068,8 +2068,13 @@ public:
    */
   void add_pre_command_hook(PreCommandHook hook)
   {
+    if (m_pre_hooks == nullptr)
+    {
+      m_pre_hooks = std::make_shared<std::vector<PreCommandHook>>();
+    }
     m_pre_hooks->push_back(std::move(hook));
-    if (m_root_cmd) {
+    if (m_root_cmd)
+    {
       m_root_cmd->set_pre_hooks(m_pre_hooks);
     }
   }

--- a/native/c/parser.hpp
+++ b/native/c/parser.hpp
@@ -82,18 +82,16 @@ inline std::vector<std::string> make_aliases(const char *a1 = 0,
 }
 
 class Command;
-typedef std::shared_ptr<Command> command_ptr;
-typedef std::enable_shared_from_this<Command> enable_shared_command;
+using command_ptr = std::shared_ptr<Command>;
+using enable_shared_command = std::enable_shared_from_this<Command>;
 
 class ArgumentParser;
 class ParseResult;
 
-typedef plugin::Argument ArgValue;
-
-class Command;
+using ArgValue = plugin::Argument;
 
 // Return value signals whether the hook succeeded
-typedef std::function<bool(const Command &command, bool is_help_request)> PreCommandHook;
+using PreCommandHook = std::function<bool(const Command &command, bool is_help_request)>;
 
 enum ArgType
 {
@@ -325,7 +323,7 @@ struct CmdExample
 class Command : public enable_shared_command
 {
 public:
-  typedef int (*CommandHandler)(plugin::InvocationContext &context);
+  using CommandHandler = int (*)(plugin::InvocationContext &context);
 
   Command(std::string name, std::string help)
       : m_name(name), m_help(help), m_handler(nullptr),

--- a/native/c/parser.hpp
+++ b/native/c/parser.hpp
@@ -327,7 +327,7 @@ public:
 
   Command(std::string name, std::string help)
       : m_name(name), m_help(help), m_handler(nullptr),
-        m_allow_dynamic_keywords(false), m_allow_passthrough(false), m_apf_authorized(false)
+        m_allow_dynamic_keywords(false), m_allow_passthrough(false), m_privileged(false)
   {
     ensure_help_argument();
   }
@@ -338,23 +338,23 @@ public:
     m_commands.clear();
   }
 
-  // mark command as APF authorized (and propagate to children)
-  Command &set_apf_authorized(bool authorized = true)
+  // mark command as privileged (and propagate to children)
+  Command &set_privileged(bool privileged = true)
   {
-    m_apf_authorized = authorized;
+    m_privileged = privileged;
     for (auto &pair : m_commands)
     {
       if (pair.second)
       {
-        pair.second->set_apf_authorized(authorized);
+        pair.second->set_privileged(privileged);
       }
     }
     return *this;
   }
 
-  bool is_apf_authorized() const
+  bool is_privileged() const
   {
-    return m_apf_authorized;
+    return m_privileged;
   }
 
   // propagate pre_hooks recursively
@@ -490,10 +490,10 @@ public:
 
     sub->ensure_help_argument();
 
-    // Only propagate APF authorization if the parent is authorized
-    if (m_apf_authorized)
+    // Only propagate privileges if the parent is privileged
+    if (m_privileged)
     {
-      sub->set_apf_authorized(true);
+      sub->set_privileged(true);
     }
 
     if (m_pre_hooks)
@@ -839,7 +839,7 @@ public:
 private:
   bool m_allow_dynamic_keywords;
   bool m_allow_passthrough;
-  bool m_apf_authorized;
+  bool m_privileged;
   std::string m_passthrough_description;
   std::shared_ptr<std::vector<PreCommandHook>> m_pre_hooks;
 

--- a/native/c/test/parser.test.cpp
+++ b/native/c/test/parser.test.cpp
@@ -595,8 +595,6 @@ void parser_tests()
                  return true;
                });
                
-               Command &root = arg_parser.get_root_command();
-               
                std::vector<std::string> raw = {"prog", "--help"};
                std::vector<char *> argv = to_argv(raw);
                

--- a/native/c/test/parser.test.cpp
+++ b/native/c/test/parser.test.cpp
@@ -520,6 +520,127 @@ void parser_tests()
              });
              });
 
+             describe("pre-command hooks", []() -> void
+                      {
+             it("executes hooks before command handler", []() {
+               g_handler_called = false;
+               bool hook_called = false;
+               bool hook_is_help = true;
+               
+               ArgumentParser arg_parser("prog", "hook sample");
+               arg_parser.add_pre_command_hook([&](const Command &cmd, bool is_help_request) -> bool {
+                 hook_called = true;
+                 hook_is_help = is_help_request;
+                 return true;
+               });
+               
+               Command &root = arg_parser.get_root_command();
+               root.add_keyword_arg("name", make_aliases("-n"), "name to capture", ArgType_Single, true);
+               root.set_handler(&sample_handler);
+               
+               std::vector<std::string> raw = {"prog", "--name", "cli"};
+               std::vector<char *> argv = to_argv(raw);
+               
+               ParseResult result = arg_parser.parse(static_cast<int>(argv.size()), argv.data());
+               
+               Expect(result.status).ToBe(ParseResult::ParserStatus_Success);
+               Expect(hook_called).ToBe(true);
+               Expect(hook_is_help).ToBe(false);
+               Expect(g_handler_called).ToBe(true);
+             });
+             
+             it("aborts execution if hook returns false", []() {
+               g_handler_called = false;
+               bool hook1_called = false;
+               bool hook2_called = false;
+               
+               ArgumentParser arg_parser("prog", "hook abort sample");
+               arg_parser.add_pre_command_hook([&](const Command &cmd, bool is_help_request) -> bool {
+                 hook1_called = true;
+                 return false; // abort
+               });
+               arg_parser.add_pre_command_hook([&](const Command &cmd, bool is_help_request) -> bool {
+                 hook2_called = true;
+                 return true;
+               });
+               
+               Command &root = arg_parser.get_root_command();
+               root.add_keyword_arg("name", make_aliases("-n"), "name to capture", ArgType_Single, true);
+               root.set_handler(&sample_handler);
+               
+               std::vector<std::string> raw = {"prog", "--name", "cli"};
+               std::vector<char *> argv = to_argv(raw);
+               
+               ParseResult result;
+               {
+                 test_utils::ErrorStreamCapture error_capture;
+                 result = arg_parser.parse(static_cast<int>(argv.size()), argv.data());
+               }
+               
+               // Exit code is 1, status is Success but handler wasn't run
+               Expect(result.exit_code).ToBe(1);
+               Expect(hook1_called).ToBe(true);
+               Expect(hook2_called).ToBe(false); // Second hook shouldn't run
+               Expect(g_handler_called).ToBe(false); // Handler shouldn't run
+             });
+             
+             it("executes hooks before help is shown", []() {
+               bool hook_called = false;
+               bool hook_is_help = false;
+               
+               ArgumentParser arg_parser("prog", "hook help sample");
+               arg_parser.add_pre_command_hook([&](const Command &cmd, bool is_help_request) -> bool {
+                 hook_called = true;
+                 hook_is_help = is_help_request;
+                 return true;
+               });
+               
+               Command &root = arg_parser.get_root_command();
+               
+               std::vector<std::string> raw = {"prog", "--help"};
+               std::vector<char *> argv = to_argv(raw);
+               
+               ParseResult result;
+               {
+                 test_utils::OutputStreamCapture out_capture;
+                 result = arg_parser.parse(static_cast<int>(argv.size()), argv.data());
+               }
+               
+               Expect(result.status).ToBe(ParseResult::ParserStatus_HelpRequested);
+               Expect(hook_called).ToBe(true);
+               Expect(hook_is_help).ToBe(true);
+             });
+             
+             it("executes hooks for command groups without handler when help is shown implicitly", []() {
+               bool hook_called = false;
+               bool hook_is_help = false;
+               
+               ArgumentParser arg_parser("prog", "hook group sample");
+               arg_parser.add_pre_command_hook([&](const Command &cmd, bool is_help_request) -> bool {
+                 hook_called = true;
+                 hook_is_help = is_help_request;
+                 return true;
+               });
+               
+               Command &root = arg_parser.get_root_command();
+               command_ptr sub_cmd(new Command("sub", "sub command"));
+               root.add_command(sub_cmd);
+               
+               std::vector<std::string> raw = {"prog"};
+               std::vector<char *> argv = to_argv(raw);
+               
+               ParseResult result;
+               {
+                 test_utils::OutputStreamCapture out_capture;
+                 result = arg_parser.parse(static_cast<int>(argv.size()), argv.data());
+               }
+               
+               Expect(result.status).ToBe(ParseResult::ParserStatus_HelpRequested);
+               Expect(hook_called).ToBe(true);
+               Expect(hook_is_help).ToBe(true); // Treated as help request
+             });
+             });
+             
              describe("passthrough arguments", []() -> void
                       {
              it("captures arguments after -- delimiter", []() {

--- a/native/c/test/test_utils.hpp
+++ b/native/c/test/test_utils.hpp
@@ -100,6 +100,42 @@ private:
   std::streambuf *original_cerr_; ///< Original std::cerr buffer to restore
 };
 
+/**
+ * @brief RAII utility class for capturing stdout output during tests
+ */
+class OutputStreamCapture
+{
+public:
+  OutputStreamCapture()
+      : original_cout_(std::cout.rdbuf())
+  {
+    std::cout.rdbuf(buffer_.rdbuf());
+  }
+
+  ~OutputStreamCapture()
+  {
+    std::cout.rdbuf(original_cout_);
+  }
+
+  OutputStreamCapture(const OutputStreamCapture &) = delete;
+  OutputStreamCapture &operator=(const OutputStreamCapture &) = delete;
+
+  std::string get_output() const
+  {
+    return buffer_.str();
+  }
+
+  void clear()
+  {
+    buffer_.str("");
+    buffer_.clear();
+  }
+
+private:
+  std::stringstream buffer_;
+  std::streambuf *original_cout_;
+};
+
 } // namespace test_utils
 
 #endif // TEST_UTILS_HPP

--- a/native/c/zmetal.h
+++ b/native/c/zmetal.h
@@ -336,8 +336,6 @@ static void *PTR64 load_module(const char *name)
 
   void *PTR64 ep = NULL;
 
-  auth_off(); // NOTE(Kelosky): force auth off before loading any module
-
   // Save 8 bytes for each register 2-13 (including 13) for PDSMAN/IEBCOPY
   unsigned long long save_registers[12] = {0};
   LOAD(name_truncated, ep, rc, rsn, save_registers[0]);

--- a/native/c/zutm.c
+++ b/native/c/zutm.c
@@ -407,6 +407,14 @@ int ZUTSSIQ(ZDIAG *diag, JQRY_HEADER **area, const char *filter)
   return rc;
 }
 
+#pragma prolog(ZUTNOAUT, " ZWEPROLG NEWDSA=(YES,1) ")
+#pragma epilog(ZUTNOAUT, " ZWEEPILG ")
+int ZUTNOAUT()
+{
+  auth_off();
+  return 0;
+}
+
 #pragma prolog(ZUTMSREL, " ZWEPROLG NEWDSA=(YES,4) ")
 #pragma epilog(ZUTMSREL, " ZWEEPILG ")
 int ZUTMSREL(int *size, void *data)

--- a/native/c/zutm.h
+++ b/native/c/zutm.h
@@ -100,6 +100,7 @@ extern "C"
   int ZUTMLPLB(ZDIAG *, int *, PARMLIB_DSNS *);
   int ZUTSSIQ(ZDIAG *, JQRY_HEADER **, const char *filter);
   int ZUTCVTD(const char *ptr, char *time_out);
+  int ZUTNOAUT();
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
**What It Does**

- Adds support for pre-command hooks in the command-line parser
- Fixed an issue where `zoweax` could run the `server` command or `plugin` command group as privileged. Now, `zoweax` disables privileges before command handlers (& their help logic) are executed. Commands in the `console` group continue to run as privileged.

**How to Test**

- Build `zoweax` & run commands w/ it 😋 
  - Console commands should continue to work as expected
  - Plug-ins should not be able to run APF authorized code
  - Running help on a command should also disable APF authorization
- Verify that typical commands outside of `console` group are running w/o APF authorization

_Tip:_ you can really test this in numerous ways, but the simplest way is adding a `std::cout` call to the pre-command hook and rebuilding to verify these cases - see lines 216-225 of `native/c/commands/core.cpp`.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)