### PR TITLE
refactor(uss): avoid CSV parsing when listing USS files through SDK & `zowex`

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Optimized USS file list operations by replacing CSV formatting and parsing with structured data transfer via the `ZusfListEntry` struct. This improves performance for `zowex uss list` and provides type-safe, programmatic access to file attributes for SDK consumers. [#990](https://github.com/zowe/zowex/pull/990)
+- `c`: Fixed parsing of file names containing commas in USS list API responses, which caused data misalignment for SDK consumers. [#989](https://github.com/zowe/zowex/issues/989)
 - `c`: Fixed an issue where the `zoweax` authorized CLI binary could run the `server` command or `plugin` command group as privileged. Now, `zoweax` disables privileges before commands are executed. Commands in the `console` group continue to run as privileged. [#958](https://github.com/zowe/zowex/issues/958)
 - `c`: Added support for pre-command hooks in the command-line parser utility. [#958](https://github.com/zowe/zowex/issues/958)
 - `c`: Fixes issue where ZWEPROLG could return to caller in an incorrect AMODE. [#951](https://github.com/zowe/zowex/issues/951)

--- a/native/c/commands/uss.cpp
+++ b/native/c/commands/uss.cpp
@@ -170,7 +170,8 @@ int handle_uss_list(InvocationContext &context)
 
   ZUSF zusf{};
   std::string response;
-  rc = zusf_list_uss_file_path(&zusf, uss_file, response, list_options, use_csv_format);
+  std::vector<ZusfListEntry> entries;
+  rc = zusf_list_uss_file_path(&zusf, uss_file, response, list_options, use_csv_format, use_csv_format ? &entries : nullptr);
   if (0 != rc)
   {
     context.error_stream() << "Error: could not list USS files: '" << uss_file << "' rc: '" << rc << "'" << std::endl;
@@ -187,59 +188,32 @@ int handle_uss_list(InvocationContext &context)
     const auto result = obj();
     const auto entries_array = arr();
 
-    // Parse CSV lines
-    std::stringstream ss(response);
-    std::string line;
-    int row_count = 0;
-
-    while (std::getline(ss, line))
+    for (const auto& list_entry : entries)
     {
-      if (line.empty())
-      {
-        continue;
-      }
-
       const auto entry = obj();
 
       if (list_options.long_format)
       {
-        // Parse CSV fields: mode,links,user,group,size,tag,date,name
-        std::vector<std::string> fields;
-        std::stringstream line_ss(line);
-        std::string field;
-
-        while (std::getline(line_ss, field, ','))
-        {
-          fields.push_back(field);
-        }
-
-        // We should have 8 fields: mode, links, user, group, size, filetag, mtime, name
-        if (fields.size() < 8)
-        {
-          continue;
-        }
-
-        entry->set("mode", str(fields[0]));
-        entry->set("links", i64(atoi(fields[1].c_str())));
-        entry->set("user", str(fields[2]));
-        entry->set("group", str(fields[3]));
-        entry->set("size", i64(atoi(fields[4].c_str())));
-        entry->set("filetag", str(fields[5]));
-        entry->set("mtime", str(fields[6]));
-        entry->set("name", str(fields[7]));
+        entry->set("mode", str(list_entry.mode));
+        entry->set("links", i64(list_entry.links));
+        entry->set("user", str(list_entry.user));
+        entry->set("group", str(list_entry.group));
+        entry->set("size", i64(list_entry.size));
+        entry->set("filetag", str(list_entry.filetag));
+        entry->set("mtime", str(list_entry.mtime));
+        entry->set("name", str(list_entry.name));
       }
       else
       {
         // Simple format: just the name
-        entry->set("name", str(line));
+        entry->set("name", str(list_entry.name));
       }
 
       entries_array->push(entry);
-      row_count++;
     }
 
     result->set("items", entries_array);
-    result->set("returnedRows", i64(row_count));
+    result->set("returnedRows", i64(entries.size()));
     context.set_object(result);
   }
 

--- a/native/c/test/zowex.uss.test.cpp
+++ b/native/c/test/zowex.uss.test.cpp
@@ -991,6 +991,20 @@ void zowex_uss_tests()
                              Expect(response).ToContain("drwxrwxrwx,");
                              Expect(response).ToContain(",subDir1");
                            });
+                        it("should properly handle file names with commas with --response-format-csv",
+                           [&]() -> void
+                           {
+                             std::string commaFile = ussTestDir + "/subDir1/comma,file,test.txt";
+                             execute_command_with_output(zowex_command + " uss create-file " + commaFile, response);
+
+                             std::string listDepthCommand = zowex_command + " uss ls " + ussTestDir + "/subDir1 -l --rfc";
+                             rc = execute_command_with_output(listDepthCommand, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain("comma,file,test.txt");
+
+                             // cleanup
+                             execute_command_with_output(zowex_command + " uss delete " + commaFile, response);
+                           });
                         it("should preserve symlink file type in long listing",
                            [&]() -> void
                            {

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -1089,8 +1089,25 @@ int zusf_move_uss_file_or_dir(ZUSF *zusf, const std::string &source, const std::
  *
  * @return formatted std::string for the file entry
  */
-std::string zusf_format_file_entry(ZUSF *zusf, const struct stat &file_stats, const std::string &file_path, const std::string &display_name, ListOptions options, bool use_csv_format)
+std::string zusf_format_file_entry(ZUSF *zusf, const struct stat &file_stats, const std::string &file_path, const std::string &display_name, ListOptions options, bool use_csv_format, std::vector<ZusfListEntry> *entries)
 {
+  if (entries)
+  {
+    ZusfListEntry entry;
+    entry.name = display_name;
+    if (options.long_format)
+    {
+      entry.mode = zusf_build_mode_string(file_stats.st_mode);
+      entry.links = file_stats.st_nlink;
+      entry.user = zusf_get_owner_from_uid(file_stats.st_uid);
+      entry.group = zusf_get_group_from_gid(file_stats.st_gid);
+      entry.size = file_stats.st_size;
+      entry.filetag = zusf_get_ccsid_display_name(file_stats.st_tag.ft_ccsid);
+      entry.mtime = zusf_format_ls_time(file_stats.st_mtime, true);
+    }
+    entries->push_back(entry);
+  }
+
   if (!options.long_format)
   {
     return display_name + "\n";
@@ -1217,7 +1234,7 @@ static int zusf_collect_directory_entries_recursive(ZUSF *zusf, const std::strin
  *
  * @return RTNCD_SUCCESS on success, RTNCD_FAILURE on failure
  */
-int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &response, ListOptions options, bool use_csv_format)
+int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &response, ListOptions options, bool use_csv_format, std::vector<ZusfListEntry> *entries)
 {
   if (!zusf_is_valid_path(file))
   {
@@ -1236,7 +1253,7 @@ int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &re
   if (S_ISREG(file_stats.st_mode))
   {
     const auto file_name = file.substr(file.find_last_of("/") + 1);
-    response = zusf_format_file_entry(zusf, file_stats, file, file_name, options, use_csv_format);
+    response = zusf_format_file_entry(zusf, file_stats, file, file_name, options, use_csv_format, entries);
     return RTNCD_SUCCESS;
   }
 
@@ -1252,7 +1269,7 @@ int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &re
   if (options.max_depth == 0)
   {
     const auto dir_name = file.substr(file.find_last_of("/") + 1);
-    response = zusf_format_file_entry(zusf, file_stats, file, dir_name, options, use_csv_format);
+    response = zusf_format_file_entry(zusf, file_stats, file, dir_name, options, use_csv_format, entries);
     return RTNCD_SUCCESS;
   }
 
@@ -1260,7 +1277,7 @@ int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &re
   if (options.all_files)
   {
     // Add "." entry
-    response += zusf_format_file_entry(zusf, file_stats, file, ".", options, use_csv_format);
+    response += zusf_format_file_entry(zusf, file_stats, file, ".", options, use_csv_format, entries);
 
     // Add ".." entry if we can stat the parent directory
     std::string parent_path = file.substr(0, file.find_last_of("/"));
@@ -1271,7 +1288,7 @@ int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &re
     struct stat parent_stats;
     if (stat(parent_path.c_str(), &parent_stats) == 0)
     {
-      response += zusf_format_file_entry(zusf, parent_stats, parent_path, "..", options, use_csv_format);
+      response += zusf_format_file_entry(zusf, parent_stats, parent_path, "..", options, use_csv_format, entries);
     }
   }
 
@@ -1295,7 +1312,7 @@ int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &re
       return RTNCD_FAILURE;
     }
 
-    response += zusf_format_file_entry(zusf, child_stats, child_path, name, options, use_csv_format);
+    response += zusf_format_file_entry(zusf, child_stats, child_path, name, options, use_csv_format, entries);
   }
 
   return RTNCD_SUCCESS;

--- a/native/c/zusf.hpp
+++ b/native/c/zusf.hpp
@@ -59,11 +59,23 @@ struct ListOptions
   }
 };
 
+struct ZusfListEntry
+{
+  std::string name;
+  std::string mode;
+  int64_t links;
+  std::string user;
+  std::string group;
+  int64_t size;
+  std::string filetag;
+  std::string mtime;
+};
+
 int zusf_copy_file_or_dir(ZUSF *zusf, const std::string &source_fs, const std::string &dest_fs, const CopyOptions &options);
 int zusf_create_uss_file_or_dir(ZUSF *zusf, const std::string &file, mode_t mode, const CreateOptions &options);
 int zusf_move_uss_file_or_dir(ZUSF *zusf, const std::string &source, const std::string &target, bool force = true);
-std::string zusf_format_file_entry(ZUSF *zusf, const struct stat &file_stats, const std::string &file_path, const std::string &display_name, ListOptions options, bool use_csv_format);
-int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &response, ListOptions options = ListOptions{}, bool use_csv_format = false);
+std::string zusf_format_file_entry(ZUSF *zusf, const struct stat &file_stats, const std::string &file_path, const std::string &display_name, ListOptions options, bool use_csv_format, std::vector<ZusfListEntry> *entries = nullptr);
+int zusf_list_uss_file_path(ZUSF *zusf, const std::string &file, std::string &response, ListOptions options = ListOptions{}, bool use_csv_format = false, std::vector<ZusfListEntry> *entries = nullptr);
 int zusf_read_from_uss_file(ZUSF *zusf, const std::string &file, std::string &response);
 int zusf_read_from_uss_file_streamed(ZUSF *zusf, const std::string &file, const std::string &pipe, size_t *content_len);
 int zusf_write_to_uss_file(ZUSF *zusf, const std::string &file, std::string &data);


### PR DESCRIPTION
**What It Does**

Fixes #989 

Parsing CSV returned by a C++ function is redundant 😄  we used to do this when Go middleware was in the repo, but now we don't need to parse the string from this API.

This feeds two birds with one scone: it speeds up listing USS files while also addressing the issue Andrew identified above.

**How to Test**

- `npm run z:rebuild && npm run z:test`
- List USS files using `zowex` with `-l` flag
- LGTM

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)