### PR TITLE
USS integration tests

### DIFF
--- a/native/c/commands/uss.cpp
+++ b/native/c/commands/uss.cpp
@@ -415,6 +415,10 @@ int handle_uss_chmod(InvocationContext &context)
   if (mode == 0 && !context.get<std::string>("mode", "").empty())
   {
     std::string mode_str = context.get<std::string>("mode", "");
+    if (mode_str.find_first_not_of("01234567") != std::string::npos || mode_str.length() < 3 || mode_str.length() > 4) {
+      context.error_stream() << "Error: invalid octal mode provided. Examples of valid modes: 777, 0644" << std::endl;
+      return RTNCD_FAILURE;
+    }
     try
     {
       mode = std::stoll(mode_str);

--- a/native/c/commands/uss.cpp
+++ b/native/c/commands/uss.cpp
@@ -414,8 +414,16 @@ int handle_uss_chmod(InvocationContext &context)
   long long mode = context.get<long long>("mode", 0);
   if (mode == 0 && !context.get<std::string>("mode", "").empty())
   {
-    context.error_stream() << "Error: invalid mode provided.\nExamples of valid modes: 777, 0644" << std::endl;
-    return RTNCD_FAILURE;
+    std::string mode_str = context.get<std::string>("mode", "");
+    try
+    {
+      mode = std::stoll(mode_str);
+    }
+    catch (...)
+    {
+      context.error_stream() << "Error: invalid mode provided.\nExamples of valid modes: 777, 0644" << std::endl;
+      return RTNCD_FAILURE;
+    }
   }
 
   std::string file_path = context.get<std::string>("file-path", "");

--- a/native/c/test/makefile
+++ b/native/c/test/makefile
@@ -137,6 +137,7 @@ build-out/zlogger_metal.o \
 build-out/zjson.test.o \
 build-out/zjsonm.o \
 build-out/zowex.server.test.o \
+build-out/zowex.uss.server.test.o \
 build-out/server.worker.test.o \
 build-out/server_validator.o \
 build-out/server.validator.test.o
@@ -281,6 +282,9 @@ build-out/zjson.test.o: zjson.test.cpp
 	$(CXX) $(CXXFLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zowex.server.test.o: zowex.server.test.cpp
+	$(CXX) $(CXXFLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
+
+build-out/zowex.uss.server.test.o: zowex.uss.server.test.cpp
 	$(CXX) $(CXXFLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/server.worker.test.o: server/worker.test.cpp

--- a/native/c/test/zowex.server.test.cpp
+++ b/native/c/test/zowex.server.test.cpp
@@ -23,14 +23,7 @@
 
 using namespace ztst;
 
-struct ServerHandle
-{
-  pid_t pid;
-  FILE *output_stream;
-  FILE *input_stream;
-};
-
-std::string read_line_from_server(ServerHandle &handle, int timeout_ms = 5000)
+std::string read_line_from_server(ServerHandle &handle, int timeout_ms)
 {
   fd_set read_fds;
   struct timeval timeout;
@@ -69,7 +62,7 @@ void write_to_server(ServerHandle &handle, const std::string &input)
   }
 }
 
-ServerHandle start_server(const std::string &command, bool read_ready_message = false)
+ServerHandle start_server(const std::string &command, bool read_ready_message)
 {
   int output_pipe[2];
   int input_pipe[2];
@@ -136,8 +129,8 @@ void stop_server(ServerHandle &handle)
   waitpid(handle.pid, nullptr, 0);
 }
 
-const std::string zowex_dir = "./../build-out";
-const std::string zowex_server_command = zowex_dir + "/zowex server";
+extern const std::string zowex_dir = "./../build-out";
+extern const std::string zowex_server_command = zowex_dir + "/zowex server";
 
 void zowex_server_tests()
 {

--- a/native/c/test/zowex.server.test.cpp
+++ b/native/c/test/zowex.server.test.cpp
@@ -129,8 +129,8 @@ void stop_server(ServerHandle &handle)
   waitpid(handle.pid, nullptr, 0);
 }
 
-extern const std::string zowex_dir = "./../build-out";
-extern const std::string zowex_server_command = zowex_dir + "/zowex server";
+const std::string zowex_dir = "./../build-out";
+const std::string zowex_server_command = zowex_dir + "/zowex server";
 
 void zowex_server_tests()
 {

--- a/native/c/test/zowex.server.test.hpp
+++ b/native/c/test/zowex.server.test.hpp
@@ -11,5 +11,26 @@
 
 #ifndef ZOWEX_SERVER_TEST_HPP
 #define ZOWEX_SERVER_TEST_HPP
+
+#include <string>
+#include <cstdio>
+#include <sys/types.h>
+
+struct ServerHandle
+{
+  pid_t pid;
+  FILE *output_stream;
+  FILE *input_stream;
+};
+
+std::string read_line_from_server(ServerHandle &handle, int timeout_ms = 5000);
+void write_to_server(ServerHandle &handle, const std::string &input);
+ServerHandle start_server(const std::string &command, bool read_ready_message = false);
+void stop_server(ServerHandle &handle);
+
+extern const std::string zowex_dir;
+extern const std::string zowex_server_command;
+
 void zowex_server_tests();
+
 #endif

--- a/native/c/test/zowex.uss.server.test.cpp
+++ b/native/c/test/zowex.uss.server.test.cpp
@@ -17,6 +17,7 @@
 
 using namespace ztst;
 
+// Create unique test directory to avoid conflicts between test runs
 static const std::string ussTestDir = "/tmp/zowex-uss-srv_" + get_random_string(10);
 
 void zowex_uss_server_tests()
@@ -27,6 +28,7 @@ void zowex_uss_server_tests()
     beforeAll([&]() -> void {
       server = start_server(zowex_server_command, true);
 
+      // Create test directory with full permissions for all test operations
       std::string response;
       execute_command_with_output(zowex_command + " uss create-dir " + ussTestDir + " --mode 777", response);
     });
@@ -56,6 +58,7 @@ void zowex_uss_server_tests()
         Expect(response).ToContain("\"success\":true");
         Expect(response).ToContain("\"id\":1");
 
+        // Verify permissions were actually set by checking ls output
         std::string ls_response;
         execute_command_with_output("ls -l " + uss_path, ls_response);
         Expect(ls_response).ToContain("-rwxrwxrwx");
@@ -72,9 +75,10 @@ void zowex_uss_server_tests()
       });
 
       it("should properly chown a file via RPC", [&]() -> void {
+        // Get current user ID for chown operation
         std::string resp;
         execute_command_with_output("id -u", resp);
-        resp.erase(resp.find_last_not_of(" \t\r\n") + 1);
+        resp.erase(resp.find_last_not_of(" \t\r\n") + 1); // trim whitespace
         
         std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"chownFile\",\"params\":{\"fspath\":\"" + uss_path + "\",\"owner\":\"" + resp + "\"},\"id\":2}\n";
         
@@ -104,6 +108,7 @@ void zowex_uss_server_tests()
         Expect(response).ToContain("\"success\":true");
         Expect(response).ToContain("\"id\":3");
         
+        // Verify tag was applied using ls -alT (shows encoding tags)
         std::string ls_response;
         execute_command_with_output("ls -alT " + uss_path, ls_response);
         Expect(ls_response).ToContain("IBM-1047");
@@ -130,6 +135,7 @@ void zowex_uss_server_tests()
         Expect(response).ToContain("\"success\":true");
         Expect(response).ToContain("\"id\":4");
         
+        // Verify destination file exists after copy
         std::string ls_response;
         int rc = execute_command_with_output("ls " + dest_path, ls_response);
         Expect(rc).ToBe(0);
@@ -152,10 +158,11 @@ void zowex_uss_server_tests()
         Expect(response).ToContain("\"success\":true");
         Expect(response).ToContain("\"id\":5");
         
+        // Verify directory was created and has directory permissions
         std::string ls_response;
         int rc = execute_command_with_output("ls -ld " + dir_path, ls_response);
         Expect(rc).ToBe(0);
-        Expect(ls_response).ToContain("drwx");
+        Expect(ls_response).ToContain("drwx"); // directory prefix in permissions
       });
     });
 
@@ -199,6 +206,7 @@ void zowex_uss_server_tests()
         Expect(response).ToContain("\"success\":true");
         Expect(response).ToContain("\"id\":7");
         
+        // Verify file no longer exists (ls should fail)
         std::string ls_response;
         int rc = execute_command_with_output("ls " + file_path, ls_response);
         Expect(rc).Not().ToBe(0);
@@ -224,6 +232,7 @@ void zowex_uss_server_tests()
       beforeEach([&]() -> void {
         dir_path = get_random_uss(ussTestDir) + "_listdir";
         std::string response;
+        // Create test directory with a file inside for listing
         execute_command_with_output(zowex_command + " uss create-dir " + dir_path, response);
         execute_command_with_output(zowex_command + " uss create-file " + dir_path + "/testfile", response);
       });
@@ -260,11 +269,12 @@ void zowex_uss_server_tests()
         Expect(response).ToContain("\"success\":true");
         Expect(response).ToContain("\"id\":10");
         
+        // Verify move: source should not exist, destination should exist
         std::string ls_response;
         int rc1 = execute_command_with_output("ls " + src_path, ls_response);
-        Expect(rc1).Not().ToBe(0);
+        Expect(rc1).Not().ToBe(0); // source file gone
         int rc2 = execute_command_with_output("ls " + dest_path, ls_response);
-        Expect(rc2).ToBe(0);
+        Expect(rc2).ToBe(0); // destination file exists
       });
     });
 
@@ -276,7 +286,7 @@ void zowex_uss_server_tests()
       });
 
       it("should properly write and view a file via RPC", [&]() -> void {
-        // base64 encoded "Hello World!" is "SGVsbG8gV29ybGQh"
+        // Write operation: base64 encoded "Hello World!" is "SGVsbG8gV29ybGQh"
         std::string write_req = "{\"jsonrpc\":\"2.0\",\"method\":\"writeFile\",\"params\":{\"fspath\":\"" + file_path + "\",\"data\":\"SGVsbG8gV29ybGQh\"},\"id\":11}\n";
         
         write_to_server(server, write_req);
@@ -285,6 +295,7 @@ void zowex_uss_server_tests()
         Expect(write_resp).ToContain("\"success\":true");
         Expect(write_resp).ToContain("\"id\":11");
         
+        // Read operation: verify we get back the same base64 content
         std::string read_req = "{\"jsonrpc\":\"2.0\",\"method\":\"readFile\",\"params\":{\"fspath\":\"" + file_path + "\"},\"id\":12}\n";
         
         write_to_server(server, read_req);
@@ -292,7 +303,7 @@ void zowex_uss_server_tests()
 
         Expect(read_resp).ToContain("\"success\":true");
         Expect(read_resp).ToContain("\"id\":12");
-        Expect(read_resp).ToContain("\"SGVsbG8gV29ybGQh\"");
+        Expect(read_resp).ToContain("\"SGVsbG8gV29ybGQh\""); // same base64 data
       });
     });
 

--- a/native/c/test/zowex.uss.server.test.cpp
+++ b/native/c/test/zowex.uss.server.test.cpp
@@ -18,7 +18,7 @@
 using namespace ztst;
 
 // Create unique test directory to avoid conflicts between test runs
-static const std::string ussTestDir = "/tmp/zowex-uss-srv_" + get_random_string(10);
+static const std::string ussTestDir = "/tmp/zowex_uss_srv_" + get_random_string(10);
 
 void zowex_uss_server_tests()
 {
@@ -87,6 +87,17 @@ void zowex_uss_server_tests()
 
         Expect(response).ToContain("\"success\":true");
         Expect(response).ToContain("\"id\":2");
+
+        // Verify ownership was actually set by checking ls -l output
+        std::string ls_response;
+        execute_command_with_output("ls -l " + uss_path, ls_response);
+        
+        // ls -l shows the username, so we need to get it via id -un to compare
+        std::string username_resp;
+        execute_command_with_output("id -un", username_resp);
+        username_resp.erase(username_resp.find_last_not_of(" \t\r\n") + 1); // trim whitespace
+        
+        ExpectWithContext(ls_response, "File should be owned by the user").ToContain(username_resp);
       });
     });
 
@@ -124,6 +135,11 @@ void zowex_uss_server_tests()
         dest_path = get_random_uss(ussTestDir) + "_dest";
         std::string response;
         execute_command_with_output(zowex_command + " uss create-file " + src_path, response);
+
+        // Populate the source file with some sample content via RPC writeFile
+        std::string write_req = "{\"jsonrpc\":\"2.0\",\"method\":\"writeFile\",\"params\":{\"fspath\":\"" + src_path + "\",\"data\":\"SGVsbG8gY29weSE=\"},\"id\":40}\n";
+        write_to_server(server, write_req);
+        read_line_from_server(server); // consume response
       });
 
       it("should properly copy a file via RPC", [&]() -> void {
@@ -139,6 +155,15 @@ void zowex_uss_server_tests()
         std::string ls_response;
         int rc = execute_command_with_output("ls " + dest_path, ls_response);
         Expect(rc).ToBe(0);
+
+        // Verify the destination file contains the identical content via RPC readFile
+        std::string read_req = "{\"jsonrpc\":\"2.0\",\"method\":\"readFile\",\"params\":{\"fspath\":\"" + dest_path + "\"},\"id\":41}\n";
+        write_to_server(server, read_req);
+        std::string read_resp = read_line_from_server(server);
+
+        Expect(read_resp).ToContain("\"success\":true");
+        Expect(read_resp).ToContain("\"id\":41");
+        Expect(read_resp).ToContain("\"SGVsbG8gY29weSE=\""); // same base64 data
       });
     });
 
@@ -258,6 +283,11 @@ void zowex_uss_server_tests()
         dest_path = get_random_uss(ussTestDir) + "_mvdest";
         std::string response;
         execute_command_with_output(zowex_command + " uss create-file " + src_path, response);
+
+        // Populate the source file with some sample content via RPC writeFile
+        std::string write_req = "{\"jsonrpc\":\"2.0\",\"method\":\"writeFile\",\"params\":{\"fspath\":\"" + src_path + "\",\"data\":\"SGVsbG8gbW92ZSE=\"},\"id\":100}\n";
+        write_to_server(server, write_req);
+        read_line_from_server(server); // consume response
       });
 
       it("should properly move a file via RPC", [&]() -> void {
@@ -275,6 +305,15 @@ void zowex_uss_server_tests()
         Expect(rc1).Not().ToBe(0); // source file gone
         int rc2 = execute_command_with_output("ls " + dest_path, ls_response);
         Expect(rc2).ToBe(0); // destination file exists
+
+        // Verify the destination file contains the identical content via RPC readFile
+        std::string read_req = "{\"jsonrpc\":\"2.0\",\"method\":\"readFile\",\"params\":{\"fspath\":\"" + dest_path + "\"},\"id\":101}\n";
+        write_to_server(server, read_req);
+        std::string read_resp = read_line_from_server(server);
+
+        Expect(read_resp).ToContain("\"success\":true");
+        Expect(read_resp).ToContain("\"id\":101");
+        Expect(read_resp).ToContain("\"SGVsbG8gbW92ZSE=\""); // same base64 data
       });
     });
 

--- a/native/c/test/zowex.uss.server.test.cpp
+++ b/native/c/test/zowex.uss.server.test.cpp
@@ -1,0 +1,301 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+#include "ztest.hpp"
+#include <string>
+#include "zutils.hpp"
+#include "zowex.server.test.hpp"
+#include "zowex.uss.server.test.hpp"
+
+using namespace ztst;
+
+static const std::string ussTestDir = "/tmp/zowex-uss-srv_" + get_random_string(10);
+
+void zowex_uss_server_tests()
+{
+  describe("uss server tests", []() -> void {
+    ServerHandle server;
+    
+    beforeAll([&]() -> void {
+      server = start_server(zowex_server_command, true);
+
+      std::string response;
+      execute_command_with_output(zowex_command + " uss create-dir " + ussTestDir + " --mode 777", response);
+    });
+
+    afterAll([&]() -> void {
+      stop_server(server);
+
+      std::string response;
+      execute_command_with_output(zowex_command + " uss delete " + ussTestDir + " --recursive", response);
+    });
+
+    describe("chmod", [&]() -> void {
+      std::string uss_path;
+
+      beforeEach([&]() -> void {
+        uss_path = get_random_uss(ussTestDir);
+        std::string response;
+        execute_command_with_output(zowex_command + " uss create-file " + uss_path, response);
+      });
+
+      it("should properly chmod a file via RPC", [&]() -> void {
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"chmodFile\",\"params\":{\"fspath\":\"" + uss_path + "\",\"mode\":\"777\"},\"id\":1}\n";
+        
+        write_to_server(server, request);
+        std::string response = read_line_from_server(server);
+
+        Expect(response).ToContain("\"success\":true");
+        Expect(response).ToContain("\"id\":1");
+
+        std::string ls_response;
+        execute_command_with_output("ls -l " + uss_path, ls_response);
+        Expect(ls_response).ToContain("-rwxrwxrwx");
+      });
+    });
+
+    describe("chown", [&]() -> void {
+      std::string uss_path;
+
+      beforeEach([&]() -> void {
+        uss_path = get_random_uss(ussTestDir);
+        std::string response;
+        execute_command_with_output(zowex_command + " uss create-file " + uss_path, response);
+      });
+
+      it("should properly chown a file via RPC", [&]() -> void {
+        std::string resp;
+        execute_command_with_output("id -u", resp);
+        resp.erase(resp.find_last_not_of(" \t\r\n") + 1);
+        
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"chownFile\",\"params\":{\"fspath\":\"" + uss_path + "\",\"owner\":\"" + resp + "\"},\"id\":2}\n";
+        
+        write_to_server(server, request);
+        std::string response = read_line_from_server(server);
+
+        Expect(response).ToContain("\"success\":true");
+        Expect(response).ToContain("\"id\":2");
+      });
+    });
+
+    describe("chtag", [&]() -> void {
+      std::string uss_path;
+
+      beforeEach([&]() -> void {
+        uss_path = get_random_uss(ussTestDir);
+        std::string response;
+        execute_command_with_output(zowex_command + " uss create-file " + uss_path, response);
+      });
+
+      it("should properly chtag a file via RPC", [&]() -> void {
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"chtagFile\",\"params\":{\"fspath\":\"" + uss_path + "\",\"tag\":\"IBM-1047\"},\"id\":3}\n";
+        
+        write_to_server(server, request);
+        std::string response = read_line_from_server(server);
+
+        Expect(response).ToContain("\"success\":true");
+        Expect(response).ToContain("\"id\":3");
+        
+        std::string ls_response;
+        execute_command_with_output("ls -alT " + uss_path, ls_response);
+        Expect(ls_response).ToContain("IBM-1047");
+      });
+    });
+
+    describe("copy", [&]() -> void {
+      std::string src_path;
+      std::string dest_path;
+
+      beforeEach([&]() -> void {
+        src_path = get_random_uss(ussTestDir) + "_src";
+        dest_path = get_random_uss(ussTestDir) + "_dest";
+        std::string response;
+        execute_command_with_output(zowex_command + " uss create-file " + src_path, response);
+      });
+
+      it("should properly copy a file via RPC", [&]() -> void {
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"copyUss\",\"params\":{\"srcFsPath\":\"" + src_path + "\",\"dstFsPath\":\"" + dest_path + "\"},\"id\":4}\n";
+        
+        write_to_server(server, request);
+        std::string response = read_line_from_server(server);
+
+        Expect(response).ToContain("\"success\":true");
+        Expect(response).ToContain("\"id\":4");
+        
+        std::string ls_response;
+        int rc = execute_command_with_output("ls " + dest_path, ls_response);
+        Expect(rc).ToBe(0);
+      });
+    });
+
+    describe("create-dir", [&]() -> void {
+      std::string dir_path;
+
+      beforeEach([&]() -> void {
+        dir_path = get_random_uss(ussTestDir) + "_newdir";
+      });
+
+      it("should properly create a directory via RPC", [&]() -> void {
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"createFile\",\"params\":{\"fspath\":\"" + dir_path + "\",\"isDir\":true},\"id\":5}\n";
+        
+        write_to_server(server, request);
+        std::string response = read_line_from_server(server);
+
+        Expect(response).ToContain("\"success\":true");
+        Expect(response).ToContain("\"id\":5");
+        
+        std::string ls_response;
+        int rc = execute_command_with_output("ls -ld " + dir_path, ls_response);
+        Expect(rc).ToBe(0);
+        Expect(ls_response).ToContain("drwx");
+      });
+    });
+
+    describe("create-file", [&]() -> void {
+      std::string file_path;
+
+      beforeEach([&]() -> void {
+        file_path = get_random_uss(ussTestDir) + "_newfile";
+      });
+
+      it("should properly create a file via RPC", [&]() -> void {
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"createFile\",\"params\":{\"fspath\":\"" + file_path + "\",\"isDir\":false},\"id\":6}\n";
+        
+        write_to_server(server, request);
+        std::string response = read_line_from_server(server);
+
+        Expect(response).ToContain("\"success\":true");
+        Expect(response).ToContain("\"id\":6");
+        
+        std::string ls_response;
+        int rc = execute_command_with_output("ls -l " + file_path, ls_response);
+        Expect(rc).ToBe(0);
+      });
+    });
+
+    describe("delete", [&]() -> void {
+      std::string file_path;
+
+      beforeEach([&]() -> void {
+        file_path = get_random_uss(ussTestDir) + "_delfile";
+        std::string response;
+        execute_command_with_output(zowex_command + " uss create-file " + file_path, response);
+      });
+
+      it("should properly delete a file via RPC", [&]() -> void {
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"deleteFile\",\"params\":{\"fspath\":\"" + file_path + "\"},\"id\":7}\n";
+        
+        write_to_server(server, request);
+        std::string response = read_line_from_server(server);
+
+        Expect(response).ToContain("\"success\":true");
+        Expect(response).ToContain("\"id\":7");
+        
+        std::string ls_response;
+        int rc = execute_command_with_output("ls " + file_path, ls_response);
+        Expect(rc).Not().ToBe(0);
+      });
+    });
+
+    describe("issue", [&]() -> void {
+      it("should properly issue a UNIX command via RPC", [&]() -> void {
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"unixCommand\",\"params\":{\"commandText\":\"echo hello\"},\"id\":8}\n";
+        
+        write_to_server(server, request);
+        std::string response = read_line_from_server(server);
+
+        Expect(response).ToContain("\"success\":true");
+        Expect(response).ToContain("\"id\":8");
+        Expect(response).ToContain("\"data\":\"hello\\n\"");
+      });
+    });
+
+    describe("list", [&]() -> void {
+      std::string dir_path;
+
+      beforeEach([&]() -> void {
+        dir_path = get_random_uss(ussTestDir) + "_listdir";
+        std::string response;
+        execute_command_with_output(zowex_command + " uss create-dir " + dir_path, response);
+        execute_command_with_output(zowex_command + " uss create-file " + dir_path + "/testfile", response);
+      });
+
+      it("should properly list files via RPC", [&]() -> void {
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"listFiles\",\"params\":{\"fspath\":\"" + dir_path + "\"},\"id\":9}\n";
+        
+        write_to_server(server, request);
+        std::string response = read_line_from_server(server);
+
+        Expect(response).ToContain("\"success\":true");
+        Expect(response).ToContain("\"id\":9");
+        Expect(response).ToContain("\"testfile\"");
+      });
+    });
+
+    describe("move", [&]() -> void {
+      std::string src_path;
+      std::string dest_path;
+
+      beforeEach([&]() -> void {
+        src_path = get_random_uss(ussTestDir) + "_mvsrc";
+        dest_path = get_random_uss(ussTestDir) + "_mvdest";
+        std::string response;
+        execute_command_with_output(zowex_command + " uss create-file " + src_path, response);
+      });
+
+      it("should properly move a file via RPC", [&]() -> void {
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"moveFile\",\"params\":{\"source\":\"" + src_path + "\",\"target\":\"" + dest_path + "\"},\"id\":10}\n";
+        
+        write_to_server(server, request);
+        std::string response = read_line_from_server(server);
+
+        Expect(response).ToContain("\"success\":true");
+        Expect(response).ToContain("\"id\":10");
+        
+        std::string ls_response;
+        int rc1 = execute_command_with_output("ls " + src_path, ls_response);
+        Expect(rc1).Not().ToBe(0);
+        int rc2 = execute_command_with_output("ls " + dest_path, ls_response);
+        Expect(rc2).ToBe(0);
+      });
+    });
+
+    describe("write and view", [&]() -> void {
+      std::string file_path;
+
+      beforeEach([&]() -> void {
+        file_path = get_random_uss(ussTestDir) + "_wvfile";
+      });
+
+      it("should properly write and view a file via RPC", [&]() -> void {
+        // base64 encoded "Hello World!" is "SGVsbG8gV29ybGQh"
+        std::string write_req = "{\"jsonrpc\":\"2.0\",\"method\":\"writeFile\",\"params\":{\"fspath\":\"" + file_path + "\",\"data\":\"SGVsbG8gV29ybGQh\"},\"id\":11}\n";
+        
+        write_to_server(server, write_req);
+        std::string write_resp = read_line_from_server(server);
+
+        Expect(write_resp).ToContain("\"success\":true");
+        Expect(write_resp).ToContain("\"id\":11");
+        
+        std::string read_req = "{\"jsonrpc\":\"2.0\",\"method\":\"readFile\",\"params\":{\"fspath\":\"" + file_path + "\"},\"id\":12}\n";
+        
+        write_to_server(server, read_req);
+        std::string read_resp = read_line_from_server(server);
+
+        Expect(read_resp).ToContain("\"success\":true");
+        Expect(read_resp).ToContain("\"id\":12");
+        Expect(read_resp).ToContain("\"SGVsbG8gV29ybGQh\"");
+      });
+    });
+
+
+  });
+}

--- a/native/c/test/zowex.uss.server.test.cpp
+++ b/native/c/test/zowex.uss.server.test.cpp
@@ -11,6 +11,10 @@
 
 #include "ztest.hpp"
 #include <string>
+#include <thread>
+#include <fcntl.h>
+#include <unistd.h>
+#include "../zbase64.h"
 #include "zutils.hpp"
 #include "zowex.server.test.hpp"
 #include "zowex.uss.server.test.hpp"
@@ -346,6 +350,117 @@ void zowex_uss_server_tests()
       });
     });
 
+    describe("streaming integration", [&]() -> void {
+      std::string file_path;
+
+      beforeEach([&]() -> void {
+        file_path = get_random_uss(ussTestDir) + "_stream_file";
+      });
+
+      it("should write via stream", [&]() -> void {
+        int stream_id = 300;
+
+        const std::string payload = "Hello USS Stream\nLine 2 of USS\n";
+        const auto encoded = zbase64::encode(payload.c_str(), payload.size());
+        const std::string encoded_payload(encoded.begin(), encoded.end());
+
+        std::string pipe_path;
+        std::thread writer;
+
+        std::string request = "{\"jsonrpc\":\"2.0\",\"method\":\"writeFile\",\"params\":{\"fspath\":\"" + file_path + "\",\"stream\":" + std::to_string(stream_id) + ",\"encoding\":\"binary\"},\"id\":45}\n";
+
+        write_to_server(server, request);
+
+        std::string notification = read_line_from_server(server);
+
+        ExpectWithContext(notification, "Should be sendStream notification").ToContain("\"method\":\"sendStream\"");
+        ExpectWithContext(notification, "Should have correct stream ID").ToContain("\"id\":" + std::to_string(stream_id));
+
+        size_t pipe_path_start = notification.find("\"pipePath\":\"") + 12;
+        size_t pipe_path_end = notification.find("\"", pipe_path_start);
+        pipe_path = notification.substr(pipe_path_start, pipe_path_end - pipe_path_start);
+
+        writer = std::thread([&]() -> void {
+          int fd = -1;
+          for (int attempt = 0; attempt < 100 && fd == -1; ++attempt) {
+            fd = open(pipe_path.c_str(), O_WRONLY | O_NONBLOCK);
+            if (fd == -1) {
+              usleep(10000);
+            }
+          }
+          if (fd != -1) {
+            write(fd, encoded_payload.data(), encoded_payload.size());
+            close(fd);
+          }
+        });
+
+        std::string response = read_line_from_server(server);
+
+        if (writer.joinable()) {
+          writer.join();
+        }
+
+        Expect(response).ToContain("\"id\":45");
+        Expect(response).ToContain("\"success\":true");
+
+        std::string read_request = "{\"jsonrpc\":\"2.0\",\"method\":\"readFile\",\"params\":{\"fspath\":\"" + file_path + "\"},\"id\":46}\n";
+
+        write_to_server(server, read_request);
+        std::string read_response = read_line_from_server(server);
+
+        Expect(read_response).ToContain("\"success\":true");
+        ExpectWithContext(read_response, "Should contain streamed text").ToContain("SGVsbG8gVVNTIFN0cmVhbQ");
+      });
+
+      it("should read via stream", [&]() -> void {
+        std::string test_content = "VVNTIFN0cmVhbSByZWFkIHRlc3QK"; // "USS Stream read test\n" base64
+        std::string write_request = "{\"jsonrpc\":\"2.0\",\"method\":\"writeFile\",\"params\":{\"fspath\":\"" + file_path + "\",\"data\":\"" + test_content + "\"},\"id\":50}\n";
+
+        write_to_server(server, write_request);
+        std::string write_response = read_line_from_server(server);
+
+        Expect(write_response).ToContain("\"success\":true");
+
+        int stream_id = 400;
+
+        std::string read_request = "{\"jsonrpc\":\"2.0\",\"method\":\"readFile\",\"params\":{\"fspath\":\"" + file_path + "\",\"stream\":" + std::to_string(stream_id) + "},\"id\":51}\n";
+
+        write_to_server(server, read_request);
+
+        std::string notification = read_line_from_server(server);
+        Expect(notification).ToContain("\"method\":\"receiveStream\"");
+        ExpectWithContext(notification, "Should have correct stream ID").ToContain("\"id\":" + std::to_string(stream_id));
+
+        size_t pipe_path_start = notification.find("\"pipePath\":\"") + 12;
+        size_t pipe_path_end = notification.find("\"", pipe_path_start);
+        std::string output_pipe = notification.substr(pipe_path_start, pipe_path_end - pipe_path_start);
+
+        std::string file_content;
+        std::thread reader([&]() -> void {
+          // Open FIFO for reading - this will block until the server opens it for writing
+          int fd = open(output_pipe.c_str(), O_RDONLY);
+          if (fd != -1) {
+            char buffer[4096];
+            ssize_t bytes_read = read(fd, buffer, sizeof(buffer) - 1);
+            if (bytes_read > 0) {
+              buffer[bytes_read] = '\0';
+              file_content = std::string(buffer, bytes_read);
+            }
+            close(fd);
+          }
+        });
+
+        std::string read_response = read_line_from_server(server);
+
+        reader.join();
+
+        Expect(read_response).ToContain("\"id\":51");
+
+        ExpectWithContext(file_content, "Streamed file should contain data").ToContain(test_content);
+        ExpectWithContext(read_response, "Should be valid JSON-RPC response").ToContain("jsonrpc");
+        ExpectWithContext(read_response, "Read streaming RPC interface should be supported").ToContain("\"id\":51");
+      });
+    });
 
   });
 }

--- a/native/c/test/zowex.uss.server.test.hpp
+++ b/native/c/test/zowex.uss.server.test.hpp
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+#ifndef ZOWEX_USS_SERVER_TEST_HPP
+#define ZOWEX_USS_SERVER_TEST_HPP
+
+void zowex_uss_server_tests();
+
+#endif

--- a/native/c/test/ztest_runner.cpp
+++ b/native/c/test/ztest_runner.cpp
@@ -25,6 +25,7 @@
 #include "zstd.test.hpp"
 #include "zjson.test.hpp"
 #include "zowex.server.test.hpp"
+#include "zowex.uss.server.test.hpp"
 #include "server/worker.test.hpp"
 #include "server/validator.test.hpp"
 #include "ztest.hpp"
@@ -54,6 +55,7 @@ int main(int argc, char *argv[])
         zstd_tests();
         zjson_tests();
         zowex_server_tests();
+        zowex_uss_server_tests();
         server_worker_tests();
         server_validator_tests();
       });


### PR DESCRIPTION
**What It Does**

Added happy path integration tests for zowex uss commands.

- Modified `chown` function to properly handle the new mode as a string when passed from jsonRPC

**How to Test**

1. After building run `npm run z:test "uss server tests"`
2. Observe that all of the tests are passing
3. (Optional): run `npm run z:test` to confirm there are no regressions

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
