### PR TITLE
feat: Add z/OS recovery around `iefssreq` calls

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- `c`: Added z/OS recovery around JES operations in `zowex` to allow recovering from abends. [#1011](https://github.com/zowe/zowex/pull/1011)
+- `c`: Added z/OS recovery around JES operations in the `zowex` CLI binary to allow recovering from abends. [#1011](https://github.com/zowe/zowex/pull/1011)
 - **Breaking:** `c`: Renamed C function `zjb_read_jobs_output_by_key` in zjb.hpp to `zjb_read_job_content_by_key` to be consistent with `zjb_read_job_content_by_dsn.
 - `c`: Fixes issue where `zowex` failed to allocate `sysout` DDs that were dynamically allocated under z/OS UNIX. [#840](https://github.com/zowe/zowex/issues/840)
 - `c`: Add command `zowex system list-apf` to list APF authorized data sets.

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Added z/OS recovery around JES operations in `zowex` to allow recovering from abends. [#1011](https://github.com/zowe/zowex/pull/1011)
 - **Breaking:** `c`: Renamed C function `zjb_read_jobs_output_by_key` in zjb.hpp to `zjb_read_job_content_by_key` to be consistent with `zjb_read_job_content_by_dsn.
 - `c`: Fixes issue where `zowex` failed to allocate `sysout` DDs that were dynamically allocated under z/OS UNIX. [#840](https://github.com/zowe/zowex/issues/840)
 - `c`: Add command `zowex system list-apf` to list APF authorized data sets.

--- a/native/c/test/zrecovery.metal.test.c
+++ b/native/c/test/zrecovery.metal.test.c
@@ -162,20 +162,13 @@ static int ZRCVYSTI(void)
 #pragma epilog(ZRCVYSTK, " ZWEEPILG ")
 int ZRCVYSTK(void)
 {
-  unsigned long long int regs_before[7] = {0};
+  unsigned long long int regs_before[7] = {1005, 1006, 1007, 1008, 1009, 1010, 1011};
   unsigned long long int regs_after[7] = {0};
   int i;
 
   __asm(
-      "*                                                   \n"
-      " LGHI   5,1005             Set R5                   \n"
-      " LGHI   6,1006             Set R6                   \n"
-      " LGHI   7,1007             Set R7                   \n"
-      " LGHI   8,1008             Set R8                   \n"
-      " LGHI   9,1009             Set R9                   \n"
-      " LGHI   10,1010            Set R10                  \n"
-      " LGHI   11,1011            Set R11                  \n"
-      " STMG   5,11,%0            Capture before R5-R11    \n"
+      "*                                                          \n"
+      " LMG   5,11,%0            Load regs_before into R5-R11    \n"
       "*                                                    "
       : "=m"(regs_before[0])
       :
@@ -184,8 +177,8 @@ int ZRCVYSTK(void)
   ZRCVYSTI();
 
   __asm(
-      "*                                                   \n"
-      " STMG   5,11,%0            Capture after R5-R11     \n"
+      "*                                                        \n"
+      " STMG   5,11,%0            Store R5-R11 into regs_after    \n"
       "*                                                    "
       : "=m"(regs_after[0])
       :

--- a/native/c/test/zrecovery.metal.test.c
+++ b/native/c/test/zrecovery.metal.test.c
@@ -111,7 +111,7 @@ int ZRCVYNCL()
 
 #pragma prolog(ZRCVYTHR, " ZWEPROLG NEWDSA=(YES,128) ")
 #pragma epilog(ZRCVYTHR, " ZWEEPILG ")
-int ZRCVYTHR(int *PTR64 thread_id, int *PTR64 rc)
+int ZRCVYTHR(const int *PTR64 thread_id, int *PTR64 rc)
 {
   ZRCVY_ENV zenv = {0};
   *rc = -1;

--- a/native/c/test/zrecovery.metal.test.c
+++ b/native/c/test/zrecovery.metal.test.c
@@ -36,10 +36,7 @@ int ZRCVYEN()
 int ZRCVYDIS()
 {
   ZRCVY_ENV zenv = {0};
-  if (0 == enable_recovery(&zenv))
-  {
-    // do nothing
-  }
+  enable_recovery(&zenv);
   disable_recovery(&zenv);
   s0c3_abend(0);
   return 0;
@@ -57,7 +54,7 @@ static int ZRCVYNST_INNER(int *PTR64 rc2)
   }
   else
   {
-    *rc2 = 1;      // zenv2 recovery entered!
+    *rc2 = 1; // zenv2 recovery entered!
     disable_recovery(&zenv2);
     s0c3_abend(0); // Trigger outer abend -> goes to zenv1 else
   }
@@ -102,10 +99,8 @@ int ZRCVYNCL()
 
   if (0 == enable_recovery(&zenv1))
   {
-    if (0 == enable_recovery(&zenv2))
-    {
-      // do nothing, just establish both and exit inner
-    }
+    // Establish inner recovery as part of nested setup
+    enable_recovery(&zenv2);
   }
 
   disable_recovery(&zenv2);

--- a/native/c/test/zrecovery.metal.test.c
+++ b/native/c/test/zrecovery.metal.test.c
@@ -137,10 +137,10 @@ int ZRCVYNUL()
   return iefssreq(NULL);
 }
 
-#pragma prolog(ZRCVYSTK_INNER, " ZWEPROLG NEWDSA=(YES,128),SAVE=BAKR ")
-#pragma epilog(ZRCVYSTK_INNER, " ZWEEPILG ")
-static int ZRCVYSTK_INNER(void) ATTRIBUTE(noinline);
-static int ZRCVYSTK_INNER(void)
+#pragma prolog(ZRCVYSTI, " ZWEPROLG NEWDSA=(YES,128),SAVE=BAKR ")
+#pragma epilog(ZRCVYSTI, " ZWEEPILG ")
+static int ZRCVYSTI(void) ATTRIBUTE(noinline);
+static int ZRCVYSTI(void)
 {
   __asm(
       "*                                                   \n"
@@ -200,7 +200,7 @@ int ZRCVYSTK(void)
       :
       : "r5", "r6", "r7", "r8", "r9", "r10", "r11");
 
-  ZRCVYSTK_INNER();
+  ZRCVYSTI();
 
   __asm(
       "*                                                   \n"

--- a/native/c/test/zrecovery.metal.test.c
+++ b/native/c/test/zrecovery.metal.test.c
@@ -162,21 +162,9 @@ static int ZRCVYSTI(void)
 #pragma epilog(ZRCVYSTK, " ZWEEPILG ")
 int ZRCVYSTK(void)
 {
-  unsigned long long int r5_before = 0;
-  unsigned long long int r6_before = 0;
-  unsigned long long int r7_before = 0;
-  unsigned long long int r8_before = 0;
-  unsigned long long int r9_before = 0;
-  unsigned long long int r10_before = 0;
-  unsigned long long int r11_before = 0;
-
-  unsigned long long int r5_after = 0;
-  unsigned long long int r6_after = 0;
-  unsigned long long int r7_after = 0;
-  unsigned long long int r8_after = 0;
-  unsigned long long int r9_after = 0;
-  unsigned long long int r10_after = 0;
-  unsigned long long int r11_after = 0;
+  unsigned long long int regs_before[7] = {0};
+  unsigned long long int regs_after[7] = {0};
+  int i;
 
   __asm(
       "*                                                   \n"
@@ -187,16 +175,9 @@ int ZRCVYSTK(void)
       " LGHI   9,1009             Set R9                   \n"
       " LGHI   10,1010            Set R10                  \n"
       " LGHI   11,1011            Set R11                  \n"
-      " STG    5,%0               Capture before R5        \n"
-      " STG    6,%1               Capture before R6        \n"
-      " STG    7,%2               Capture before R7        \n"
-      " STG    8,%3               Capture before R8        \n"
-      " STG    9,%4               Capture before R9        \n"
-      " STG    10,%5              Capture before R10       \n"
-      " STG    11,%6              Capture before R11       \n"
+      " STMG   5,11,%0            Capture before R5-R11    \n"
       "*                                                    "
-      : "=m"(r5_before), "=m"(r6_before), "=m"(r7_before), "=m"(r8_before),
-        "=m"(r9_before), "=m"(r10_before), "=m"(r11_before)
+      : "=m"(regs_before[0])
       :
       : "r5", "r6", "r7", "r8", "r9", "r10", "r11");
 
@@ -204,25 +185,18 @@ int ZRCVYSTK(void)
 
   __asm(
       "*                                                   \n"
-      " STG    5,%0               Capture after R5         \n"
-      " STG    6,%1               Capture after R6         \n"
-      " STG    7,%2               Capture after R7         \n"
-      " STG    8,%3               Capture after R8         \n"
-      " STG    9,%4               Capture after R9         \n"
-      " STG    10,%5              Capture after R10        \n"
-      " STG    11,%6              Capture after R11        \n"
+      " STMG   5,11,%0            Capture after R5-R11     \n"
       "*                                                    "
-      : "=m"(r5_after), "=m"(r6_after), "=m"(r7_after), "=m"(r8_after),
-        "=m"(r9_after), "=m"(r10_after), "=m"(r11_after)
+      : "=m"(regs_after[0])
       :
       :);
 
-  if (r5_before != r5_after || r6_before != r6_after ||
-      r7_before != r7_after || r8_before != r8_after ||
-      r9_before != r9_after || r10_before != r10_after ||
-      r11_before != r11_after)
+  for (i = 0; i < 7; i++)
   {
-    return -1;
+    if (regs_before[i] != regs_after[i])
+    {
+      return -1;
+    }
   }
 
   return 0;

--- a/native/c/test/zrecovery.metal.test.c
+++ b/native/c/test/zrecovery.metal.test.c
@@ -45,33 +45,50 @@ int ZRCVYDIS()
   return 0;
 }
 
+#pragma prolog(ZRCVYNST_INNER, " ZWEPROLG NEWDSA=(YES,128) ")
+#pragma epilog(ZRCVYNST_INNER, " ZWEEPILG ")
+static int ZRCVYNST_INNER(int *PTR64 rc2) ATTRIBUTE(noinline);
+static int ZRCVYNST_INNER(int *PTR64 rc2)
+{
+  ZRCVY_ENV zenv2 = {0};
+  if (0 == enable_recovery(&zenv2))
+  {
+    s0c3_abend(0); // Trigger inner abend -> goes to zenv2 else
+  }
+  else
+  {
+    *rc2 = 1;      // zenv2 recovery entered!
+    disable_recovery(&zenv2);
+    s0c3_abend(0); // Trigger outer abend -> goes to zenv1 else
+  }
+  return 0;
+}
+
+#pragma prolog(ZRCVYNST_HELPER, " ZWEPROLG NEWDSA=(YES,128),SAVE=BAKR ")
+#pragma epilog(ZRCVYNST_HELPER, " ZWEEPILG ")
+static int ZRCVYNST_HELPER(int *PTR64 rc2) ATTRIBUTE(noinline);
+static int ZRCVYNST_HELPER(int *PTR64 rc2)
+{
+  return ZRCVYNST_INNER(rc2);
+}
+
 #pragma prolog(ZRCVYNST, " ZWEPROLG NEWDSA=(YES,128) ")
 #pragma epilog(ZRCVYNST, " ZWEEPILG ")
 int ZRCVYNST(int *PTR64 rc1, int *PTR64 rc2)
 {
   ZRCVY_ENV zenv1 = {0};
-  ZRCVY_ENV zenv2 = {0};
   *rc1 = 0;
   *rc2 = 0;
 
   if (0 == enable_recovery(&zenv1))
   {
-    if (0 == enable_recovery(&zenv2))
-    {
-      s0c3_abend(0); // Trigger inner abend -> goes to zenv2 else
-    }
-    else
-    {
-      *rc2 = 1; // zenv2 recovery entered!
-      s0c3_abend(0); // Trigger outer abend -> goes to zenv1 else
-    }
+    ZRCVYNST_HELPER(rc2);
   }
   else
   {
     *rc1 = 1; // zenv1 recovery entered!
   }
 
-  disable_recovery(&zenv2);
   disable_recovery(&zenv1);
   return 0;
 }
@@ -123,4 +140,95 @@ int ZRCVYNUL()
 {
   // Call iefssreq with a NULL SSOB pointer (which triggers a safe error return rather than abending)
   return iefssreq(NULL);
+}
+
+#pragma prolog(ZRCVYSTK_INNER, " ZWEPROLG NEWDSA=(YES,128),SAVE=BAKR ")
+#pragma epilog(ZRCVYSTK_INNER, " ZWEEPILG ")
+static int ZRCVYSTK_INNER(void) ATTRIBUTE(noinline);
+static int ZRCVYSTK_INNER(void)
+{
+  __asm(
+      "*                                                   \n"
+      " LGHI   5,16462            Dirty R5                 \n"
+      " LGHI   6,16463            Dirty R6                 \n"
+      " LGHI   7,16464            Dirty R7                 \n"
+      " LGHI   8,16465            Dirty R8                 \n"
+      " LGHI   9,16466            Dirty R9                 \n"
+      " LGHI   10,16467           Dirty R10                \n"
+      " LGHI   11,16468           Dirty R11                \n"
+      "*                                                    "
+      :
+      :
+      : "r5", "r6", "r7", "r8", "r9", "r10", "r11");
+  return 0;
+}
+
+#pragma prolog(ZRCVYSTK, " ZWEPROLG NEWDSA=(YES,128) ")
+#pragma epilog(ZRCVYSTK, " ZWEEPILG ")
+int ZRCVYSTK(void)
+{
+  unsigned long long int r5_before = 0;
+  unsigned long long int r6_before = 0;
+  unsigned long long int r7_before = 0;
+  unsigned long long int r8_before = 0;
+  unsigned long long int r9_before = 0;
+  unsigned long long int r10_before = 0;
+  unsigned long long int r11_before = 0;
+
+  unsigned long long int r5_after = 0;
+  unsigned long long int r6_after = 0;
+  unsigned long long int r7_after = 0;
+  unsigned long long int r8_after = 0;
+  unsigned long long int r9_after = 0;
+  unsigned long long int r10_after = 0;
+  unsigned long long int r11_after = 0;
+
+  __asm(
+      "*                                                   \n"
+      " LGHI   5,1005             Set R5                   \n"
+      " LGHI   6,1006             Set R6                   \n"
+      " LGHI   7,1007             Set R7                   \n"
+      " LGHI   8,1008             Set R8                   \n"
+      " LGHI   9,1009             Set R9                   \n"
+      " LGHI   10,1010            Set R10                  \n"
+      " LGHI   11,1011            Set R11                  \n"
+      " STG    5,%0               Capture before R5        \n"
+      " STG    6,%1               Capture before R6        \n"
+      " STG    7,%2               Capture before R7        \n"
+      " STG    8,%3               Capture before R8        \n"
+      " STG    9,%4               Capture before R9        \n"
+      " STG    10,%5              Capture before R10       \n"
+      " STG    11,%6              Capture before R11       \n"
+      "*                                                    "
+      : "=m"(r5_before), "=m"(r6_before), "=m"(r7_before), "=m"(r8_before),
+        "=m"(r9_before), "=m"(r10_before), "=m"(r11_before)
+      :
+      : "r5", "r6", "r7", "r8", "r9", "r10", "r11");
+
+  ZRCVYSTK_INNER();
+
+  __asm(
+      "*                                                   \n"
+      " STG    5,%0               Capture after R5         \n"
+      " STG    6,%1               Capture after R6         \n"
+      " STG    7,%2               Capture after R7         \n"
+      " STG    8,%3               Capture after R8         \n"
+      " STG    9,%4               Capture after R9         \n"
+      " STG    10,%5              Capture after R10        \n"
+      " STG    11,%6              Capture after R11        \n"
+      "*                                                    "
+      : "=m"(r5_after), "=m"(r6_after), "=m"(r7_after), "=m"(r8_after),
+        "=m"(r9_after), "=m"(r10_after), "=m"(r11_after)
+      :
+      :);
+
+  if (r5_before != r5_after || r6_before != r6_after ||
+      r7_before != r7_after || r8_before != r8_after ||
+      r9_before != r9_after || r10_before != r10_after ||
+      r11_before != r11_after)
+  {
+    return -1;
+  }
+
+  return 0;
 }

--- a/native/c/test/zrecovery.metal.test.c
+++ b/native/c/test/zrecovery.metal.test.c
@@ -12,6 +12,7 @@
 #include "zwto.h"
 #include "zrecovery.metal.test.h"
 #include "zrecovery.h"
+#include "zssi.h"
 
 #pragma prolog(ZRCVYEN, " ZWEPROLG NEWDSA=(YES,4) ")
 #pragma epilog(ZRCVYEN, " ZWEEPILG ")
@@ -28,4 +29,98 @@ int ZRCVYEN()
 
   disable_recovery(&zenv);
   return 0;
+}
+
+#pragma prolog(ZRCVYDIS, " ZWEPROLG NEWDSA=(YES,128) ")
+#pragma epilog(ZRCVYDIS, " ZWEEPILG ")
+int ZRCVYDIS()
+{
+  ZRCVY_ENV zenv = {0};
+  if (0 == enable_recovery(&zenv))
+  {
+    // do nothing
+  }
+  disable_recovery(&zenv);
+  s0c3_abend(0);
+  return 0;
+}
+
+#pragma prolog(ZRCVYNST, " ZWEPROLG NEWDSA=(YES,128) ")
+#pragma epilog(ZRCVYNST, " ZWEEPILG ")
+int ZRCVYNST(int *PTR64 rc1, int *PTR64 rc2)
+{
+  ZRCVY_ENV zenv1 = {0};
+  ZRCVY_ENV zenv2 = {0};
+  *rc1 = 0;
+  *rc2 = 0;
+
+  if (0 == enable_recovery(&zenv1))
+  {
+    if (0 == enable_recovery(&zenv2))
+    {
+      s0c3_abend(0); // Trigger inner abend -> goes to zenv2 else
+    }
+    else
+    {
+      *rc2 = 1; // zenv2 recovery entered!
+      s0c3_abend(0); // Trigger outer abend -> goes to zenv1 else
+    }
+  }
+  else
+  {
+    *rc1 = 1; // zenv1 recovery entered!
+  }
+
+  disable_recovery(&zenv2);
+  disable_recovery(&zenv1);
+  return 0;
+}
+
+#pragma prolog(ZRCVYNCL, " ZWEPROLG NEWDSA=(YES,128) ")
+#pragma epilog(ZRCVYNCL, " ZWEEPILG ")
+int ZRCVYNCL()
+{
+  ZRCVY_ENV zenv1 = {0};
+  ZRCVY_ENV zenv2 = {0};
+
+  if (0 == enable_recovery(&zenv1))
+  {
+    if (0 == enable_recovery(&zenv2))
+    {
+      // do nothing, just establish both and exit inner
+    }
+  }
+
+  disable_recovery(&zenv2);
+  disable_recovery(&zenv1);
+  s0c3_abend(0); // This should propagate up and not be handled by either
+  return 0;
+}
+
+#pragma prolog(ZRCVYTHR, " ZWEPROLG NEWDSA=(YES,128) ")
+#pragma epilog(ZRCVYTHR, " ZWEEPILG ")
+int ZRCVYTHR(int *PTR64 thread_id, int *PTR64 rc)
+{
+  ZRCVY_ENV zenv = {0};
+  *rc = -1;
+
+  if (0 == enable_recovery(&zenv))
+  {
+    s0c3_abend(0);
+  }
+  else
+  {
+    *rc = *thread_id; // successful recovery
+  }
+
+  disable_recovery(&zenv);
+  return 0;
+}
+
+#pragma prolog(ZRCVYNUL, " ZWEPROLG NEWDSA=(YES,128) ")
+#pragma epilog(ZRCVYNUL, " ZWEEPILG ")
+int ZRCVYNUL()
+{
+  // Call iefssreq with a NULL SSOB pointer (which triggers a safe error return rather than abending)
+  return iefssreq(NULL);
 }

--- a/native/c/test/zrecovery.metal.test.h
+++ b/native/c/test/zrecovery.metal.test.h
@@ -12,6 +12,8 @@
 #ifndef ZRECOVERY_METAL_TEST_H
 #define ZRECOVERY_METAL_TEST_H
 
+#include "ztype.h"
+
 #if defined(__cplusplus) && defined(__MVS__)
 extern "OS"
 {
@@ -21,6 +23,11 @@ extern "C"
 #endif
 
   int ZRCVYEN(void);
+  int ZRCVYDIS(void);
+  int ZRCVYNST(int *PTR64 rc1, int *PTR64 rc2);
+  int ZRCVYNCL(void);
+  int ZRCVYTHR(int *PTR64 thread_id, int *PTR64 rc);
+  int ZRCVYNUL(void);
 
 #if defined(__cplusplus)
 }

--- a/native/c/test/zrecovery.metal.test.h
+++ b/native/c/test/zrecovery.metal.test.h
@@ -28,6 +28,7 @@ extern "C"
   int ZRCVYNCL(void);
   int ZRCVYTHR(int *PTR64 thread_id, int *PTR64 rc);
   int ZRCVYNUL(void);
+  int ZRCVYSTK(void);
 
 #if defined(__cplusplus)
 }

--- a/native/c/test/zrecovery.metal.test.h
+++ b/native/c/test/zrecovery.metal.test.h
@@ -26,7 +26,7 @@ extern "C"
   int ZRCVYDIS(void);
   int ZRCVYNST(int *PTR64 rc1, int *PTR64 rc2);
   int ZRCVYNCL(void);
-  int ZRCVYTHR(int *PTR64 thread_id, int *PTR64 rc);
+  int ZRCVYTHR(const int *PTR64 thread_id, int *PTR64 rc);
   int ZRCVYNUL(void);
   int ZRCVYSTK(void);
 

--- a/native/c/test/zrecovery.test.cpp
+++ b/native/c/test/zrecovery.test.cpp
@@ -39,6 +39,13 @@ void zrecovery_tests()
                   Expect(rc).ToBe(RTNCD_FAILURE);
                 });
 
+             it("should verify that the entire stack/registers are saved and restored on prolog and epilog invocation",
+                []() -> void
+                {
+                  int rc = ZRCVYSTK();
+                  Expect(rc).ToBe(0);
+                });
+
              it("should not handle abend if disable_recovery was called, so it propagates up to the test runner",
                 []() -> void
                 {
@@ -47,15 +54,15 @@ void zrecovery_tests()
                       .ToAbend();
                 });
 
-             xit("should execute recovery twice for nested recovery",
-                 []() -> void
-                 {
-                   int rc1 = 0;
-                   int rc2 = 0;
-                   ZRCVYNST(&rc1, &rc2);
-                   Expect(rc1).ToBe(1);
-                   Expect(rc2).ToBe(1);
-                 });
+             it("should execute recovery twice for nested recovery",
+                []() -> void
+                {
+                  int rc1 = 0;
+                  int rc2 = 0;
+                  ZRCVYNST(&rc1, &rc2);
+                  Expect(rc1).ToBe(1);
+                  Expect(rc2).ToBe(1);
+                });
 
              it("should cleanup recovery fully for nested recovery",
                 []() -> void
@@ -77,8 +84,7 @@ void zrecovery_tests()
                     threads.push_back(std::thread([i, &rcs]()
                                                   {
                                                     int thread_id = i;
-                                                    ZRCVYTHR(&thread_id, &rcs[i]);
-                                                  }));
+                                                    ZRCVYTHR(&thread_id, &rcs[i]); }));
                   }
 
                   for (auto &t : threads)

--- a/native/c/test/zrecovery.test.cpp
+++ b/native/c/test/zrecovery.test.cpp
@@ -11,6 +11,8 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <thread>
+#include <vector>
 
 #include "ztest.hpp"
 #include "zrecovery.metal.test.h"
@@ -28,6 +30,69 @@ void zrecovery_tests()
                 {
                   int rc = ZRCVYEN();
                   Expect(rc).ToBe(0);
+                });
+
+             it("should handle error for NULL SSOB pointer",
+                []() -> void
+                {
+                  int rc = ZRCVYNUL();
+                  Expect(rc).ToBe(RTNCD_FAILURE);
+                });
+
+             it("should not handle abend if disable_recovery was called, so it propagates up to the test runner",
+                []() -> void
+                {
+                  Expect([]()
+                         { ZRCVYDIS(); })
+                      .ToAbend();
+                });
+
+             xit("should execute recovery twice for nested recovery",
+                 []() -> void
+                 {
+                   int rc1 = 0;
+                   int rc2 = 0;
+                   ZRCVYNST(&rc1, &rc2);
+                   Expect(rc1).ToBe(1);
+                   Expect(rc2).ToBe(1);
+                 });
+
+             it("should cleanup recovery fully for nested recovery",
+                []() -> void
+                {
+                  Expect([]()
+                         { ZRCVYNCL(); })
+                      .ToAbend();
+                });
+
+             it("should handle concurrent recoveries in multiple threads",
+                []() -> void
+                {
+                  constexpr int num_threads = 5;
+                  std::vector<std::thread> threads;
+                  std::vector<int> rcs(num_threads, -1);
+
+                  for (int i = 0; i < num_threads; ++i)
+                  {
+                    threads.push_back(std::thread([i, &rcs]()
+                                                  {
+                                                    int thread_id = i;
+                                                    ZRCVYTHR(&thread_id, &rcs[i]);
+                                                  }));
+                  }
+
+                  for (auto &t : threads)
+                  {
+                    if (t.joinable())
+                    {
+                      t.join();
+                    }
+                  }
+
+                  for (int i = 0; i < num_threads; ++i)
+                  {
+                    Expect(rcs[i]).ToBe(i);
+                  }
                 });
            });
 }

--- a/native/c/zjbm.c
+++ b/native/c/zjbm.c
@@ -87,7 +87,7 @@ static void init_stat(STAT *stat)
   stat->statlen = statsize;
 }
 
-static void zjb_recovery_diag(ZJB *zjb, const char *service_name, ZRCVY_ENV *zenv)
+static void zjb_recovery_diag(ZJB *zjb, const char *service_name, const ZRCVY_ENV *zenv)
 {
   memset(zjb->diag.service_name, 0, sizeof(zjb->diag.service_name));
   strncpy(zjb->diag.service_name, service_name, sizeof(zjb->diag.service_name) - 1);

--- a/native/c/zjbm.c
+++ b/native/c/zjbm.c
@@ -94,7 +94,7 @@ static void zjb_recovery_diag(ZJB *zjb, const char *service_name, ZRCVY_ENV *zen
   zjb->diag.detail_rc = ZJB_RTNCD_UNEXPECTED_ERROR;
   zjb->diag.service_rc = zenv->abend_rc;
   zjb->diag.service_rsn = zenv->abend_rsn;
-  ZDIAG_SET_MSG(&zjb->diag, "Unexpected abend occurred during %.16s (rc:%X, rsn:%X)", 
+  ZDIAG_SET_MSG(&zjb->diag, "Unexpected abend occurred during %.16s (rc:%X, rsn:%X)",
                 service_name, zenv->abend_rc, zenv->abend_rsn);
 }
 
@@ -867,7 +867,8 @@ int ZJBMLPRC(ZJB *zjb, char *buffer, int *buffer_size, int *entries)
 
   if (0 != rc || 0 != ssob.ssobretn)
   {
-    strcpy(zjb->diag.service_name, "IEFSSREQ");
+    strncpy(zjb->diag.service_name, "IEFSSREQ", sizeof(zjb->diag.service_name) - 1);
+    zjb->diag.service_name[sizeof(zjb->diag.service_name) - 1] = '\0';
     zjb->diag.service_rc = ssob.ssobretn;
     zjb->diag.service_rsn = ssjp.ssjpretn;
     ZDIAG_SET_MSG(&zjb->diag, "IEFSSREQ rc was: '%d' SSOBRETN was: '%d', SSJPRETN was: '%d'", rc, ssob.ssobretn, ssjp.ssjpretn);

--- a/native/c/zjbm.c
+++ b/native/c/zjbm.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include "zjblkup.h"
 #include "iazjproc.h"
+#include "zrecovery.h"
 #include "zssitype.h"
 #include "zjbm.h"
 #include "zssi.h"
@@ -24,6 +25,7 @@
 #include "ihapsa.h"
 #include "cvt.h"
 #include "iefjesct.h"
+#include "ztype.h"
 
 // TODO(Kelosky):
 // https://www.ibm.com/docs/en/zos/3.1.0?topic=79-putget-requests
@@ -197,6 +199,8 @@ int ZJBMMOD(ZJB *zjb, int type, int flags)
   SSJM ssjm = {0};
   SSJF *ssjfp = NULL;
 
+  ZRCVY_ENV zenv = {0};
+
   // https://www.ibm.com/docs/en/zos/3.1.0?topic=sfcd-modify-job-function-call-ssi-function-code-85
   init_ssob(&ssob, &ssib, &ssjm, 85);
   rc = init_ssib(&ssib);
@@ -269,7 +273,16 @@ int ZJBMMOD(ZJB *zjb, int type, int flags)
 
   ssobp = &ssob;
   ssobp = (SSOB * PTR32)((unsigned int)ssobp | 0x80000000);
-  rc = iefssreq(&ssobp); // TODO(Kelosky): recovery
+  if (0 == enable_recovery(&zenv))
+  {
+    rc = iefssreq(&ssobp);
+  }
+  else
+  {
+    rc = RTNCD_FAILURE;
+  }
+
+  disable_recovery(&zenv);
 
   if (0 != rc || 0 != ssob.ssobretn)
   {
@@ -367,9 +380,20 @@ int ZJBMGJQ(ZJB *zjb, SSOB *ssobp, STAT *statp, STATJQ *PTR32 *PTR32 statjqp)
 
   SSOB *PTR32 ssobp2 = NULL;
 
+  ZRCVY_ENV zenv = {0};
+
   ssobp2 = ssobp;
   ssobp2 = (SSOB * PTR32)((unsigned int)ssobp2 | 0x80000000);
-  rc = iefssreq(&ssobp2); // TODO(Kelosky): recovery
+  if (0 == enable_recovery(&zenv))
+  {
+    rc = iefssreq(&ssobp2);
+  }
+  else
+  {
+    rc = RTNCD_FAILURE;
+  }
+
+  disable_recovery(&zenv);
 
   if (0 != rc || 0 != ssobp->ssobretn)
   {
@@ -412,6 +436,8 @@ int ZJBMTCOM(ZJB *zjb, STAT *PTR64 stat, ZJB_JOB_INFO **PTR64 job_info, int *ent
   SSOB ssob = {0};
   SSIB ssib = {0};
 
+  ZRCVY_ENV zenv = {0};
+
   // https://www.ibm.com/docs/en/zos/3.1.0?topic=sfcd-extended-status-function-call-ssi-function-code-80
   init_ssob(&ssob, &ssib, stat, 80);
   if (0 != init_ssib(&ssib))
@@ -423,7 +449,16 @@ int ZJBMTCOM(ZJB *zjb, STAT *PTR64 stat, ZJB_JOB_INFO **PTR64 job_info, int *ent
 
   ssobp = &ssob;
   ssobp = (SSOB * PTR32)((unsigned int)ssobp | 0x80000000);
-  rc = iefssreq(&ssobp); // TODO(Kelosky): recovery
+  if (0 == enable_recovery(&zenv))
+  {
+    rc = iefssreq(&ssobp);
+  }
+  else
+  {
+    rc = RTNCD_FAILURE;
+  }
+
+  disable_recovery(&zenv);
 
   if (0 != rc || 0 != ssob.ssobretn)
   {
@@ -451,8 +486,17 @@ int ZJBMTCOM(ZJB *zjb, STAT *PTR64 stat, ZJB_JOB_INFO **PTR64 job_info, int *ent
       zjb->diag.detail_rc = ZJB_RSNCD_MAX_JOBS_REACHED;
       ZDIAG_SET_MSG(&zjb->diag, "Reached maximum returned jobs requested %d", zjb->jobs_max);
       stat->stattype = statmem; // free storage
-      rc = iefssreq(&ssobp);
-      return RTNCD_WARNING;
+      if (0 == enable_recovery(&zenv))
+      {
+        rc = iefssreq(&ssobp);
+      }
+      else
+      {
+        rc = RTNCD_FAILURE;
+        disable_recovery(&zenv);
+        return rc;
+      }
+      disable_recovery(&zenv);
       break;
     }
 
@@ -496,9 +540,17 @@ int ZJBMTCOM(ZJB *zjb, STAT *PTR64 stat, ZJB_JOB_INFO **PTR64 job_info, int *ent
   zjb->buffer_size_needed = total_size;
 
   stat->stattype = statmem; // free storage
-  rc = iefssreq(&ssobp);    // TODO(Kelosky): recovery
+  if (0 == enable_recovery(&zenv))
+  {
+    rc = iefssreq(&ssobp);
+  }
+  else
+  {
+    rc = RTNCD_FAILURE;
+  }
+  disable_recovery(&zenv);
 
-  return RTNCD_SUCCESS;
+  return rc;
 }
 
 #define LOOP_MAX 100
@@ -516,6 +568,8 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
   SSOB ssob = {0};
   SSIB ssib = {0};
   STAT stat = {0};
+
+  ZRCVY_ENV zenv = {0};
 
   STATJQ *PTR32 statjqp = NULL;
   STATJQHD *PTR32 statjqhdp = NULL;
@@ -581,14 +635,30 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
     }
 
     stat.stattype = statmem; // free storage
-    rc = iefssreq(&ssobp);   // TODO(Kelosky): recovery
-    return RTNCD_FAILURE;
+    if (0 == enable_recovery(&zenv))
+    {
+      rc = iefssreq(&ssobp);
+    }
+    else
+    {
+      rc = RTNCD_FAILURE;
+    }
+    disable_recovery(&zenv);
+    return rc;
   }
 
   stat.stattrsa = statjqp;
   stat.stattype = statoutv;
 
-  rc = iefssreq(&ssobp); // TODO(Kelosky): recovery
+  if (0 == enable_recovery(&zenv))
+  {
+    rc = iefssreq(&ssobp);
+  }
+  else
+  {
+    rc = RTNCD_FAILURE;
+  }
+  disable_recovery(&zenv);
 
   if (0 != rc || 0 != ssob.ssobretn)
   {
@@ -603,6 +673,8 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
                   stat.statrea2); // STATREAS contains the reason
     return RTNCD_FAILURE;
   }
+
+  memset(&zenv, 0, sizeof(ZRCVY_ENV));
 
   statjqp = (STATJQ * PTR32) stat.statjobf;
   statvop = (STATVO * PTR32) statjqp->stjqsvrb;
@@ -627,8 +699,16 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
     }
     zjb->diag.detail_rc = ZJB_RTNCD_JOB_NOT_FOUND;
     stat.stattype = statmem; // free storage
-    rc = iefssreq(&ssobp);   // TODO(Kelosky): recovery
-    return RTNCD_FAILURE;
+    if (0 == enable_recovery(&zenv))
+    {
+      rc = iefssreq(&ssobp);
+    }
+    else
+    {
+      rc = RTNCD_FAILURE;
+    }
+    disable_recovery(&zenv);
+    return rc;
   }
 
   STATSEVB *statsetrsp = storage_get64(zjb->buffer_size);
@@ -647,10 +727,18 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
       if (loop_control >= zjb->dds_max)
       {
         stat.stattype = statmem; // free storage
-        rc = iefssreq(&ssobp);   // TODO(Kelosky): recovery
+        if (0 == enable_recovery(&zenv))
+        {
+          rc = iefssreq(&ssobp);
+        }
+        else
+        {
+          rc = RTNCD_FAILURE;
+        }
+        disable_recovery(&zenv);
         zjb->diag.detail_rc = ZJB_RSNCD_MAX_JOBS_REACHED;
         ZDIAG_SET_MSG(&zjb->diag, "max DDs reached '%d', results truncated", zjb->dds_max);
-        return RTNCD_WARNING;
+        return rc == RTNCD_FAILURE ? rc : RTNCD_WARNING;
       }
 
       total_size += (int)sizeof(STATSEVB);
@@ -681,9 +769,17 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
   zjb->buffer_size_needed = total_size;
 
   stat.stattype = statmem; // free storage
-  rc = iefssreq(&ssobp);   // TODO(Kelosky): recovery
+  if (0 == enable_recovery(&zenv))
+  {
+    rc = iefssreq(&ssobp);
+  }
+  else
+  {
+    rc = RTNCD_FAILURE;
+  }
+  disable_recovery(&zenv);
 
-  return RTNCD_SUCCESS;
+  return rc;
 }
 
 #pragma prolog(ZJBMLPRC, " ZWEPROLG NEWDSA=(YES,128) ")
@@ -698,6 +794,8 @@ int ZJBMLPRC(ZJB *zjb, char *buffer, int *buffer_size, int *entries)
   SSIB ssib = {0};
   SSJP ssjp = {0};
   JPROC jproc = {0};
+
+  ZRCVY_ENV zenv = {0};
 
   *entries = 0;
 
@@ -731,11 +829,19 @@ int ZJBMLPRC(ZJB *zjb, char *buffer, int *buffer_size, int *entries)
 
   ssobp = &ssob;
   ssobp = (SSOB * PTR32)((unsigned int)ssobp | 0x80000000);
-  rc = iefssreq(&ssobp); // TODO(Kelosky): recovery
+  if (0 == enable_recovery(&zenv))
+  {
+    rc = iefssreq(&ssobp);
+  }
+  else
+  {
+    rc = RTNCD_FAILURE;
+  }
+  disable_recovery(&zenv);
 
   if (0 != rc || 0 != ssob.ssobretn)
   {
-    strcpy(zjb->diag.service_name, "IEFSSREQ"); // TODO(Kelosky): recovery
+    strcpy(zjb->diag.service_name, "IEFSSREQ");
     zjb->diag.service_rc = ssob.ssobretn;
     zjb->diag.service_rsn = ssjp.ssjpretn;
     ZDIAG_SET_MSG(&zjb->diag, "IEFSSREQ rc was: '%d' SSOBRETN was: '%d', SSJPRETN was: '%d'", rc, ssob.ssobretn, ssjp.ssjpretn);
@@ -775,7 +881,15 @@ int ZJBMLPRC(ZJB *zjb, char *buffer, int *buffer_size, int *entries)
   }
 
   ssjp.ssjpfreq = ssjpprrs; // free storage
-  rc = iefssreq(&ssobp);    // TODO(Kelosky): recovery
+  if (0 == enable_recovery(&zenv))
+  {
+    rc = iefssreq(&ssobp);
+  }
+  else
+  {
+    rc = RTNCD_FAILURE;
+  }
+  disable_recovery(&zenv);
 
   return rc;
 }

--- a/native/c/zjbm.c
+++ b/native/c/zjbm.c
@@ -486,6 +486,7 @@ int ZJBMTCOM(ZJB *zjb, STAT *PTR64 stat, ZJB_JOB_INFO **PTR64 job_info, int *ent
       zjb->diag.detail_rc = ZJB_RSNCD_MAX_JOBS_REACHED;
       ZDIAG_SET_MSG(&zjb->diag, "Reached maximum returned jobs requested %d", zjb->jobs_max);
       stat->stattype = statmem; // free storage
+      memset(&zenv, 0, sizeof(ZRCVY_ENV));
       if (0 == enable_recovery(&zenv))
       {
         rc = iefssreq(&ssobp);
@@ -497,7 +498,7 @@ int ZJBMTCOM(ZJB *zjb, STAT *PTR64 stat, ZJB_JOB_INFO **PTR64 job_info, int *ent
         return rc;
       }
       disable_recovery(&zenv);
-      break;
+      return rc == RTNCD_FAILURE ? rc : RTNCD_WARNING;
     }
 
     total_size += (int)sizeof(ZJB_JOB_INFO);
@@ -540,6 +541,7 @@ int ZJBMTCOM(ZJB *zjb, STAT *PTR64 stat, ZJB_JOB_INFO **PTR64 job_info, int *ent
   zjb->buffer_size_needed = total_size;
 
   stat->stattype = statmem; // free storage
+  memset(&zenv, 0, sizeof(ZRCVY_ENV));
   if (0 == enable_recovery(&zenv))
   {
     rc = iefssreq(&ssobp);
@@ -644,7 +646,7 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
       rc = RTNCD_FAILURE;
     }
     disable_recovery(&zenv);
-    return rc;
+    return rc == RTNCD_FAILURE ? rc : RTNCD_FAILURE;
   }
 
   stat.stattrsa = statjqp;
@@ -699,6 +701,7 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
     }
     zjb->diag.detail_rc = ZJB_RTNCD_JOB_NOT_FOUND;
     stat.stattype = statmem; // free storage
+    memset(&zenv, 0, sizeof(ZRCVY_ENV));
     if (0 == enable_recovery(&zenv))
     {
       rc = iefssreq(&ssobp);
@@ -708,7 +711,7 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
       rc = RTNCD_FAILURE;
     }
     disable_recovery(&zenv);
-    return rc;
+    return rc == RTNCD_FAILURE ? rc : RTNCD_FAILURE;
   }
 
   STATSEVB *statsetrsp = storage_get64(zjb->buffer_size);
@@ -769,6 +772,7 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
   zjb->buffer_size_needed = total_size;
 
   stat.stattype = statmem; // free storage
+  memset(&zenv, 0, sizeof(ZRCVY_ENV));
   if (0 == enable_recovery(&zenv))
   {
     rc = iefssreq(&ssobp);
@@ -881,6 +885,7 @@ int ZJBMLPRC(ZJB *zjb, char *buffer, int *buffer_size, int *entries)
   }
 
   ssjp.ssjpfreq = ssjpprrs; // free storage
+  memset(&zenv, 0, sizeof(ZRCVY_ENV));
   if (0 == enable_recovery(&zenv))
   {
     rc = iefssreq(&ssobp);

--- a/native/c/zjbm.c
+++ b/native/c/zjbm.c
@@ -87,6 +87,17 @@ static void init_stat(STAT *stat)
   stat->statlen = statsize;
 }
 
+static void zjb_recovery_diag(ZJB *zjb, const char *service_name, ZRCVY_ENV *zenv)
+{
+  memset(zjb->diag.service_name, 0, sizeof(zjb->diag.service_name));
+  strncpy(zjb->diag.service_name, service_name, sizeof(zjb->diag.service_name) - 1);
+  zjb->diag.detail_rc = ZJB_RTNCD_UNEXPECTED_ERROR;
+  zjb->diag.service_rc = zenv->abend_rc;
+  zjb->diag.service_rsn = zenv->abend_rsn;
+  ZDIAG_SET_MSG(&zjb->diag, "Unexpected abend occurred during %.16s (rc:%X, rsn:%X)", 
+                service_name, zenv->abend_rc, zenv->abend_rsn);
+}
+
 #pragma prolog(ZJBSYMB, " ZWEPROLG NEWDSA=(YES,128) ")
 #pragma epilog(ZJBSYMB, " ZWEEPILG ")
 int ZJBSYMB(ZJB *zjb, const char *symbol, char *value, int *value_size)
@@ -279,6 +290,7 @@ int ZJBMMOD(ZJB *zjb, int type, int flags)
   }
   else
   {
+    zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
     rc = RTNCD_FAILURE;
   }
 
@@ -390,6 +402,7 @@ int ZJBMGJQ(ZJB *zjb, SSOB *ssobp, STAT *statp, STATJQ *PTR32 *PTR32 statjqp)
   }
   else
   {
+    zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
     rc = RTNCD_FAILURE;
   }
 
@@ -455,6 +468,7 @@ int ZJBMTCOM(ZJB *zjb, STAT *PTR64 stat, ZJB_JOB_INFO **PTR64 job_info, int *ent
   }
   else
   {
+    zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
     rc = RTNCD_FAILURE;
   }
 
@@ -493,6 +507,7 @@ int ZJBMTCOM(ZJB *zjb, STAT *PTR64 stat, ZJB_JOB_INFO **PTR64 job_info, int *ent
       }
       else
       {
+        zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
         rc = RTNCD_FAILURE;
         disable_recovery(&zenv);
         return rc;
@@ -548,6 +563,7 @@ int ZJBMTCOM(ZJB *zjb, STAT *PTR64 stat, ZJB_JOB_INFO **PTR64 job_info, int *ent
   }
   else
   {
+    zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
     rc = RTNCD_FAILURE;
   }
   disable_recovery(&zenv);
@@ -643,6 +659,7 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
     }
     else
     {
+      zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
       rc = RTNCD_FAILURE;
     }
     disable_recovery(&zenv);
@@ -658,6 +675,7 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
   }
   else
   {
+    zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
     rc = RTNCD_FAILURE;
   }
   disable_recovery(&zenv);
@@ -708,6 +726,7 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
     }
     else
     {
+      zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
       rc = RTNCD_FAILURE;
     }
     disable_recovery(&zenv);
@@ -736,6 +755,7 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
         }
         else
         {
+          zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
           rc = RTNCD_FAILURE;
         }
         disable_recovery(&zenv);
@@ -779,6 +799,7 @@ int ZJBMLSDS(ZJB *PTR64 zjb, STATSEVB **PTR64 sysoutInfo, int *entries)
   }
   else
   {
+    zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
     rc = RTNCD_FAILURE;
   }
   disable_recovery(&zenv);
@@ -839,6 +860,7 @@ int ZJBMLPRC(ZJB *zjb, char *buffer, int *buffer_size, int *entries)
   }
   else
   {
+    zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
     rc = RTNCD_FAILURE;
   }
   disable_recovery(&zenv);
@@ -892,6 +914,7 @@ int ZJBMLPRC(ZJB *zjb, char *buffer, int *buffer_size, int *entries)
   }
   else
   {
+    zjb_recovery_diag(zjb, "IEFSSREQ", &zenv);
     rc = RTNCD_FAILURE;
   }
   disable_recovery(&zenv);

--- a/native/c/zssi.h
+++ b/native/c/zssi.h
@@ -131,6 +131,11 @@ static int iefssi_query(JQRY_HEADER *PTR32 *PTR32 area, int *PTR32 rsn, const ch
 // https://www.ibm.com/docs/en/zos/3.1.0?topic=subsystem-making-request-iefssreq-macro
 static int iefssreq(SSOB *PTR32 *PTR32 ssob)
 {
+  if (!ssob)
+  {
+    return RTNCD_FAILURE;
+  }
+
   int rc = 0;
   IEFSSREQ(ssob, rc);
   return rc;


### PR DESCRIPTION
**What It Does**

- Adds `enable_recovery` / `disable_recovery` pattern around IEFSSREQ invocation (`iefssreq` thunk)
- Adds diagnostic helper function `zjb_recovery_diag` that populates abend information into ZDIAG when abend is encountered 

**How to Test**
- Build and run tests on an LPAR (`npm run z:rebuild && npm run z:test`)
- All tests (pre-existing and new cases) should pass 😋 
- Test pre-existing commands in `zowex` and in the CLI plug-in; operations should succeed identically to `main`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)