### PR TITLE
Fix reading job spool and timestamps in syslog

### DIFF
--- a/native/c/commands/system.cpp
+++ b/native/c/commands/system.cpp
@@ -181,7 +181,7 @@ int handle_system_view_syslog(InvocationContext &context)
     }
     strftime(buf, sizeof(buf), "%Y-%m-%d", tm_start);
     date_value = buf;
-    strftime(buf, sizeof(buf), "%H:%M:%S.00", tm_start);
+    strftime(buf, sizeof(buf), "%H:%M:%S", tm_start);
     time_value = buf;
   }
   else

--- a/native/c/test/zowex.system.test.cpp
+++ b/native/c/test/zowex.system.test.cpp
@@ -338,7 +338,7 @@ void zowex_system_tests()
                   auto end_pos = stderr1.find("End: ");
                   Expect(end_pos).Not().ToBe(string::npos);
                   string end_date = stderr1.substr(end_pos + 5, 10);
-                  string end_time = stderr1.substr(end_pos + 13, 8);
+                  string end_time = stderr1.substr(end_pos + 16, 8);
 
                   string stdout2, stderr2;
                   rc = execute_command(zowex_command + " system view-syslog --date " + end_date + " --time " + end_time + " --max-lines 3", stdout2, stderr2);

--- a/native/c/zjb.cpp
+++ b/native/c/zjb.cpp
@@ -191,8 +191,7 @@ int zjb_read_job_jcl(ZJB *zjb, const std::string &jobid, std::string &response)
 #define NUM_TEXT_UNITS 5
 
 // Disable optimization for this function since `ibm-clang` -O2 removes required assignments.
-static int zjb_read_job_dynamic_allocation(ZJB *zjb, std::string jobdsn, std::string &ddname) ATTRIBUTE(optnone);
-static int zjb_read_job_dynamic_allocation(ZJB *zjb, std::string jobdsn, std::string &ddname)
+__attribute__((optnone)) static int zjb_read_job_dynamic_allocation(ZJB *zjb, std::string jobdsn, std::string &ddname)
 {
   int rc = 0;
 
@@ -458,13 +457,7 @@ int zjb_read_syslog(ZJB *zjb, ZJBSyslogOptions &opts, ZJBSyslogResponse &respons
     //
     uint32_t utc_cs = 0;
     memcpy(&utc_cs, &zds.ts_binary, sizeof(utc_cs));
-    const int64_t cs_per_day = 24LL * 360000LL; // Number of centiseconds in a day
-    int64_t local_cs = (int64_t)utc_cs + (int64_t)tz_offset_cs;
-    local_cs %= cs_per_day;
-    if (local_cs < 0)
-    {
-      local_cs += cs_per_day;
-    }
+    uint32_t local_cs = utc_cs + (uint32_t)tz_offset_cs;
     unsigned end_hh = local_cs / 360000U;
     unsigned end_mm = (local_cs / 6000U) % 60U;
     unsigned end_ss = (local_cs / 100U) % 60U;

--- a/native/c/zjb.cpp
+++ b/native/c/zjb.cpp
@@ -247,7 +247,7 @@ __attribute__((optnone)) static int zjb_read_job_dynamic_allocation(ZJB *zjb, st
 
   if (use_stvsctkn)
   {
-    memcpy(&iazbtokp->btokiotp[0], &token31, 4);
+    memcpy(&iazbtokp->btokiotp[0], &token31, sizeof(token31));
   }
 
   memcpy(iazbtokp->btokpl3, &len, sizeof(len));
@@ -490,7 +490,7 @@ int zjb_read_job_content_by_dsn(ZJB *zjb, const std::string &dsn, std::string &r
   ZDS zds = {};
 
   std::string parsed_jobid;
-  int parsed_key;
+  int parsed_key = 0;
 
   // parse dsn for jobid and key - if found, attempt to get the token for the dsn
   memset(zjb->token, 0, sizeof(zjb->token));

--- a/native/c/zjb.cpp
+++ b/native/c/zjb.cpp
@@ -191,7 +191,8 @@ int zjb_read_job_jcl(ZJB *zjb, const std::string &jobid, std::string &response)
 #define NUM_TEXT_UNITS 5
 
 // Disable optimization for this function since `ibm-clang` -O2 removes required assignments.
-__attribute__((optnone)) static int zjb_read_job_dynamic_allocation(ZJB *zjb, std::string jobdsn, std::string &ddname)
+static int zjb_read_job_dynamic_allocation(ZJB *zjb, std::string jobdsn, std::string &ddname) ATTRIBUTE(optnone);
+static int zjb_read_job_dynamic_allocation(ZJB *zjb, std::string jobdsn, std::string &ddname)
 {
   int rc = 0;
 

--- a/native/c/zjb.cpp
+++ b/native/c/zjb.cpp
@@ -190,7 +190,8 @@ int zjb_read_job_jcl(ZJB *zjb, const std::string &jobid, std::string &response)
 
 #define NUM_TEXT_UNITS 5
 
-static int zjb_read_job_dynamic_allocation(ZJB *zjb, std::string jobdsn, std::string &ddname)
+// Disable optimization for this function since `ibm-clang` -O2 removes required assignments.
+__attribute__((optnone)) static int zjb_read_job_dynamic_allocation(ZJB *zjb, std::string jobdsn, std::string &ddname)
 {
   int rc = 0;
 
@@ -333,13 +334,6 @@ static int zjb_read_job_dynamic_allocation(ZJB *zjb, std::string jobdsn, std::st
   s99parms->__S99FLAG1 = 0x4000;  // s99nocnv;
   s99parms->__S99TXTPP = s99tupl;
 
-  // NOTE(Kelosky): `ibm-clang` appears to optimize the previous assignments, so this approach is to
-  // force the compiler to not optimize the assignments.
-  unsigned char size = sizeof(__S99parms);
-  unsigned char verb = s99vrbal;
-  memcpy(&s99parms->__S99RBLN, &size, sizeof(size));
-  memcpy(&s99parms->__S99VERB, &verb, sizeof(verb));
-
   // s99parms->__S99S99X = s99parmsx; // TODO(Kelosky): reenable when we look at s99parmsx->__S99ENMSG and free
 
   // https://www.ibm.com/docs/en/zos/3.1.0?topic=list-coding-dynamic-allocation-request
@@ -463,7 +457,13 @@ int zjb_read_syslog(ZJB *zjb, ZJBSyslogOptions &opts, ZJBSyslogResponse &respons
     //
     uint32_t utc_cs = 0;
     memcpy(&utc_cs, &zds.ts_binary, sizeof(utc_cs));
-    uint32_t local_cs = utc_cs + (uint32_t)tz_offset_cs;
+    const int64_t cs_per_day = 24LL * 360000LL; // Number of centiseconds in a day
+    int64_t local_cs = (int64_t)utc_cs + (int64_t)tz_offset_cs;
+    local_cs %= cs_per_day;
+    if (local_cs < 0)
+    {
+      local_cs += cs_per_day;
+    }
     unsigned end_hh = local_cs / 360000U;
     unsigned end_mm = (local_cs / 6000U) % 60U;
     unsigned end_ss = (local_cs / 100U) % 60U;


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes reading job spool which failed in release build, and syslog timestamps which failed in system tests

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
See that tests are passing in internal pipeline (build # 115).
There are only 2 known test failures (`chown` and DCB abend handling).

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
