### PR TITLE
Update z/OS Workflow compiler version

### DIFF
--- a/.github/workflows/zos-build.yml
+++ b/.github/workflows/zos-build.yml
@@ -53,7 +53,7 @@ jobs:
                 user: "${{ secrets.SSH_MARIST_ZNP_ID }}"
                 password: "${{ secrets.SSH_MARIST_ZNP_PASS }}"
               deployDir: "/ZOWE/tmp/zowex"
-              preBuildCmd: "export PATH=/usr/lpp/IBM/cnw/v2r1/openxl/bin:$PATH"
+              preBuildCmd: "export PATH=/usr/lpp/IBM/cnw/v2r2/openxl/bin:$PATH"
           EOF
 
       - name: Install Dependencies


### PR DESCRIPTION
Updates z/OS Build workflow to use Open XL C/C++ 2.2. Not expected to fix [failing test cases](https://github.com/zowe/zowex/actions/runs/26976614916/job/79605136957) in main.