### PR TITLE
ci: Split out z/OS tests into separate workflow step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,17 +45,17 @@ jobs:
           script: |
             const artifactName = "zowe-server-bin";
             const runId = process.env.RUN_ID;
-            const timeoutMs = 10 * 60 * 1000;
+            const timeoutMs = 30 * 60 * 1000;
             const intervalMs = 5 * 1000;
             const deadline = Date.now() + timeoutMs;
             let attempts = 0;
-            const isRunning = async () => {
+            const isCompleted = async () => {
               const { data: run } = await github.rest.actions.getWorkflowRun({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id: runId,
               });
-              return run.status === "in_progress";
+              return run.status === "completed";
             };
             const hasArtifact = async () => {
               const { data } = await github.rest.actions.listWorkflowRunArtifacts({
@@ -67,7 +67,7 @@ jobs:
             };
             while (Date.now() < deadline) {
               core.info(`Checking for artifact "${artifactName}" (attempt ${++attempts})...`);
-              if (!(await isRunning())) {
+              if (await isCompleted()) {
                 core.setFailed(`z/OS build run ${runId} completed without producing "${artifactName}"`);
                 return;
               }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,43 @@ jobs:
 
       - name: Watch z/OS build
         if: ${{ matrix.os == 'ubuntu' }}
-        run: |
-          [ -z "$RUN_ID" ] || gh run watch $RUN_ID
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifactName = "zowe-server-bin";
+            const timeoutMs = 10 * 60 * 1000;
+            const intervalMs = 5 * 1000;
+            const deadline = Date.now() + timeoutMs;
+            const attempts = 0;
+            const isRunning = async () => {
+              const { data: run } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              });
+              return run.status === "in_progress";
+            };
+            const hasArtifact = async () => {
+              const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              });
+              return data.artifacts.some((a) => a.name === artifactName);
+            };
+            while (Date.now() < deadline) {
+              core.info(`Checking for artifact "${artifactName}" (attempt ${++attempts})...`);
+              if (!(await isRunning())) {
+                core.setFailed(`z/OS build run ${runId} completed without producing "${artifactName}"`);
+                return;
+              }
+              if (await hasArtifact()) {
+                core.info(`Artifact "${artifactName}" is available`);
+                return;
+              }
+              await new Promise((r) => setTimeout(r, intervalMs));
+            }
+            core.setFailed(`Timed out after 10 minutes waiting for "${artifactName}"`);
 
       - name: Download server PAX into SDK bin
         if: ${{ matrix.os == 'ubuntu' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
               }
               await new Promise((r) => setTimeout(r, intervalMs));
             }
-            core.setFailed(`Timed out after 10 minutes waiting for "${artifactName}"`);
+            core.setFailed(`Timed out after ${Math.round(timeoutMs / 60000)} minutes waiting for "${artifactName}"`);
 
       - name: Download server PAX into SDK bin
         if: ${{ matrix.os == 'ubuntu' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,14 +49,6 @@ jobs:
             const intervalMs = 5 * 1000;
             const deadline = Date.now() + timeoutMs;
             let attempts = 0;
-            const isCompleted = async () => {
-              const { data: run } = await github.rest.actions.getWorkflowRun({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: runId,
-              });
-              return run.status === "completed";
-            };
             const hasArtifact = async () => {
               const { data } = await github.rest.actions.listWorkflowRunArtifacts({
                 owner: context.repo.owner,
@@ -65,14 +57,22 @@ jobs:
               });
               return data.artifacts.some((a) => a.name === artifactName);
             };
+            const isCompleted = async () => {
+              const { data: run } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              });
+              return run.status === "completed";
+            };
             while (Date.now() < deadline) {
               core.info(`Checking for artifact "${artifactName}" (attempt ${++attempts} of ${Math.ceil(timeoutMs / intervalMs)})...`);
-              if (await isCompleted()) {
-                core.setFailed(`z/OS build run ${runId} completed without producing "${artifactName}"`);
-                return;
-              }
               if (await hasArtifact()) {
                 core.info(`Artifact "${artifactName}" is available`);
+                return;
+              }
+              if (await isCompleted()) {
+                core.setFailed(`z/OS build run ${runId} completed without producing "${artifactName}"`);
                 return;
               }
               await new Promise((r) => setTimeout(r, intervalMs));

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Watch z/OS build
-        if: ${{ matrix.os == 'ubuntu' }}
+        if: ${{ matrix.os == 'ubuntu' && env.RUN_ID }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           script: |
             const artifactName = "zowe-server-bin";
+            const runId = process.env.RUN_ID;
             const timeoutMs = 10 * 60 * 1000;
             const intervalMs = 5 * 1000;
             const deadline = Date.now() + timeoutMs;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
             const timeoutMs = 10 * 60 * 1000;
             const intervalMs = 5 * 1000;
             const deadline = Date.now() + timeoutMs;
-            const attempts = 0;
+            let attempts = 0;
             const isRunning = async () => {
               const { data: run } = await github.rest.actions.getWorkflowRun({
                 owner: context.repo.owner,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
               return data.artifacts.some((a) => a.name === artifactName);
             };
             while (Date.now() < deadline) {
-              core.info(`Checking for artifact "${artifactName}" (attempt ${++attempts})...`);
+              core.info(`Checking for artifact "${artifactName}" (attempt ${++attempts} of ${Math.ceil(timeoutMs / intervalMs)})...`);
               if (await isCompleted()) {
                 core.setFailed(`z/OS build run ${runId} completed without producing "${artifactName}"`);
                 return;

--- a/.github/workflows/zos-build.yml
+++ b/.github/workflows/zos-build.yml
@@ -64,7 +64,7 @@ jobs:
         run: npm pkg set version=${{ inputs.version }}
 
       - name: Build on z/OS
-        run: npm run z:all
+        run: npm run z:build && npm run z:package
 
       - uses: actions/upload-artifact@v4
         with:
@@ -86,6 +86,9 @@ jobs:
           message: |
             Server artifacts:
              - PAX: ${{ steps.pax-artifact-upload.outputs.artifact-url }}
+
+      - name: Test on z/OS
+        run: npm run z:test
 
       - name: Test Report
         uses: dorny/test-reporter@v2

--- a/.github/workflows/zos-build.yml
+++ b/.github/workflows/zos-build.yml
@@ -64,7 +64,7 @@ jobs:
         run: npm pkg set version=${{ inputs.version }}
 
       - name: Build on z/OS
-        run: npm run z:build && npm run z:package
+        run: npm run z:rebuild && npm run z:package
 
       - uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "tools": "tsx scripts/buildTools.ts",
     "watch": "npm run watch --workspaces",
     "watch:all": "concurrently \"npm run z:watch\" \"npm run watch\"",
-    "z:all": "npm run z:rebuild && npm run z:test && npm run z:package",
+    "z:all": "npm run z:rebuild && npm run z:package && npm run z:test",
     "z:artifacts": "tsx scripts/buildTools.ts artifacts",
     "z:build": "tsx scripts/buildTools.ts build",
     "z:build:python": "tsx scripts/buildTools.ts build:python",


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
* Uploads server PAX artifact earlier during the `zos-build` workflow before tests run
* Optimizes `build` workflow to download `zowex-sdk` artifact as soon as it's available
* Also updates the `npm run z:all` script so that package happens before test

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
See that the `build` workflow for Ubuntu passed 😋 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
