### PR TITLE
Add List APF and PROCLIB Data Sets to SDK

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Added support for listing APF and PROCLIB data sets to JSON-RPC server.
 - `c`: Fix regression on ENQ qname.  [#1027](https://github.com/zowe/zowex/issues/1027)
 - `c`: Added z/OS recovery around JES operations in the `zowex` CLI binary to allow recovering from abends. [#1011](https://github.com/zowe/zowex/pull/1011)
 - **Breaking:** `c`: Renamed C function `zjb_read_jobs_output_by_key` in zjb.hpp to `zjb_read_job_content_by_key` to be consistent with `zjb_read_job_content_by_dsn.

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Fix regression on ENQ qname.  [#1027](https://github.com/zowe/zowex/issues/1027)
 - `c`: Added z/OS recovery around JES operations in the `zowex` CLI binary to allow recovering from abends. [#1011](https://github.com/zowe/zowex/pull/1011)
 - **Breaking:** `c`: Renamed C function `zjb_read_jobs_output_by_key` in zjb.hpp to `zjb_read_job_content_by_key` to be consistent with `zjb_read_job_content_by_dsn.
 - `c`: Fixes issue where `zowex` failed to allocate `sysout` DDs that were dynamically allocated under z/OS UNIX. [#840](https://github.com/zowe/zowex/issues/840)

--- a/native/c/commands/system.cpp
+++ b/native/c/commands/system.cpp
@@ -78,10 +78,18 @@ int handle_system_list_proclib(InvocationContext &context)
     return RTNCD_FAILURE;
   }
 
-  for (vector<string>::iterator it = proclib.begin(); it != proclib.end(); it++)
+  const auto result = obj();
+  const auto items = arr();
+  
+  for (const auto &dsn : proclib)
   {
-    context.output_stream() << *it << endl;
+    context.output_stream() << dsn << endl;
+    items->push(str(dsn));
   }
+  
+  result->set("items", items);
+  result->set("returnedRows", i64(proclib.size()));
+  context.set_object(result);
 
   return RTNCD_SUCCESS;
 }
@@ -292,12 +300,27 @@ int handle_system_list_apf(InvocationContext &context)
     context.error_stream() << "  Details: " << diag.e_msg << endl;
     return RTNCD_FAILURE;
   }
-  for (std::vector<std::pair<std::string, std::string>>::iterator it = apf.begin(); it != apf.end(); it++)
+
+  const auto result = obj();
+  const auto items = arr();
+  
+  for (const auto &entry : apf)
   {
-    context.output_stream() << setw(44) << left << it->first << " " << setw(6) << right << it->second << endl;
+    context.output_stream() << setw(44) << left << entry.first << " " << setw(6) << right << entry.second << endl;
+    
+    const auto item = obj();
+    item->set("dsname", str(entry.first));
+    item->set("volume", str(entry.second));
+    items->push(item);
   }
+  
+  result->set("items", items);
+  result->set("returnedRows", i64(apf.size()));
+  context.set_object(result);
+  
   return RTNCD_SUCCESS;
 }
+
 
 void register_commands(parser::Command &root_command)
 {

--- a/native/c/server/rpc_commands.cpp
+++ b/native/c/server/rpc_commands.cpp
@@ -223,6 +223,10 @@ void register_system_commands(CommandDispatcher &dispatcher)
                                   .rename_arg("secondsAgo", "seconds-ago")
                                   .rename_arg("maxLines", "max-lines")
                                   .read_stdout("data", false));
+  dispatcher.register_command("listProclib",
+                              CommandBuilder(sys::handle_system_list_proclib));
+  dispatcher.register_command("listApf",
+                              CommandBuilder(sys::handle_system_list_apf));
 }
 
 void register_all_commands(CommandDispatcher &dispatcher)

--- a/native/c/server/schemas/requests.hpp
+++ b/native/c/server/schemas/requests.hpp
@@ -204,6 +204,10 @@ ZJSON_SCHEMA(ViewSyslogRequest,
     FIELD_OPTIONAL(maxLines, NUMBER)
 );
 
+struct ListProclibRequest {};
+
+struct ListApfRequest {};
+
 struct ToolSearchRequest {};
 ZJSON_SCHEMA(ToolSearchRequest,
     FIELD_REQUIRED(dsname, STRING),

--- a/native/c/server/schemas/responses.hpp
+++ b/native/c/server/schemas/responses.hpp
@@ -269,6 +269,20 @@ ZJSON_SCHEMA(ViewSyslogResponse,
     FIELD_OPTIONAL(hasMore, BOOL)
 );
 
+struct ListProclibResponse {};
+ZJSON_SCHEMA(ListProclibResponse,
+    FIELD_REQUIRED(success, BOOL),
+    FIELD_REQUIRED_ARRAY(items, STRING),
+    FIELD_REQUIRED(returnedRows, NUMBER)
+);
+
+struct ListApfResponse {};
+ZJSON_SCHEMA(ListApfResponse,
+    FIELD_REQUIRED(success, BOOL),
+    FIELD_REQUIRED_ARRAY(items, ANY),
+    FIELD_REQUIRED(returnedRows, NUMBER)
+);
+
 struct ToolSearchResponse {};
 ZJSON_SCHEMA(ToolSearchResponse,
     FIELD_REQUIRED(success, BOOL),

--- a/native/c/zam.c
+++ b/native/c/zam.c
@@ -99,7 +99,7 @@ static int enq_data_set(ZDIAG *PTR32 diag, IO_CTRL *PTR32 ioc)
   int rc = 0;
   QNAME qname = {0};
   RNAME rname = {0};
-  strcpy(qname.value, "SPFEDIT ");
+  memcpy(qname.value, "SPFEDIT ", sizeof(qname.value));
   rname.rlen = sprintf(rname.value, "%.*s%.*s", sizeof(ioc->jfcb.jfcbdsnm), ioc->jfcb.jfcbdsnm, sizeof(ioc->jfcb.jfcbelnm), ioc->jfcb.jfcbelnm);
   rc = enq(&qname, &rname);
 

--- a/native/c/zam.c
+++ b/native/c/zam.c
@@ -64,7 +64,7 @@ static int handle_dcb_abend(ZDIAG *PTR32 diag, IO_CTRL *PTR32 ioc, const char *P
     {
       strcpy(diag->service_name, operation);
       ZDIAG_SET_MSG(diag, "DCB abend during %.16s for %8.8s data set: %44.44s",
-                                operation, ioc->ddname, ioc->jfcb.jfcbdsnm);
+                    operation, ioc->ddname, ioc->jfcb.jfcbdsnm);
       diag->detail_rc = ZDS_RTNCD_DCB_ABEND_ERROR;
     }
     return RTNCD_FAILURE;
@@ -99,7 +99,7 @@ static int enq_data_set(ZDIAG *PTR32 diag, IO_CTRL *PTR32 ioc)
   int rc = 0;
   QNAME qname = {0};
   RNAME rname = {0};
-  strcpy(qname.value, "SPFEDIT");
+  strcpy(qname.value, "SPFEDIT ");
   rname.rlen = sprintf(rname.value, "%.*s%.*s", sizeof(ioc->jfcb.jfcbdsnm), ioc->jfcb.jfcbdsnm, sizeof(ioc->jfcb.jfcbelnm), ioc->jfcb.jfcbelnm);
   rc = enq(&qname, &rname);
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- Added support to list APF and PROCLIB data sets.
 - Added support for viewing syslog.
 
 ## `0.6.0`

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- Added support to list APF and PROCLIB data sets.
+- Added support to list APF and PROCLIB data sets. [#1029](https://github.com/zowe/zowex/pull/1029)
 - Added support for viewing syslog.
 
 ## `0.6.0`

--- a/packages/sdk/src/RpcClientApi.ts
+++ b/packages/sdk/src/RpcClientApi.ts
@@ -58,6 +58,8 @@ export abstract class RpcClientApi implements IRpcClient {
 
     public system = {
         viewSyslog: this.rpc<system.ViewSyslogRequest, system.ViewSyslogResponse>("viewSyslog"),
+        listProclib: this.rpc<system.ListProclibRequest, system.ListProclibResponse>("listProclib"),
+        listApf: this.rpc<system.ListApfRequest, system.ListApfResponse>("listApf"),
     };
 
     public tool = {

--- a/packages/sdk/src/doc/rpc/system.ts
+++ b/packages/sdk/src/doc/rpc/system.ts
@@ -62,3 +62,40 @@ export interface ViewSyslogResponse extends common.CommandResponse {
      */
     hasMore?: boolean;
 }
+
+export interface ListProclibRequest extends common.CommandRequest<"listProclib"> {}
+
+export interface ListProclibResponse extends common.CommandResponse {
+    /**
+     * List of proclib data set names.
+     */
+    items: string[];
+    /**
+     * Number of rows returned.
+     */
+    returnedRows: number;
+}
+
+export interface ListApfRequest extends common.CommandRequest<"listApf"> {}
+
+export interface ApfDataset {
+    /**
+     * Data set name.
+     */
+    dsname: string;
+    /**
+     * Volume serial.
+     */
+    volume: string;
+}
+
+export interface ListApfResponse extends common.CommandResponse {
+    /**
+     * List of APF data sets.
+     */
+    items: ApfDataset[];
+    /**
+     * Number of rows returned.
+     */
+    returnedRows: number;
+}


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

- adds SDK methods for listing APF & PROCLIB data sets

APF example:

```
{
  success: true,
  returnedRows: 68,
  items: [
    { volume: 'MVZ31A', dsname: 'SYS1.LINKLIB' },
    { volume: 'MVZ31A', dsname: 'SYS1.SVCLIB' },
    { volume: 'MVZ31A', dsname: 'BPN.SBPNLOAD' },
    { volume: 'MVZ31A', dsname: 'CEE.SCEELKED' },
    { volume: 'MVZ31A', dsname: 'CEE.SCEERUN' },
    { volume: 'MVZ31A', dsname: 'CEE.SCEERUN2' },
```

PROCLIB example:

```
{
  success: true,
  returnedRows: 3,
  items: [
    'SYS1.PROCLIB                                ',
    'PRODUCT.PROCLIB                             ',
    'SYS1.IBM.PROCLIB                            '
  ]
}
```

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
