### PR TITLE
fix: SPFEDIT string missing space for qname

### DIFF
--- a/native/c/examples/ams/ams.c
+++ b/native/c/examples/ams/ams.c
@@ -192,7 +192,7 @@ int AMSMAIN(const char *ddname)
     return -1;
   }
 
-  strcpy(resources.qname.value, "SPFEDIT ");
+  memcpy(resources.qname.value, "SPFEDIT ", sizeof(resources.qname.value));
   resources.rname.rlen = sprintf(resources.rname.value, "%.*s%.*s", sizeof(resources.sysprint->jfcb.jfcbdsnm), resources.sysprint->jfcb.jfcbdsnm, sizeof(resources.sysprint->jfcb.jfcbelnm), resources.sysprint->jfcb.jfcbelnm);
 
   rc = enq(&resources.qname, &resources.rname); // TODO(Kelosky): before open? How is directory entry protected?

--- a/native/c/zam.c
+++ b/native/c/zam.c
@@ -160,7 +160,7 @@ static int reserve_data_set(ZDIAG *PTR32 diag, IO_CTRL *PTR32 ioc)
   int rc = 0;
   QNAME qname_reserve = {0};
   RNAME rname_reserve = {0};
-  strcpy(qname_reserve.value, "SPFEDIT");
+  memcpy(qname_reserve.value, "SPFEDIT ", sizeof(qname_reserve.value));
   rname_reserve.rlen = sprintf(rname_reserve.value, "%.*s", sizeof(ioc->jfcb.jfcbdsnm), ioc->jfcb.jfcbdsnm);
   rc = reserve(&qname_reserve, &rname_reserve, (UCB * PTR32) ioc->ucb);
   if (0 != rc)
@@ -962,7 +962,7 @@ static int deq_reserve_data_set(ZDIAG *PTR32 diag, IO_CTRL *PTR32 ioc)
   {
     QNAME qname_reserve = {0};
     RNAME rname_reserve = {0};
-    strcpy(qname_reserve.value, "SPFEDIT");
+    memcpy(qname_reserve.value, "SPFEDIT ", sizeof(qname_reserve.value));
     rname_reserve.rlen = sprintf(rname_reserve.value, "%.*s", sizeof(ioc->jfcb.jfcbdsnm), ioc->jfcb.jfcbdsnm);
     rc = deq_reserve(&qname_reserve, &rname_reserve, (UCB * PTR32) ioc->ucb);
     if (0 != rc)
@@ -988,7 +988,7 @@ static int deq_data_set(ZDIAG *PTR32 diag, IO_CTRL *PTR32 ioc)
   {
     RNAME rname = {0};
     QNAME qname = {0};
-    strcpy(qname.value, "SPFEDIT");
+    memcpy(qname.value, "SPFEDIT ", sizeof(qname.value));
     rname.rlen = sprintf(rname.value, "%.*s%.*s", sizeof(ioc->jfcb.jfcbdsnm), ioc->jfcb.jfcbdsnm, sizeof(ioc->jfcb.jfcbelnm), ioc->jfcb.jfcbelnm);
     rc = deq(&qname, &rname);
     if (0 != rc)


### PR DESCRIPTION
**What It Does**

Fixes failing tests on `main` by adding the missing space in `SPFEDIT ` so that the QNAMEs match ISPF's and the enq/deq works as expected.

**How to Test**

- `npm run z:rebuild && npm run z:test` should pass w/o any write data set or create member test failures

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
