### PR TITLE
fix: BPAM writes now produce self-contained records

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,10 +6,11 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Fixed an issue where data set member write operations did not produce self-contained records for stateful mixed single-byte and double-byte character sets. Now, each record written to a data set member is self-contained to avoid code page conversion errors. [#1049](https://github.com/zowe/zowex/pull/1049)
 - `c`: Fixed an issue where the `zowex ds copy` command would fail to allocate DDs when copying PDS members in parallel. [#994](https://github.com/zowe/zowex/issues/994)
 - `c`: Added support for listing APF and PROCLIB data sets to JSON-RPC server.
 - `c`: Optimized Adler32 calculations to compute e-tags incrementally during streamed data set downloads. This significantly reduces memory footprint and resolves a failure when downloading large data sets. [#1016](https://github.com/zowe/zowex/issues/1016)
-- `c`: Fix regression on ENQ qname.  [#1027](https://github.com/zowe/zowex/issues/1027)
+- `c`: Fix regression on ENQ qname. [#1027](https://github.com/zowe/zowex/issues/1027)
 - `c`: Added z/OS recovery around JES operations in the `zowex` CLI binary to allow recovering from abends. [#1011](https://github.com/zowe/zowex/pull/1011)
 - **Breaking:** `c`: Renamed C function `zjb_read_jobs_output_by_key` in zjb.hpp to `zjb_read_job_content_by_key` to be consistent with `zjb_read_job_content_by_dsn.
 - `c`: Fixes issue where `zowex` failed to allocate `sysout` DDs that were dynamically allocated under z/OS UNIX. [#840](https://github.com/zowe/zowex/issues/840)

--- a/native/c/test/zds.test.cpp
+++ b/native/c/test/zds.test.cpp
@@ -621,6 +621,112 @@ void zds_tests()
                            });
                       });
 
+             // Regression tests for writing DBCS content to PDS members with a
+             // stateful mixed SBCS/DBCS target codepage (e.g. IBM-1399). Each
+             // record must be self-contained: it has to start and end in
+             // single-byte state with balanced shift-out/shift-in. The member
+             // (BPAM) write paths encode line-by-line, so a DBCS record that is
+             // not the last line previously had its closing SI dropped, which
+             // corrupted the record and made the read-back conversion fail.
+             describe("DBCS member encoding round-trip",
+                      [&]() -> void
+                      {
+                        // UTF-8 bytes for 日本語 (U+65E5 U+672C U+8A9E).
+                        const std::string japanese =
+                            std::string("\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E", 9);
+                        // ASCII markers built as raw bytes so they don't depend
+                        // on the (EBCDIC) compile-time charset of the test.
+                        const std::string marker_a = std::string("\x2F\x2F\x41", 3); // "//A"
+                        const std::string marker_b = std::string("\x2F\x2F\x42", 3); // "//B"
+
+                        // UTF-8 input where the DBCS record is in the middle, so
+                        // it is followed by another record: "//A\n日本語\n//B\n".
+                        const std::string utf8_input =
+                            marker_a + "\x0A" + japanese + "\x0A" + marker_b + "\x0A";
+
+                        it("should round-trip a non-final DBCS record written to a member (buffered)",
+                           [&]() -> void
+                           {
+                             ZDS zds = {0};
+                             std::string dsn = get_random_ds(3);
+                             created_dsns.push_back(dsn);
+                             create_pds(&zds, dsn); // FB/80 PDS, like a JCL library
+                             std::string member = dsn + "(JCL)";
+
+                             // Write UTF-8 -> IBM-1399 (stateful Japanese mixed codepage)
+                             strcpy(zds.encoding_opts.codepage, "IBM-1399");
+                             strcpy(zds.encoding_opts.source_codepage, "UTF-8");
+                             zds.encoding_opts.data_type = eDataTypeText;
+
+                             ZDSWriteOpts wopts{.zds = &zds, .dsname = member};
+                             int wrc = zds_write(wopts, utf8_input);
+                             // Pre-fix this failed: the post-write etag read-back
+                             // conversion (IBM-1399 -> UTF-8) hit a malformed record.
+                             ExpectWithContext(wrc, zds.diag.e_msg).ToBe(RTNCD_SUCCESS);
+
+                             // Read back with the same encoding and verify the
+                             // DBCS record and its neighbors survived intact.
+                             ZDS rzds = {0};
+                             strcpy(rzds.encoding_opts.codepage, "IBM-1399");
+                             strcpy(rzds.encoding_opts.source_codepage, "UTF-8");
+                             rzds.encoding_opts.data_type = eDataTypeText;
+
+                             std::string out;
+                             ZDSReadOpts ropts{.zds = &rzds, .dsname = member};
+                             int rrc = zds_read(ropts, out);
+                             ExpectWithContext(rrc, rzds.diag.e_msg).ToBe(RTNCD_SUCCESS);
+
+                             ExpectWithContext(out.find(japanese) != std::string::npos,
+                                               "DBCS record should round-trip intact")
+                                 .ToBe(true);
+                             Expect(out.find(marker_a) != std::string::npos).ToBe(true);
+                             Expect(out.find(marker_b) != std::string::npos).ToBe(true);
+                           });
+
+                        it("should round-trip a non-final DBCS record written to a member (streamed)",
+                           [&]() -> void
+                           {
+                             ZDS zds = {0};
+                             std::string dsn = get_random_ds(3);
+                             created_dsns.push_back(dsn);
+                             create_pds(&zds, dsn);
+                             std::string member = dsn + "(JCL)";
+
+                             // The streamed write path consumes base64 chunks from
+                             // a pipe/file, mirroring how the extension uploads.
+                             std::string temp_file = "/tmp/zds_dbcs_stream_" + std::to_string(getpid());
+                             std::ofstream temp_out(temp_file);
+                             temp_out << zbase64::encode(utf8_input);
+                             temp_out.close();
+
+                             strcpy(zds.encoding_opts.codepage, "IBM-1399");
+                             strcpy(zds.encoding_opts.source_codepage, "UTF-8");
+                             zds.encoding_opts.data_type = eDataTypeText;
+
+                             size_t content_len = 0;
+                             ZDSWriteOpts wopts{.zds = &zds, .dsname = member};
+                             int wrc = zds_write_streamed(wopts, temp_file, &content_len);
+                             unlink(temp_file.c_str());
+                             ExpectWithContext(wrc, zds.diag.e_msg).ToBe(RTNCD_SUCCESS);
+
+                             ZDS rzds = {0};
+                             strcpy(rzds.encoding_opts.codepage, "IBM-1399");
+                             strcpy(rzds.encoding_opts.source_codepage, "UTF-8");
+                             rzds.encoding_opts.data_type = eDataTypeText;
+
+                             std::string out;
+                             ZDSReadOpts ropts{.zds = &rzds, .dsname = member};
+                             int rrc = zds_read(ropts, out);
+                             ExpectWithContext(rrc, rzds.diag.e_msg).ToBe(RTNCD_SUCCESS);
+
+                             ExpectWithContext(out.find(japanese) != std::string::npos,
+                                               "DBCS record should round-trip intact")
+                                 .ToBe(true);
+                             Expect(out.find(marker_a) != std::string::npos).ToBe(true);
+                             Expect(out.find(marker_b) != std::string::npos).ToBe(true);
+                           });
+                      });
+
              describe("copy datasets",
                       [&]() -> void
                       {

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -1186,6 +1186,13 @@ static int flush_encoding_state(const EncodingSetup &setup, IconvGuard &iconv_gu
  * Encode a single line using the provided encoding setup.
  * Consolidates line encoding logic used in BPAM write functions.
  *
+ * Each line becomes its own data set record, so the shift state is flushed after
+ * every line. This keeps every record self-contained for stateful mixed
+ * SBCS/DBCS encodings (e.g. IBM-1399/IBM-939): the bytes start and end in
+ * single-byte state with balanced shift-out/shift-in. Without the per-line
+ * flush, the closing SI for a DBCS record would leak into the following record,
+ * producing malformed records that fail to convert on read-back.
+ *
  * @param line Line to encode (modified in place)
  * @param setup Encoding setup context
  * @param iconv_guard IconvGuard for encoding conversion
@@ -1201,7 +1208,7 @@ static int encode_line_if_needed(std::string &line, const EncodingSetup &setup, 
 
   try
   {
-    line = zut_encode(line, iconv_guard.get(), diag);
+    line = zut_encode(line, iconv_guard.get(), diag, /*flush_state=*/true);
     return RTNCD_SUCCESS;
   }
   catch (std::exception &e)
@@ -1645,27 +1652,8 @@ static int zds_write_member_bpam(ZDS *zds, const std::string &dsn, const std::st
     }
   }
 
-  // Flush encoding state and append to last line if needed
-  std::vector<char> flush_buffer;
-  rc = flush_encoding_state(encoding, iconv_guard, zds->diag, flush_buffer);
-  if (rc != RTNCD_SUCCESS)
-  {
-    zds_close_output_bpam(zds, ioc);
-    return rc;
-  }
-
-  // Append flush bytes to the last non-empty line
-  if (!flush_buffer.empty() && !lines_to_write.empty())
-  {
-    for (auto it = lines_to_write.rbegin(); it != lines_to_write.rend(); ++it)
-    {
-      if (!it->first.empty())
-      {
-        it->first.append(flush_buffer.begin(), flush_buffer.end());
-        break;
-      }
-    }
-  }
+  // Each line was encoded with its shift state flushed (see encode_line_if_needed),
+  // so every record is already self-contained; no end-of-member flush is needed.
 
   // Now write all the lines
   for (size_t i = 0; i < lines_to_write.size(); i++)
@@ -4264,20 +4252,8 @@ static int zds_write_member_bpam_streamed(ZDS *zds, const std::string &dsn, cons
     }
   }
 
-  // Flush encoding state and append to the last line
-  std::vector<char> flush_buffer;
-  rc = flush_encoding_state(encoding, iconv_guard, zds->diag, flush_buffer);
-  if (rc != RTNCD_SUCCESS)
-  {
-    zds_close_output_bpam(zds, ioc);
-    return rc;
-  }
-
-  // Append flush bytes to the last line
-  if (!flush_buffer.empty() && has_prev_line)
-  {
-    prev_line.append(flush_buffer.begin(), flush_buffer.end());
-  }
+  // Each line was encoded with its shift state flushed (see encode_line_if_needed),
+  // so every record is already self-contained; no end-of-member flush is needed.
 
   // Write the last buffered line
   if (has_prev_line)

--- a/native/c/zut.cpp
+++ b/native/c/zut.cpp
@@ -1012,9 +1012,9 @@ std::vector<char> zut_encode(const char *input_str, const size_t input_size, con
  * @param cd iconv descriptor (caller manages opening, flushing, and closing)
  * @param diag diagnostic structure to store error information
  */
-std::string zut_encode(const std::string &input_str, iconv_t cd, ZDIAG &diag)
+std::string zut_encode(const std::string &input_str, iconv_t cd, ZDIAG &diag, bool flush_state)
 {
-  std::vector<char> result = zut_encode(input_str.data(), input_str.size(), cd, diag);
+  std::vector<char> result = zut_encode(input_str.data(), input_str.size(), cd, diag, flush_state);
   return std::string(result.begin(), result.end());
 }
 
@@ -1024,10 +1024,14 @@ std::string zut_encode(const std::string &input_str, iconv_t cd, ZDIAG &diag)
  * @param input_size size of the input data in bytes
  * @param cd iconv descriptor (caller manages opening, flushing, and closing)
  * @param diag diagnostic structure to store error information
+ * @param flush_state when true, flush the shift state after the input so the
+ *   returned bytes are a self-contained unit (ends back in single-byte state)
  */
-std::vector<char> zut_encode(const char *input_str, const size_t input_size, iconv_t cd, ZDIAG &diag)
+std::vector<char> zut_encode(const char *input_str, const size_t input_size, iconv_t cd, ZDIAG &diag, bool flush_state)
 {
-  const size_t max_output_size = input_size * 4;
+  // Headroom beyond the *4 worst case so the trailing shift sequence (e.g. SI)
+  // produced when flush_state is set always fits, even for an empty input.
+  const size_t max_output_size = input_size * 4 + 16;
   std::vector<char> output_buffer(max_output_size, 0);
 
   char *input = const_cast<char *>(input_str);
@@ -1035,7 +1039,7 @@ std::vector<char> zut_encode(const char *input_str, const size_t input_size, ico
 
   ZConvData data = {input, input_size, max_output_size, &output_buffer[0], output_iter};
 
-  size_t iconv_rc = zut_iconv(cd, data, diag, false);
+  size_t iconv_rc = zut_iconv(cd, data, diag, flush_state);
   if (-1 == iconv_rc)
   {
     throw std::runtime_error(diag.e_msg);

--- a/native/c/zut.hpp
+++ b/native/c/zut.hpp
@@ -311,11 +311,16 @@ std::vector<char> zut_encode(const char *input_str, const size_t input_size, con
  * @param input_str The input string
  * @param cd iconv descriptor (caller manages opening, flushing, and closing)
  * @param diag Reference to diagnostic information structure
+ * @param flush_state If true, flush the shift state after this input so the
+ *   returned bytes are self-contained (e.g. a stateful mixed SBCS/DBCS encoding
+ *   ends back in single-byte state). Use this when each call produces an
+ *   independent unit such as a single data set record. Defaults to false so the
+ *   shift state carries across successive calls on the same descriptor.
  * @return The encoded string
  */
-std::string zut_encode(const std::string &input_str, iconv_t cd, ZDIAG &diag);
+std::string zut_encode(const std::string &input_str, iconv_t cd, ZDIAG &diag, bool flush_state = false);
 
-std::vector<char> zut_encode(const char *input_str, const size_t input_size, iconv_t cd, ZDIAG &diag);
+std::vector<char> zut_encode(const char *input_str, const size_t input_size, iconv_t cd, ZDIAG &diag, bool flush_state = false);
 
 /**
  * @brief Format a vector of strings as a CSV line


### PR DESCRIPTION
**What It Does**

Fixed issue spotted by @jace-roell where writing IBM-1399 records to a data set member would fail, regardless of contents.

**Root cause identified:** member (BPAM) writes weren't producing self-contained records for stateful mixed SBCS/DBCS encodings. I've resolved this by ensuring each record that's written is fully self-contained and does not leak Shift In/Shift Out sequences. I also added regression tests to prevent this from re-surfacing through future changes.

**How to Test**

- `npm run z:rebuild && npm run z:test`
- All tests should pass
- Using the SDK from this branch, try to save IBM-1399 records to a data set member in ZE (using SSH profile). Here's a sample JCL snippet you can use

```jcl
//TEST02J  JOB (ACCT001),'TEST',CLASS=A,MSGCLASS=X,
//             MSGLEVEL=(1,1),NOTIFY=&SYSUID
//*
//* 日本語コメント: このJCLは日本語を含みます
//*
//STEP1    EXEC PGM=IEFBR14
//*
//STEP2    EXEC PGM=IEBGENER
//SYSPRINT DD SYSOUT=*
//SYSUT1   DD *
日本語メッセージのテスト
This is a test of Japanese message output
実行日時: 2026年4月
/*
//SYSUT2   DD SYSOUT=*
//SYSIN    DD DUMMY
```

- Save should succeed w/o error

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)