### PR TITLE
support encoding flag for submit stdin and local-file

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- Added `--encoding` flag to `zssh submit local-file` and `zssh submit stdin` commands to specify the encoding of the submitted JCL. [#1050](https://github.com/zowe/zowex/pull/1050)
 - Added `zssh copy data-set` command to copy data sets and members with optional `--replace` and `--overwrite` flags. Supports PDS-to-PDS, member-to-member, and sequential-to-sequential copies. [#995](https://github.com/zowe/zowex/pull/995)
 - Added the `zssh system view-syslog` command to the CLI.
 

--- a/packages/cli/src/submit/local-file/LocalFile.definition.ts
+++ b/packages/cli/src/submit/local-file/LocalFile.definition.ts
@@ -36,7 +36,7 @@ export const SubmitLocalFileDefinition: ICommandDefinition = {
         {
             name: "encoding",
             aliases: ["ec"],
-            description: "The encoding of the local JCL file. Defaults to UTF-8 if not specified.",
+            description: "The remote encoding to use for the JCL content. Defaults to IBM-1047 if not specified.",
             type: "string",
             required: false,
         },

--- a/packages/cli/src/submit/local-file/LocalFile.definition.ts
+++ b/packages/cli/src/submit/local-file/LocalFile.definition.ts
@@ -32,6 +32,15 @@ export const SubmitLocalFileDefinition: ICommandDefinition = {
             required: true,
         },
     ],
+    options: [
+        {
+            name: "encoding",
+            aliases: ["ec"],
+            description: "The encoding of the local JCL file. Defaults to UTF-8 if not specified.",
+            type: "string",
+            required: false,
+        },
+    ],
     profile: { optional: ["ssh"] },
     outputFormatOptions: true,
 };

--- a/packages/cli/src/submit/local-file/LocalFile.handler.ts
+++ b/packages/cli/src/submit/local-file/LocalFile.handler.ts
@@ -27,7 +27,7 @@ export default class SubmitLocalFileHandler extends SshBaseHandler {
                 causeErrors: err,
             });
         }
-        const response = await client.jobs.submitJcl({ jcl: B64String.encode(JclString) });
+        const response = await client.jobs.submitJcl({ jcl: B64String.encode(JclString), encoding: params.arguments.encoding });
 
         const msg = `Job submitted: ${response.jobId}`;
         params.response.data.setMessage(msg);

--- a/packages/cli/src/submit/local-file/LocalFile.handler.ts
+++ b/packages/cli/src/submit/local-file/LocalFile.handler.ts
@@ -27,7 +27,10 @@ export default class SubmitLocalFileHandler extends SshBaseHandler {
                 causeErrors: err,
             });
         }
-        const response = await client.jobs.submitJcl({ jcl: B64String.encode(JclString), encoding: params.arguments.encoding });
+        const response = await client.jobs.submitJcl({
+            jcl: B64String.encode(JclString),
+            encoding: params.arguments.encoding,
+        });
 
         const msg = `Job submitted: ${response.jobId}`;
         params.response.data.setMessage(msg);

--- a/packages/cli/src/submit/stdin/Stdin.definition.ts
+++ b/packages/cli/src/submit/stdin/Stdin.definition.ts
@@ -29,6 +29,13 @@ export const SubmitStdinDefinition: ICommandDefinition = {
         },
     ],
     options: [
+        {
+            name: "encoding",
+            aliases: ["ec"],
+            description: "The encoding of the JCL content being piped in. Defaults to UTF-8 if not specified.",
+            type: "string",
+            required: false,
+        },
         // {
         //     name: "wait",
         //     aliases: ["w"],

--- a/packages/cli/src/submit/stdin/Stdin.definition.ts
+++ b/packages/cli/src/submit/stdin/Stdin.definition.ts
@@ -32,7 +32,7 @@ export const SubmitStdinDefinition: ICommandDefinition = {
         {
             name: "encoding",
             aliases: ["ec"],
-            description: "The encoding of the JCL content being piped in. Defaults to UTF-8 if not specified.",
+            description: "The remote encoding to use for the JCL content. Defaults to IBM-1047 if not specified.",
             type: "string",
             required: false,
         },

--- a/packages/cli/src/submit/stdin/Stdin.handler.ts
+++ b/packages/cli/src/submit/stdin/Stdin.handler.ts
@@ -17,7 +17,7 @@ import { SshBaseHandler } from "../../SshBaseHandler";
 export default class SubmitJclHandler extends SshBaseHandler {
     public async processWithClient(params: IHandlerParameters, client: ZSshClient): Promise<jobs.DeleteJobResponse> {
         const jcl = B64String.encode(await buffer(params.stdin));
-        const response = await client.jobs.submitJcl({ jcl, localEncoding: params.arguments.encoding });
+        const response = await client.jobs.submitJcl({ jcl, encoding: params.arguments.encoding });
 
         const msg = `Job submitted: ${response.jobId}`;
         params.response.data.setMessage(msg);

--- a/packages/cli/src/submit/stdin/Stdin.handler.ts
+++ b/packages/cli/src/submit/stdin/Stdin.handler.ts
@@ -17,7 +17,7 @@ import { SshBaseHandler } from "../../SshBaseHandler";
 export default class SubmitJclHandler extends SshBaseHandler {
     public async processWithClient(params: IHandlerParameters, client: ZSshClient): Promise<jobs.DeleteJobResponse> {
         const jcl = B64String.encode(await buffer(params.stdin));
-        const response = await client.jobs.submitJcl({ jcl });
+        const response = await client.jobs.submitJcl({ jcl, localEncoding: params.arguments.encoding });
 
         const msg = `Job submitted: ${response.jobId}`;
         params.response.data.setMessage(msg);


### PR DESCRIPTION
Add support for the encoding property when using the `submit jcl` command palette option.

**How to test**

Set `encoding` and `jobEncoding` to `IBM-1399` in an ssh profile

run the `zowe zssh submit <stdin/local-file> --encoding IBM-1399` commands passing content via stdin or a local file

View the spool content with IBM-1399 and the output should not be malformed

ex:

```
//TEST02J  JOB (ACCT001),'TEST',CLASS=A,MSGCLASS=X,
//             MSGLEVEL=(1,1),NOTIFY=&SYSUID
//*
//* 日本語コメント: このJCLは日本語を含みます
//*
//STEP1    EXEC PGM=IEFBR14
//*
//STEP2    EXEC PGM=IEBGENER
//SYSPRINT DD SYSOUT=*
//SYSUT1   DD *
日本語メッセージのテスト
This is a test of Japanese message output
実行日時: 2026年4月
/*
//SYSUT2   DD SYSOUT=*
//SYSIN    DD DUMMY
```

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
No tests for this suite
