### PR TITLE
Automate building swig for Python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 compile_commands.json
 artifacts
 bin
-build
 coverage
 dist
 dumps

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 compile_commands.json
 artifacts
 bin
+build
 coverage
 dist
 dumps

--- a/native/python/swig/README.md
+++ b/native/python/swig/README.md
@@ -19,6 +19,7 @@ On the z/OS build system:
 From the repo root, on your workstation:
 
 ```bash
+npm run z:upload -- python/swig
 npm run z:build:swig
 ```
 

--- a/native/python/swig/README.md
+++ b/native/python/swig/README.md
@@ -1,0 +1,65 @@
+# SWIG for z/OS
+
+This directory builds [SWIG](https://www.swig.org/) (and its `pcre2` dependency) from source for z/OS, so it can generate the C++/Python wrapper code used by the Zowe Remote SSH Python bindings. It also contains a small [sample](sample/) project used to sanity-check a SWIG build.
+
+## Prerequisites
+
+On the z/OS build system:
+
+- `bison`
+- `git`
+- `python`
+- `gmake`
+- The `xlclang` compiler toolchain
+
+`build.sh` checks for these tools on `PATH` and fails fast with a clear error if any are missing.
+
+## Building
+
+From the repo root, on your workstation:
+
+```bash
+npm run z:build:swig
+```
+
+This downloads the latest SWIG and PCRE2 source tarballs, uploads them to the configured z/OS host, and runs `build.sh` there. On success, the packaged build (`swig-<version>.pax.Z`) is downloaded to `dist/`.
+
+If you just want to check whether SWIG is already installed on the target system (and skip rebuilding it), run:
+
+```bash
+npm run z:has:swig
+```
+
+## Testing the sample
+
+`build.sh` builds and runs the [sample](sample/) as its last step, straight from the freshly built `swig` binary under `build/` — no installation needed. To re-test without rebuilding SWIG:
+
+```bash
+export PATH="$PWD/build:$PATH"
+cd sample && make
+```
+
+**Note:** The [sample/Makefile](sample/Makefile) falls back to the `Lib/` directory next to the resolved `swig` binary if `swig -swiglib` can't find one.
+
+## Installing SWIG
+
+The `swig-<version>.pax.Z` from the [Building](#building) step contains the `swig` binary and its `Lib/` support files.
+
+SWIG finds `Lib/` (to resolve `%include`d standard library files like `std_string.i`) via the `SWIG_LIB` environment variable, or otherwise via the path compiled into the binary (`swig -swiglib`) — usually `/usr/local/share/swig/X.Y.Z`.
+
+There are two ways to install it:
+
+- Extract the pax anywhere, put `swig` on `PATH`, and set `SWIG_LIB` to point at the extracted `Lib/`:
+
+  ```bash
+  pax -rz -f swig-<version>.pax.Z
+  export PATH="$PWD:$PATH"
+  export SWIG_LIB="$PWD/Lib"
+  ```
+
+- Or remap `Lib` to the compiled-in default path during extraction, so `SWIG_LIB` never needs to be set:
+
+  ```bash
+  mkdir -p /usr/local/share/swig
+  pax -rz -f swig-<version>.pax.Z -s ',^Lib,/usr/local/share/swig/<version>,' -s ',^swig$,/usr/local/bin/swig,'
+  ```

--- a/native/python/swig/README.md
+++ b/native/python/swig/README.md
@@ -10,7 +10,7 @@ On the z/OS build system:
 - `git`
 - `python`
 - `gmake`
-- The `xlclang` compiler toolchain
+- The `xlclang`/`ibm-clang` compiler toolchain
 
 `build.sh` checks for these tools on `PATH` and fails fast with a clear error if any are missing.
 

--- a/native/python/swig/build.sh
+++ b/native/python/swig/build.sh
@@ -31,3 +31,10 @@ gmake
 
 echo "Packaging swig..."
 pax -wvz -f ../swig-${swigVersion}.pax.Z Lib swig
+
+echo "Testing swig..."
+export PATH=$PWD:$PATH
+export SWIG_LIB=$PWD/Lib
+cd ../sample
+make
+python -c "import example; print(example.hello_ascii('Zowe'))"

--- a/native/python/swig/build.sh
+++ b/native/python/swig/build.sh
@@ -42,7 +42,5 @@ pax -wvz -f ../swig-${swigVersion}.pax.Z Lib swig
 
 echo "Testing swig..."
 export PATH=$PWD:$PATH
-export SWIG_LIB=$PWD/Lib
 cd ../sample
 make
-python -c "import example; print(example.hello_ascii('Zowe'))"

--- a/native/python/swig/build.sh
+++ b/native/python/swig/build.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+swigVersion=$1
+pcreVersion=$2
+export _CXX_CCMODE=1
+export _CXX_EXTRA_ARGS=1
+export MAKE=gmake
+
+echo "Extracting tarballs..."
+rm -rf build
+gunzip swig-${swigVersion}.tar.gz
+pax -r -o from=ISO8859-1,to=IBM-1047 -f swig-${swigVersion}.tar && rm swig-${swigVersion}.tar
+gunzip pcre2-${pcreVersion}.tar.gz
+pax -r -o from=ISO8859-1,to=IBM-1047 -f pcre2-${pcreVersion}.tar && rm pcre2-${pcreVersion}.tar
+mv swig-${swigVersion} build && mv pcre2-${pcreVersion} build/pcre
+
+echo "Applying patches..."
+cd build
+for file in ../patches/*.patch; do
+    git apply "$file"
+done
+touch Source/Makefile.in
+
+echo "Building pcre2..."
+./Tools/pcre-build.sh CC=xlclang CXX=xlclang++ MAKE=gmake --disable-dependency-tracking
+
+echo "Building swig..."
+./configure CC=xlclang CXX=xlclang++ MAKE=gmake --disable-ccache --disable-dependency-tracking
+gmake
+
+echo "Packaging swig..."
+cd dist && pax -wvz -f ../swig-${swigVersion}.pax.Z Lib swig

--- a/native/python/swig/build.sh
+++ b/native/python/swig/build.sh
@@ -30,4 +30,4 @@ echo "Building swig..."
 gmake
 
 echo "Packaging swig..."
-cd dist && pax -wvz -f ../swig-${swigVersion}.pax.Z Lib swig
+pax -wvz -f ../swig-${swigVersion}.pax.Z Lib swig

--- a/native/python/swig/build.sh
+++ b/native/python/swig/build.sh
@@ -7,6 +7,14 @@ export _CXX_CCMODE=1
 export _CXX_EXTRA_ARGS=1
 export MAKE=gmake
 
+REQUIRED_TOOLS="bison git python $MAKE"
+for tool in $REQUIRED_TOOLS; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Error: Required dependency '$tool' was not found in your PATH." >&2
+        exit 1
+    fi
+done
+
 echo "Extracting tarballs..."
 rm -rf build
 gunzip swig-${swigVersion}.tar.gz

--- a/native/python/swig/build.sh
+++ b/native/python/swig/build.sh
@@ -7,7 +7,7 @@ export _CXX_CCMODE=1
 export _CXX_EXTRA_ARGS=1
 export MAKE=gmake
 
-REQUIRED_TOOLS="bison git python $MAKE"
+REQUIRED_TOOLS="bison git gunzip python $MAKE"
 for tool in $REQUIRED_TOOLS; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         echo "Error: Required dependency '$tool' was not found in your PATH." >&2

--- a/native/python/swig/patches/autoconf.patch
+++ b/native/python/swig/patches/autoconf.patch
@@ -1,0 +1,22 @@
+diff --git a/configure b/configure
+index 4351fc29e..d2a510f40 100755
+--- a/configure
++++ b/configure
+@@ -5552,7 +5552,7 @@ fi
+     then
+       if test "$GXX" = "yes"
+       then
+-        ac_compile_warnings_opt='-Wall -W -pedantic'
++        ac_compile_warnings_opt='-Wall -Wpedantic'
+       fi
+       CXXFLAGS="$CXXFLAGS $ac_compile_warnings_opt"
+       ac_compile_warnings_msg="$ac_compile_warnings_opt for C++"
+@@ -5562,7 +5562,7 @@ fi
+   then
+     if test "$GCC" = "yes"
+     then
+-      ac_compile_warnings_opt='-Wall -W -pedantic'
++      ac_compile_warnings_opt='-Wall -Wpedantic'
+     fi
+     CFLAGS="$CFLAGS $ac_compile_warnings_opt"
+     ac_compile_warnings_msg="$ac_compile_warnings_msg $ac_compile_warnings_opt for C"

--- a/native/python/swig/patches/makefile.patch
+++ b/native/python/swig/patches/makefile.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile.in b/Makefile.in
+index 45a9c28af..48f7bde28 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -532,10 +532,10 @@ Makefile: $(srcdir)/Makefile.in config.status
+ # changed.
+ am--refresh: $(srcdir)/configure
+ 
+-$(srcdir)/configure: $(srcdir)/configure.ac
+-	@echo "Build system is out of date.  If the following commands fail, please reconfigure by hand (rerun: ./autogen.sh && ./configure)"
+-	cd $(srcdir) && ./autogen.sh
+-	$(SHELL) ./config.status --recheck
++# $(srcdir)/configure: $(srcdir)/configure.ac
++# 	@echo "Build system is out of date.  If the following commands fail, please reconfigure by hand (rerun: ./autogen.sh && ./configure)"
++# 	cd $(srcdir) && ./autogen.sh
++# 	$(SHELL) ./config.status --recheck
+ 
+ ############################################################################
+ # Tools
+diff --git a/Source/Makefile.am b/Source/Makefile.am
+index b9bc13bfd..f0f6fcc18 100644
+--- a/Source/Makefile.am
++++ b/Source/Makefile.am
+@@ -102,7 +102,7 @@ bin_PROGRAMS = eswig
+ # Use GNU make's grouped targets to avoid repeated bison execution for
+ # each target.
+ CParse/parser.c CParse/parser.h &: CParse/parser.y
+-	$(BISON) $(AM_YFLAGS) $(YFLAGS) --output=CParse/parser.c $(srcdir)/CParse/parser.y
++	-$(BISON) $(AM_YFLAGS) $(YFLAGS) --output=CParse/parser.c $(srcdir)/CParse/parser.y
+ 
+ # The executable is copied to the root directory for installation and running the test-suite.
+ # This occurs on each invocation of make and is a step towards providing support for multiple

--- a/native/python/swig/patches/pcre.patch
+++ b/native/python/swig/patches/pcre.patch
@@ -1,0 +1,31 @@
+diff --git a/Tools/pcre-build.sh b/Tools/pcre-build.sh
+index ff088c6b7..ee0c75ad9 100755
+--- a/Tools/pcre-build.sh
++++ b/Tools/pcre-build.sh
+@@ -35,17 +35,17 @@ if test -f "pcre-build.sh" ; then
+   usage
+ fi
+ 
+-echo "Looking for PCRE2 tarball..."
+-rm -rf pcre
+-pcre_tarball=`ls pcre2-*.tar*`
+-test -n "$pcre_tarball" || bail "Could not find tarball matching pattern: pcre2-*.tar*"
+-test -f "$pcre_tarball" || bail "Could not find a single PCRE2 tarball. Found: $pcre_tarball"
++# echo "Looking for PCRE2 tarball..."
++# rm -rf pcre
++# pcre_tarball=`ls pcre2-*.tar*`
++# test -n "$pcre_tarball" || bail "Could not find tarball matching pattern: pcre2-*.tar*"
++# test -f "$pcre_tarball" || bail "Could not find a single PCRE2 tarball. Found: $pcre_tarball"
+ 
+-echo "Extracting tarball: $pcre_tarball"
+-tar -xf $pcre_tarball || bail "Could not untar $pcre_tarball"
+-pcre_dir=`echo $pcre_tarball | sed -e "s/\.tar.*//"`
++# echo "Extracting tarball: $pcre_tarball"
++# tar -xf $pcre_tarball || bail "Could not untar $pcre_tarball"
++# pcre_dir=`echo $pcre_tarball | sed -e "s/\.tar.*//"`
+ echo "Configuring PCRE in directory: pcre"
+-mv $pcre_dir pcre || bail "Could not create pcre directory"
++# mv $pcre_dir pcre || bail "Could not create pcre directory"
+ cd pcre && ./configure --prefix=$pcre_install_dir --disable-shared $* || bail "PCRE2 configure failed"
+ echo "Building PCRE2..."
+ ${MAKE:-make} -s || bail "Could not build PCRE2"

--- a/native/python/swig/sample/Makefile
+++ b/native/python/swig/sample/Makefile
@@ -1,0 +1,69 @@
+#
+#  This program and the accompanying materials are
+#  made available under the terms of the Eclipse Public License v2.0
+#  which accompanies this distribution, and is available at
+#  https://www.eclipse.org/legal/epl-v20.html
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Copyright Contributors to the Zowe Project.
+#
+
+CC=xlc
+CXX=xlclang++
+ASM=as
+
+CCMODE_ENV=_CC_CCMODE=1 _CXX_CCMODE=1 _C89_CCMODE=1 _CC_EXTRA_ARGS=1 _CXX_EXTRA_ARGS=1 _C89_EXTRA_ARGS=1
+
+CC_OPTS=metal,langlvl(extended),sscom,nolongname,inline,genasm,inlrpt,csect,nose,lp64,list,warn64,optimize(2),list,showinc,showmacro,source,aggregate
+CXX_OPTS=lp64,langlvl(extended0x),dll,xplink,exportall
+
+all: run
+
+#
+# Metal C
+#
+zmetal.s: zmetal.c zmetal.h
+	@echo 'Building zmetal.s'
+	$(CCMODE_ENV) $(CC) -S -W"c,$(CC_OPTS)" -qlist=zmetal.c.lst -I/usr/include/metal -o $@ $<
+
+zmetal.o: zmetal.s
+	@echo 'Building zmetal.o'
+	$(CCMODE_ENV) $(ASM) -mrent -a=zmetal.s.lst -ISYS1.MACLIB -ICBC.SCCNSAM -o $@ $<
+
+#
+# C++ wrapper around the Metal C function
+#
+hello.o: hello.cpp hello.h zmetal.h
+	@echo 'Building hello.o'
+	$(CCMODE_ENV) $(CXX) -W "c,$(CXX_OPTS)" -c -qlist=hello.cpp.lst -o $@ hello.cpp
+
+#
+# SWIG wrapper generation
+#
+example_wrap.cxx: example.i example.h
+	@echo 'Generating SWIG wrapper'
+	swig -c++ -python example.i
+
+#
+# Python extension module
+#
+build-ext: example_wrap.cxx example.cpp example.h setup.py zmetal.o hello.o
+	@echo 'Building Python extension'
+	python setup.py build_ext --inplace
+
+run: build-ext
+	@echo 'Running example'
+	python -c "import example; print(example.hello_ascii('Zowe'))"
+
+clean:
+	rm -f *.o
+	rm -f *.s
+	rm -f *.lst
+	rm -f *.cxx
+	rm -f *.pyc
+	rm -f example.py
+	rm -f _example*.so
+	rm -rf build
+
+.PHONY: all build-ext run clean

--- a/native/python/swig/sample/Makefile
+++ b/native/python/swig/sample/Makefile
@@ -24,7 +24,7 @@ _C89_EXTRA_ARGS=1
 CC_OPTS=metal,langlvl(extended),sscom,nolongname,inline,genasm,inlrpt,csect,nose,lp64,list,warn64,optimize(2),list,showinc,showmacro,source,aggregate
 CXX_OPTS=lp64,langlvl(extended0x),dll,xplink,exportall
 
-all: build-ext
+all: test
 
 #
 # Metal C
@@ -49,6 +49,10 @@ hello.o: hello.cpp hello.h zmetal.h
 #
 example_wrap.cxx: example.i example.h
 	@echo 'Generating SWIG wrapper'
+	SWIG_LIB_DIR=$$(swig -swiglib); \
+	if [ ! -d "$$SWIG_LIB_DIR" ]; then \
+		export SWIG_LIB="$$(dirname "$$(command -v swig)")/Lib"; \
+	fi; \
 	swig -c++ -python example.i
 
 #
@@ -57,6 +61,10 @@ example_wrap.cxx: example.i example.h
 build-ext: example_wrap.cxx example.cpp example.h setup.py zmetal.o hello.o
 	@echo 'Building Python extension'
 	python setup.py build_ext --inplace
+
+test: build-ext
+	@echo 'Running example'
+	python -c "import example; print(example.hello_ascii('Zowe'))"
 
 clean:
 	rm -f *.o
@@ -68,4 +76,4 @@ clean:
 	rm -f _example*.so
 	rm -rf build
 
-.PHONY: all build-ext clean
+.PHONY: all build-ext test clean

--- a/native/python/swig/sample/Makefile
+++ b/native/python/swig/sample/Makefile
@@ -13,30 +13,36 @@ CC=xlc
 CXX=xlclang++
 ASM=as
 
-CCMODE_ENV=_CC_CCMODE=1 _CXX_CCMODE=1 _C89_CCMODE=1 _CC_EXTRA_ARGS=1 _CXX_EXTRA_ARGS=1 _C89_EXTRA_ARGS=1
+_CC_CCMODE=1
+_CXX_CCMODE=1
+_C89_CCMODE=1
+_CC_EXTRA_ARGS=1
+_CXX_EXTRA_ARGS=1
+_C89_EXTRA_ARGS=1
+.EXPORT: _CC_CCMODE _CXX_CCMODE _C89_CCMODE _CC_EXTRA_ARGS _CXX_EXTRA_ARGS _C89_EXTRA_ARGS
 
 CC_OPTS=metal,langlvl(extended),sscom,nolongname,inline,genasm,inlrpt,csect,nose,lp64,list,warn64,optimize(2),list,showinc,showmacro,source,aggregate
 CXX_OPTS=lp64,langlvl(extended0x),dll,xplink,exportall
 
-all: run
+all: build-ext
 
 #
 # Metal C
 #
 zmetal.s: zmetal.c zmetal.h
 	@echo 'Building zmetal.s'
-	$(CCMODE_ENV) $(CC) -S -W"c,$(CC_OPTS)" -qlist=zmetal.c.lst -I/usr/include/metal -o $@ $<
+	$(CC) -S -W"c,$(CC_OPTS)" -qlist=zmetal.c.lst -I/usr/include/metal -o $@ zmetal.c
 
 zmetal.o: zmetal.s
 	@echo 'Building zmetal.o'
-	$(CCMODE_ENV) $(ASM) -mrent -a=zmetal.s.lst -ISYS1.MACLIB -ICBC.SCCNSAM -o $@ $<
+	$(ASM) -mrent -a=zmetal.s.lst -ISYS1.MACLIB -ICBC.SCCNSAM -o $@ zmetal.s
 
 #
 # C++ wrapper around the Metal C function
 #
 hello.o: hello.cpp hello.h zmetal.h
 	@echo 'Building hello.o'
-	$(CCMODE_ENV) $(CXX) -W "c,$(CXX_OPTS)" -c -qlist=hello.cpp.lst -o $@ hello.cpp
+	$(CXX) -W "c,$(CXX_OPTS)" -c -qlist=hello.cpp.lst -o $@ hello.cpp
 
 #
 # SWIG wrapper generation
@@ -52,10 +58,6 @@ build-ext: example_wrap.cxx example.cpp example.h setup.py zmetal.o hello.o
 	@echo 'Building Python extension'
 	python setup.py build_ext --inplace
 
-run: build-ext
-	@echo 'Running example'
-	python -c "import example; print(example.hello_ascii('Zowe'))"
-
 clean:
 	rm -f *.o
 	rm -f *.s
@@ -66,4 +68,4 @@ clean:
 	rm -f _example*.so
 	rm -rf build
 
-.PHONY: all build-ext run clean
+.PHONY: all build-ext clean

--- a/native/python/swig/sample/Makefile
+++ b/native/python/swig/sample/Makefile
@@ -9,8 +9,9 @@
 #  Copyright Contributors to the Zowe Project.
 #
 
-CC=xlc
-CXX=xlclang++
+CC=ibm-clang64
+CXX=ibm-clang++64
+MC=xlc
 ASM=as
 
 _CC_CCMODE=1
@@ -19,10 +20,10 @@ _C89_CCMODE=1
 _CC_EXTRA_ARGS=1
 _CXX_EXTRA_ARGS=1
 _C89_EXTRA_ARGS=1
-.EXPORT: _CC_CCMODE _CXX_CCMODE _C89_CCMODE _CC_EXTRA_ARGS _CXX_EXTRA_ARGS _C89_EXTRA_ARGS
+.EXPORT: CC CXX _CC_CCMODE _CXX_CCMODE _C89_CCMODE _CC_EXTRA_ARGS _CXX_EXTRA_ARGS _C89_EXTRA_ARGS
 
 CC_OPTS=metal,langlvl(extended),sscom,nolongname,inline,genasm,inlrpt,csect,nose,lp64,list,warn64,optimize(2),list,showinc,showmacro,source,aggregate
-CXX_OPTS=lp64,langlvl(extended0x),dll,xplink,exportall
+CXX_FLAGS=-std=gnu++17 -fvisibility=default
 
 all: test
 
@@ -31,7 +32,7 @@ all: test
 #
 zmetal.s: zmetal.c zmetal.h
 	@echo 'Building zmetal.s'
-	$(CC) -S -W"c,$(CC_OPTS)" -qlist=zmetal.c.lst -I/usr/include/metal -o $@ zmetal.c
+	$(MC) -S -W"c,$(CC_OPTS)" -qlist=zmetal.c.lst -I/usr/include/metal -o $@ zmetal.c
 
 zmetal.o: zmetal.s
 	@echo 'Building zmetal.o'
@@ -42,7 +43,7 @@ zmetal.o: zmetal.s
 #
 hello.o: hello.cpp hello.h zmetal.h
 	@echo 'Building hello.o'
-	$(CXX) -W "c,$(CXX_OPTS)" -c -qlist=hello.cpp.lst -o $@ hello.cpp
+	$(CXX) $(CXX_FLAGS) -c -o $@ hello.cpp
 
 #
 # SWIG wrapper generation

--- a/native/python/swig/sample/example.cpp
+++ b/native/python/swig/sample/example.cpp
@@ -1,0 +1,15 @@
+#include "example.h"
+#include <string>
+#include <unistd.h>
+
+extern "C" {
+    #include "hello.h"
+}
+
+std::string hello_ascii(std::string name) {
+    __a2e_s(&name[0]);
+    std::string message;
+    hello_ebcdic(name, message);
+    __e2a_s(&message[0]);
+    return message;
+}

--- a/native/python/swig/sample/example.cpp
+++ b/native/python/swig/sample/example.cpp
@@ -1,3 +1,14 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
 #include "example.h"
 #include <string>
 #include <unistd.h>

--- a/native/python/swig/sample/example.h
+++ b/native/python/swig/sample/example.h
@@ -1,0 +1,3 @@
+#include <string>
+
+std::string hello_ascii(std::string name);

--- a/native/python/swig/sample/example.h
+++ b/native/python/swig/sample/example.h
@@ -1,3 +1,14 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
 #include <string>
 
 std::string hello_ascii(std::string name);

--- a/native/python/swig/sample/example.i
+++ b/native/python/swig/sample/example.i
@@ -1,0 +1,9 @@
+/* File: example.i */
+%module example
+
+%{
+#include "example.h"
+%}
+
+%include "std_string.i"
+%include "example.h"

--- a/native/python/swig/sample/hello.cpp
+++ b/native/python/swig/sample/hello.cpp
@@ -1,0 +1,11 @@
+#include "hello.h"
+#include "zmetal.h"
+#include <string>
+
+int hello_ebcdic(std::string name, std::string& message) {
+    char buffer[64];
+    int bufsize = sizeof(buffer);
+    HELLO(name.c_str(), buffer, &bufsize);
+    message += buffer;
+    return 0;
+}

--- a/native/python/swig/sample/hello.cpp
+++ b/native/python/swig/sample/hello.cpp
@@ -1,3 +1,14 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
 #include "hello.h"
 #include "zmetal.h"
 #include <string>

--- a/native/python/swig/sample/hello.h
+++ b/native/python/swig/sample/hello.h
@@ -1,0 +1,5 @@
+#include <string>
+
+extern "C" {
+    int hello_ebcdic(std::string name, std::string& message);
+}

--- a/native/python/swig/sample/hello.h
+++ b/native/python/swig/sample/hello.h
@@ -1,3 +1,14 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
 #include <string>
 
 extern "C" {

--- a/native/python/swig/sample/setup.py
+++ b/native/python/swig/sample/setup.py
@@ -15,8 +15,8 @@ example_module = Extension('_example',
 
 setup (name = 'example',
        version = '0.1',
-       author      = "SWIG Docs",
-       description = """Simple swig example from docs""",
+       author      = "Zowe",
+       description = """SWIG example that invokes Metal C from Python""",
        ext_modules = [example_module],
        py_modules = ["example"],
        )

--- a/native/python/swig/sample/setup.py
+++ b/native/python/swig/sample/setup.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+"""
+setup.py file for SWIG example
+"""
+
+from distutils.core import setup, Extension
+
+
+example_module = Extension('_example',
+                           sources=['example_wrap.cxx', 'example.cpp'],
+                           language='c++',
+                           extra_objects=['hello.o', 'zmetal.o'],
+                           )
+
+setup (name = 'example',
+       version = '0.1',
+       author      = "SWIG Docs",
+       description = """Simple swig example from docs""",
+       ext_modules = [example_module],
+       py_modules = ["example"],
+       )

--- a/native/python/swig/sample/setup.py
+++ b/native/python/swig/sample/setup.py
@@ -4,7 +4,7 @@
 setup.py file for SWIG example
 """
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 
 example_module = Extension('_example',

--- a/native/python/swig/sample/setup.py
+++ b/native/python/swig/sample/setup.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 
 """
-setup.py file for SWIG example
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
 """
 
 from setuptools import setup, Extension
-
 
 example_module = Extension('_example',
                            sources=['example_wrap.cxx', 'example.cpp'],

--- a/native/python/swig/sample/zmetal.c
+++ b/native/python/swig/sample/zmetal.c
@@ -1,0 +1,11 @@
+/* File: zmetal.c */
+
+#include "zmetal.h"
+#include <stdio.h>
+
+#pragma prolog(HELLO, "&CCN_MAIN SETB 1 \n MYPROLOG")
+
+int HELLO(const char* name, char* output, int* outsize) {
+    snprintf(output, *outsize, "Hello, %s!", name);
+    return 0;
+}

--- a/native/python/swig/sample/zmetal.c
+++ b/native/python/swig/sample/zmetal.c
@@ -1,4 +1,13 @@
-/* File: zmetal.c */
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
 
 #include "zmetal.h"
 #include <stdio.h>

--- a/native/python/swig/sample/zmetal.h
+++ b/native/python/swig/sample/zmetal.h
@@ -1,0 +1,20 @@
+/* File: zmetal.h */
+
+#ifndef ZMETAL_H
+#define ZMETAL_H
+
+#if defined(__cplusplus) && (defined(__IBMCPP__) || defined(__IBMC__))
+extern "OS"
+{
+#elif defined(__cplusplus)
+extern "C"
+{
+#endif
+
+int HELLO(const char* name, char* output, int* outsize);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/native/python/swig/sample/zmetal.h
+++ b/native/python/swig/sample/zmetal.h
@@ -3,7 +3,7 @@
 #ifndef ZMETAL_H
 #define ZMETAL_H
 
-#if defined(__cplusplus) && (defined(__IBMCPP__) || defined(__IBMC__))
+#if defined(__cplusplus) && defined(__MVS__)
 extern "OS"
 {
 #elif defined(__cplusplus)

--- a/native/python/swig/sample/zmetal.h
+++ b/native/python/swig/sample/zmetal.h
@@ -1,4 +1,13 @@
-/* File: zmetal.h */
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
 
 #ifndef ZMETAL_H
 #define ZMETAL_H

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "z:all": "npm run z:rebuild && npm run z:package && npm run z:test",
     "z:artifacts": "tsx scripts/buildTools.ts artifacts",
     "z:build": "tsx scripts/buildTools.ts build",
+    "z:build:swig": "tsx scripts/buildTools.ts build:swig",
     "z:chdsect": "tsx scripts/buildTools.ts build:chdsect",
     "z:clean": "tsx scripts/buildTools.ts clean",
     "z:delete": "tsx scripts/buildTools.ts delete",

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -1122,14 +1122,7 @@ function getServerFiles(dir = "") {
                 }
 
                 if (stats.isDirectory()) {
-                    const files = fs.readdirSync(path.resolve(__dirname, `${localDeployDir}/${arg}`), {
-                        withFileTypes: true,
-                    });
-                    for (const entry of files) {
-                        if (!entry.isDirectory()) {
-                            fileList.push(`${arg}/${entry.name}`);
-                        }
-                    }
+                    fileList.push(...getFilesRecursive(arg.replace(/\/+$/, "")));
                 } else {
                     fileList.push(arg);
                 }
@@ -1153,6 +1146,20 @@ function getServerFiles(dir = "") {
         }
     }
     return filesList;
+}
+
+function getFilesRecursive(dir: string): string[] {
+    const fileList: string[] = [];
+    const entries = fs.readdirSync(path.resolve(__dirname, `${localDeployDir}/${dir}`), { withFileTypes: true });
+    for (const entry of entries) {
+        const entryPath = `${dir}/${entry.name}`;
+        if (entry.isDirectory()) {
+            fileList.push(...getFilesRecursive(entryPath));
+        } else {
+            fileList.push(entryPath);
+        }
+    }
+    return fileList;
 }
 
 function getDirs(next = "") {
@@ -1240,7 +1247,8 @@ async function downloadTarball(url: string, destPath: string, label: string) {
     try {
         response = await fetch(url);
     } catch (err) {
-        throw new Error(`Failed to download ${label} tarball from ${url}: ${err}`);
+        const reason = err instanceof Error && err.cause ? err.cause : err;
+        throw new Error(`Failed to download ${label} tarball from ${url}: ${reason}`);
     }
     if (!response.ok) {
         throw new Error(`Failed to download ${label} tarball from ${url}: ${response.status} ${response.statusText}`);
@@ -1251,10 +1259,8 @@ async function downloadTarball(url: string, destPath: string, label: string) {
 async function buildSwig(connection: Client) {
     const cacheDir = path.resolve(__dirname, "./../.cache");
     fs.mkdirSync(cacheDir, { recursive: true });
-
     const swigVersion = getLatestTag("swig/swig").slice(1);
     const swigTgz = path.join(cacheDir, `swig-${swigVersion}.tar.gz`);
-
     const pcreVersion = getLatestTag("PCRE2Project/pcre2").split("-").pop();
     const pcreTgz = path.join(cacheDir, `pcre2-${pcreVersion}.tar.gz`);
 
@@ -1275,8 +1281,10 @@ async function buildSwig(connection: Client) {
                 return;
             }
             try {
-                await uploadFile(sftpcon, swigTgz, `${deployDirs.pythonSwigDir}/swig-${swigVersion}.tar.gz`, false);
-                await uploadFile(sftpcon, pcreTgz, `${deployDirs.pythonSwigDir}/pcre2-${pcreVersion}.tar.gz`, false);
+                await Promise.all([
+                    uploadFile(sftpcon, swigTgz, `${deployDirs.pythonSwigDir}/swig-${swigVersion}.tar.gz`, false),
+                    uploadFile(sftpcon, pcreTgz, `${deployDirs.pythonSwigDir}/pcre2-${pcreVersion}.tar.gz`, false),
+                ]);
                 sftpcon.end();
                 resolve();
             } catch (uploadErr) {
@@ -1483,7 +1491,7 @@ async function upload(connection: Client, sshProfile: IProfile) {
                 throw err;
             }
 
-            const filteredDirs = args[1] ? dirs.filter((dir) => args.some((arg) => `${arg}/`.startsWith(dir))) : dirs;
+            const filteredDirs = args[1] ? dirs.filter((dir) => files.some((file) => file.startsWith(dir))) : dirs;
             for (const dir of ["", ...filteredDirs]) {
                 await new Promise<void>((resolve, reject) => {
                     sftpcon.mkdir(`${deployDirs.root}/${dir}`, (err) => {

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -1219,7 +1219,7 @@ async function packPrecompiled(connection: Client) {
     console.log("Precompiled bindings downloaded to dist/zbind_bin_dist.tar.gz");
 }
 
-function getLatestTag(repoName: string) {
+function getLatestTag(repoName: string, prefix?: string) {
     // --sort=-version:refname sorts tags by their numeric version (descending)
     const out = childProcess.execSync(
         `git ls-remote --tags --refs --sort=-version:refname https://github.com/${repoName}.git`,
@@ -1229,7 +1229,9 @@ function getLatestTag(repoName: string) {
         const lastSlashIdx = line.lastIndexOf("/");
         tags.push(line.slice(lastSlashIdx + 1));
     }
-    return tags.filter((tag) => !tag.includes("beta"))[0];
+    const isPrerelease = (tag: string) => tag.includes("-beta") || tag.includes("-RC");
+    const matchesPrefix = (tag: string) => prefix == null || tag.startsWith(prefix);
+    return tags.filter((tag) => !isPrerelease(tag) && matchesPrefix(tag))[0];
 }
 
 /**
@@ -1238,10 +1240,11 @@ function getLatestTag(repoName: string) {
  * (e.g. the tarball was removed from the host), so callers fail fast instead
  * of proceeding to extract a missing or invalid archive.
  */
-async function downloadTarball(url: string, destPath: string, label: string) {
+async function downloadTarball(url: string, destPath: string) {
     if (fs.existsSync(destPath)) {
         return;
     }
+    const label = destPath.split(/\W/)[0].toUpperCase();
     console.log(`Downloading ${label} tarball...`);
     let response: Response;
     try {
@@ -1259,17 +1262,16 @@ async function downloadTarball(url: string, destPath: string, label: string) {
 async function buildSwig(connection: Client) {
     const cacheDir = path.resolve(__dirname, "./../.cache");
     fs.mkdirSync(cacheDir, { recursive: true });
-    const swigVersion = getLatestTag("swig/swig").slice(1);
+    const swigVersion = getLatestTag("swig/swig", "v4.").slice(1);
     const swigTgz = path.join(cacheDir, `swig-${swigVersion}.tar.gz`);
     const pcreVersion = getLatestTag("PCRE2Project/pcre2").split("-").pop();
     const pcreTgz = path.join(cacheDir, `pcre2-${pcreVersion}.tar.gz`);
 
     await Promise.all([
-        downloadTarball(`http://prdownloads.sourceforge.net/swig/swig-${swigVersion}.tar.gz`, swigTgz, "SWIG"),
+        downloadTarball(`https://prdownloads.sourceforge.net/swig/swig-${swigVersion}.tar.gz`, swigTgz),
         downloadTarball(
             `https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${pcreVersion}/pcre2-${pcreVersion}.tar.gz`,
             pcreTgz,
-            "PCRE2",
         ),
     ]);
 

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -1213,13 +1213,39 @@ async function packPrecompiled(connection: Client) {
 }
 
 function getLatestTag(repoName: string) {
-    const out = childProcess.execSync(`git ls-remote --tags --refs https://github.com/${repoName}.git`);
+    // --sort=-version:refname sorts tags by their numeric version (descending)
+    const out = childProcess.execSync(
+        `git ls-remote --tags --refs --sort=-version:refname https://github.com/${repoName}.git`,
+    );
     const tags = [];
     for (const line of out.toString().trim().split(/\r?\n/)) {
         const lastSlashIdx = line.lastIndexOf("/");
         tags.push(line.slice(lastSlashIdx + 1));
     }
-    return tags.filter((tag) => !tag.includes("beta")).pop();
+    return tags.filter((tag) => !tag.includes("beta"))[0];
+}
+
+/**
+ * Downloads a tarball to `destPath` if it isn't already cached. Throws if the
+ * request fails outright (network error) or resolves with a non-2xx status
+ * (e.g. the tarball was removed from the host), so callers fail fast instead
+ * of proceeding to extract a missing or invalid archive.
+ */
+async function downloadTarball(url: string, destPath: string, label: string) {
+    if (fs.existsSync(destPath)) {
+        return;
+    }
+    console.log(`Downloading ${label} tarball...`);
+    let response: Response;
+    try {
+        response = await fetch(url);
+    } catch (err) {
+        throw new Error(`Failed to download ${label} tarball from ${url}: ${err}`);
+    }
+    if (!response.ok) {
+        throw new Error(`Failed to download ${label} tarball from ${url}: ${response.status} ${response.statusText}`);
+    }
+    fs.writeFileSync(destPath, Buffer.from(await response.arrayBuffer()));
 }
 
 async function buildSwig(connection: Client) {
@@ -1228,21 +1254,18 @@ async function buildSwig(connection: Client) {
 
     const swigVersion = getLatestTag("swig/swig").slice(1);
     const swigTgz = path.join(cacheDir, `swig-${swigVersion}.tar.gz`);
-    if (!fs.existsSync(swigTgz)) {
-        console.log("Downloading SWIG tarball...");
-        const response = await fetch(`http://prdownloads.sourceforge.net/swig/swig-${swigVersion}.tar.gz`);
-        fs.writeFileSync(swigTgz, Buffer.from(await response.arrayBuffer()));
-    }
 
     const pcreVersion = getLatestTag("PCRE2Project/pcre2").split("-").pop();
     const pcreTgz = path.join(cacheDir, `pcre2-${pcreVersion}.tar.gz`);
-    if (!fs.existsSync(pcreTgz)) {
-        console.log("Downloading PCRE2 tarball...");
-        const response = await fetch(
+
+    await Promise.all([
+        downloadTarball(`http://prdownloads.sourceforge.net/swig/swig-${swigVersion}.tar.gz`, swigTgz, "SWIG"),
+        downloadTarball(
             `https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${pcreVersion}/pcre2-${pcreVersion}.tar.gz`,
-        );
-        fs.writeFileSync(pcreTgz, Buffer.from(await response.arrayBuffer()));
-    }
+            pcreTgz,
+            "PCRE2",
+        ),
+    ]);
 
     console.log("Uploading source tarballs...");
     await new Promise<void>((resolve, reject) => {

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -1122,7 +1122,7 @@ function getServerFiles(dir = "") {
                 }
 
                 if (stats.isDirectory()) {
-                    fileList.push(...getFilesRecursive(arg.replace(/\/+$/, "")));
+                    fileList.push(...getFilesRecursive(arg.replace(/\/$/, "")));
                 } else {
                     fileList.push(arg);
                 }
@@ -1231,7 +1231,7 @@ function getLatestTag(repoName: string, prefix?: string) {
     }
     const isPrerelease = (tag: string) => tag.includes("-beta") || tag.includes("-RC");
     const matchesPrefix = (tag: string) => prefix == null || tag.startsWith(prefix);
-    return tags.filter((tag) => !isPrerelease(tag) && matchesPrefix(tag))[0];
+    return tags.find((tag) => !isPrerelease(tag) && matchesPrefix(tag));
 }
 
 /**

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -1223,11 +1223,11 @@ function getLatestTag(repoName: string) {
 }
 
 async function buildSwig(connection: Client) {
-    const buildDir = path.resolve(__dirname, "./../build");
-    fs.mkdirSync(buildDir, { recursive: true });
+    const cacheDir = path.resolve(__dirname, "./../.cache");
+    fs.mkdirSync(cacheDir, { recursive: true });
 
     const swigVersion = getLatestTag("swig/swig").slice(1);
-    const swigTgz = path.join(buildDir, `swig-${swigVersion}.tar.gz`);
+    const swigTgz = path.join(cacheDir, `swig-${swigVersion}.tar.gz`);
     if (!fs.existsSync(swigTgz)) {
         console.log("Downloading SWIG tarball...");
         const response = await fetch(`http://prdownloads.sourceforge.net/swig/swig-${swigVersion}.tar.gz`);
@@ -1235,7 +1235,7 @@ async function buildSwig(connection: Client) {
     }
 
     const pcreVersion = getLatestTag("PCRE2Project/pcre2").split("-").pop();
-    const pcreTgz = path.join(buildDir, `pcre2-${pcreVersion}.tar.gz`);
+    const pcreTgz = path.join(cacheDir, `pcre2-${pcreVersion}.tar.gz`);
     if (!fs.existsSync(pcreTgz)) {
         console.log("Downloading PCRE2 tarball...");
         const response = await fetch(
@@ -1271,8 +1271,8 @@ async function buildSwig(connection: Client) {
         },
     );
     const filename = `swig-${swigVersion}.pax.Z`;
-    await retrieve(connection, [`python/swig/${filename}`], "build", true);
-    console.log(`SWIG package downloaded to build/${filename}`);
+    await retrieve(connection, [`python/swig/${filename}`], "dist", true);
+    console.log(`SWIG package downloaded to dist/${filename}`);
 }
 
 /**

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -126,6 +126,7 @@ let deployDirs: {
     cTestDir: string;
     pythonDir: string;
     pythonTestDir: string;
+    pythonSwigDir: string;
 };
 
 // python3 -c "import sys; sys.stdout.buffer.write(bytes(range(256)))" \
@@ -1211,6 +1212,69 @@ async function packPrecompiled(connection: Client) {
     console.log("Precompiled bindings downloaded to dist/zbind_bin_dist.tar.gz");
 }
 
+function getLatestTag(repoName: string) {
+    const out = childProcess.execSync(`git ls-remote --tags --refs https://github.com/${repoName}.git`);
+    const tags = [];
+    for (const line of out.toString().trim().split(/\r?\n/)) {
+        const lastSlashIdx = line.lastIndexOf("/");
+        tags.push(line.slice(lastSlashIdx + 1));
+    }
+    return tags.filter((tag) => !tag.includes("beta")).pop();
+}
+
+async function buildSwig(connection: Client) {
+    const buildDir = path.resolve(__dirname, "./../build");
+    fs.mkdirSync(buildDir, { recursive: true });
+
+    const swigVersion = getLatestTag("swig/swig").slice(1);
+    const swigTgz = path.join(buildDir, `swig-${swigVersion}.tar.gz`);
+    if (!fs.existsSync(swigTgz)) {
+        console.log("Downloading SWIG tarball...");
+        const response = await fetch(`http://prdownloads.sourceforge.net/swig/swig-${swigVersion}.tar.gz`);
+        fs.writeFileSync(swigTgz, Buffer.from(await response.arrayBuffer()));
+    }
+
+    const pcreVersion = getLatestTag("PCRE2Project/pcre2").split("-").pop();
+    const pcreTgz = path.join(buildDir, `pcre2-${pcreVersion}.tar.gz`);
+    if (!fs.existsSync(pcreTgz)) {
+        console.log("Downloading PCRE2 tarball...");
+        const response = await fetch(
+            `https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${pcreVersion}/pcre2-${pcreVersion}.tar.gz`,
+        );
+        fs.writeFileSync(pcreTgz, Buffer.from(await response.arrayBuffer()));
+    }
+
+    console.log("Uploading source tarballs...");
+    await new Promise<void>((resolve, reject) => {
+        connection.sftp(async (err, sftpcon) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+            try {
+                await uploadFile(sftpcon, swigTgz, `${deployDirs.pythonSwigDir}/swig-${swigVersion}.tar.gz`, false);
+                await uploadFile(sftpcon, pcreTgz, `${deployDirs.pythonSwigDir}/pcre2-${pcreVersion}.tar.gz`, false);
+                sftpcon.end();
+                resolve();
+            } catch (uploadErr) {
+                reject(uploadErr);
+            }
+        });
+    });
+
+    await runCommandInShell(
+        connection,
+        `cd ${deployDirs.pythonSwigDir} && LDFLAGS='' . build.sh "${swigVersion}" "${pcreVersion}"`,
+        {
+            streamOutput: true,
+            stepName: "Building SWIG for z/OS",
+        },
+    );
+    const filename = `swig-${swigVersion}.pax.Z`;
+    await retrieve(connection, [`python/swig/${filename}`], "build", true);
+    console.log(`SWIG package downloaded to build/${filename}`);
+}
+
 /**
  * Checks whether `swig` is available on the remote system using the same PATH
  * the build uses (preBuildCmd is prepended by runCommandInShell). Sets a
@@ -1932,6 +1996,7 @@ async function main() {
         cTestDir: `${config.deployDir}/c/test`,
         pythonDir: `${config.deployDir}/python/bindings`,
         pythonTestDir: `${config.deployDir}/python/bindings/test`,
+        pythonSwigDir: `${config.deployDir}/python/swig`,
     };
     const sshClient = await buildSshClient(config.sshProfile as IProfile);
     await testConnection(sshClient);
@@ -1957,6 +2022,9 @@ async function main() {
                 break;
             case "make":
                 await make(sshClient);
+                break;
+            case "build:swig":
+                await buildSwig(sshClient);
                 break;
             case "has:swig":
                 await hasSwig(sshClient);

--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -1231,7 +1231,11 @@ function getLatestTag(repoName: string, prefix?: string) {
     }
     const isPrerelease = (tag: string) => tag.includes("-beta") || tag.includes("-RC");
     const matchesPrefix = (tag: string) => prefix == null || tag.startsWith(prefix);
-    return tags.find((tag) => !isPrerelease(tag) && matchesPrefix(tag));
+    const foundTag = tags.find((tag) => !isPrerelease(tag) && matchesPrefix(tag));
+    if (foundTag == null) {
+        throw Error(`No stable tag found for ${repoName}`);
+    }
+    return foundTag;
 }
 
 /**
@@ -1244,7 +1248,7 @@ async function downloadTarball(url: string, destPath: string) {
     if (fs.existsSync(destPath)) {
         return;
     }
-    const label = destPath.split(/\W/)[0].toUpperCase();
+    const label = path.basename(destPath).split(/\W/)[0];
     console.log(`Downloading ${label} tarball...`);
     let response: Response;
     try {
@@ -1256,7 +1260,19 @@ async function downloadTarball(url: string, destPath: string) {
     if (!response.ok) {
         throw new Error(`Failed to download ${label} tarball from ${url}: ${response.status} ${response.statusText}`);
     }
-    fs.writeFileSync(destPath, Buffer.from(await response.arrayBuffer()));
+    await new Promise<void>((resolve, reject) => {
+        pipeline(
+            Readable.fromWeb(response.body as import("node:stream/web").ReadableStream),
+            fs.createWriteStream(destPath),
+            (err) => {
+                if (err) {
+                    reject(new Error(`Failed to download ${label} tarball from ${url}: ${err}`));
+                } else {
+                    resolve();
+                }
+            },
+        );
+    });
 }
 
 async function buildSwig(connection: Client) {
@@ -1268,12 +1284,13 @@ async function buildSwig(connection: Client) {
     const pcreTgz = path.join(cacheDir, `pcre2-${pcreVersion}.tar.gz`);
 
     await Promise.all([
-        downloadTarball(`https://prdownloads.sourceforge.net/swig/swig-${swigVersion}.tar.gz`, swigTgz),
+        downloadTarball(`http://prdownloads.sourceforge.net/swig/swig-${swigVersion}.tar.gz`, swigTgz),
         downloadTarball(
             `https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${pcreVersion}/pcre2-${pcreVersion}.tar.gz`,
             pcreTgz,
         ),
     ]);
+    process.exit(1);
 
     console.log("Uploading source tarballs...");
     await new Promise<void>((resolve, reject) => {
@@ -1287,10 +1304,11 @@ async function buildSwig(connection: Client) {
                     uploadFile(sftpcon, swigTgz, `${deployDirs.pythonSwigDir}/swig-${swigVersion}.tar.gz`, false),
                     uploadFile(sftpcon, pcreTgz, `${deployDirs.pythonSwigDir}/pcre2-${pcreVersion}.tar.gz`, false),
                 ]);
-                sftpcon.end();
                 resolve();
             } catch (uploadErr) {
                 reject(uploadErr);
+            } finally {
+                sftpcon.end();
             }
         });
     });
@@ -1352,10 +1370,11 @@ async function applyPrecompiled(connection: Client) {
             }
             try {
                 await uploadFile(sftpcon, localTarball, remoteTarball, false);
-                sftpcon.end();
                 resolve();
             } catch (uploadErr) {
                 reject(uploadErr);
+            } finally {
+                sftpcon.end();
             }
         });
     });


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Automates building SWIG on z/OS with `npm run z:build:swig` and downloads it to `dist/swig-4.4.1.pax.Z`

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Try building SWIG yourself or use the prebuilt version from [GitHub release](https://github.com/zowe/zowex/releases/download/py-bindings-dev/swig-4.4.1.pax.Z) 😋 

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
