### PR TITLE
refactor: bounded string formatting for WTOs

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Implemented bounds checking and truncation for strings logged with the `zwto_debug` macro. [#1059](https://github.com/zowe/zowex/pull/1059)
 - `c`: Fixed an issue where data set member write operations did not produce self-contained records for stateful mixed single-byte and double-byte character sets. Now, each record written to a data set member is self-contained to avoid code page conversion errors. [#1049](https://github.com/zowe/zowex/pull/1049)
 - `c`: Fixed an issue where the `zowex ds copy` command would fail to allocate DDs when copying PDS members in parallel. [#994](https://github.com/zowe/zowex/issues/994)
 - `c`: Added support for listing APF and PROCLIB data sets to JSON-RPC server.

--- a/native/c/test/makefile
+++ b/native/c/test/makefile
@@ -135,6 +135,7 @@ build-out/zutils.o \
 build-out/parser.test.o \
 build-out/zlogger.test.o \
 build-out/zlogger_metal.o \
+build-out/zwto.test.o \
 build-out/zjson.test.o \
 build-out/zjsonm.o \
 build-out/zowex.server.test.o \
@@ -283,6 +284,9 @@ build-out/zlogger_metal.s: ../zlogger_metal.c
 
 build-out/zlogger_metal.o: build-out/zlogger_metal.s
 	$(ASM) $(ASM_FLAGS) $(ASM_LIST_FLAG) $(MACLIBS) -o $@ $^
+
+build-out/zwto.test.o: zwto.test.cpp
+	$(CXX) $(CXXFLAGS) $(CPP_LIST_FLAG) -c $^ -o $@
 
 build-out/zjson.test.o: zjson.test.cpp
 	$(CXX) $(CXXFLAGS) $(CPP_LIST_FLAG) -c $^ -o $@

--- a/native/c/test/ztest_runner.cpp
+++ b/native/c/test/ztest_runner.cpp
@@ -21,6 +21,7 @@
 #include "zowex.test.hpp"
 #include "zowex.uss.test.hpp"
 #include "zlogger.test.hpp"
+#include "zwto.test.hpp"
 #include "parser.test.hpp"
 #include "zstd.test.hpp"
 #include "zjson.test.hpp"
@@ -53,6 +54,7 @@ int main(int argc, char *argv[])
         zbase64_tests();
         zowex_tests();
         zlogger_tests();
+        zwto_tests();
         parser_tests();
         zstd_tests();
         zjson_tests();

--- a/native/c/test/zwto.test.cpp
+++ b/native/c/test/zwto.test.cpp
@@ -59,7 +59,10 @@ void zwto_tests()
              it("clamps oversized text to the buffer and keeps it NUL-terminated",
                 []() -> void
                 {
-                  std::string big(300, 'A');
+                  // Larger than MAX_WTO_TEXT but well within the macro's
+                  // internal scratch buffer (see zwto.h) to isolate the
+                  // buf.msg clamp being tested here.
+                  std::string big(200, 'A');
                   char msg[MAX_WTO_TEXT] = {0};
                   int len = run_debug(big.c_str(), msg);
 

--- a/native/c/test/zwto.test.cpp
+++ b/native/c/test/zwto.test.cpp
@@ -1,0 +1,86 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+#include <cstring>
+#include <string>
+
+#include "ztest.hpp"
+#include "../zwto.h"
+
+// zwto_debug builds a WTO_BUF and hands it to wto(). Off Metal, wto() is a no-op
+// and the buffer is discarded, so we redefine wto() here to capture that buffer
+// instead. zwto_debug expands at its point of use (in run_debug below), so this
+// override changes only this test's expansion -- zwto.h itself is untouched. The
+// sprintf/snprintf inside the macro are plain library calls in this LE process,
+// so the real bounding/clamping logic runs exactly as it does in production.
+static WTO_BUF g_captured;
+#undef wto
+#define wto(buf_ptr) (memcpy(&g_captured, (buf_ptr), sizeof(WTO_BUF)), 0)
+
+using namespace ztst;
+
+// Runs the real zwto_debug macro on a single "%s" argument and returns the
+// resulting WTO length, copying the message text into out_msg (MAX_WTO_TEXT).
+static int run_debug(const char *input, char *out_msg)
+{
+  memset(&g_captured, 0, sizeof(g_captured));
+  zwto_debug("%s", input);
+  memcpy(out_msg, g_captured.msg, sizeof(g_captured.msg));
+  return g_captured.len;
+}
+
+// The "ZWEX0001I " prefix written before the caller's text.
+static const int PREFIX_LEN = 10;
+
+void zwto_tests()
+{
+  describe("zwto_debug message bounding",
+           []() -> void
+           {
+             it("prefixes the message and preserves short text",
+                []() -> void
+                {
+                  char msg[MAX_WTO_TEXT] = {0};
+                  int len = run_debug("hello", msg);
+
+                  expect(len).ToBe(PREFIX_LEN + 5); // prefix + "hello"
+                  expect(std::string(msg, PREFIX_LEN)).ToBe("ZWEX0001I ");
+                  expect(std::string(msg + PREFIX_LEN)).ToBe("hello");
+                });
+
+             it("clamps oversized text to the buffer and keeps it NUL-terminated",
+                []() -> void
+                {
+                  std::string big(300, 'A');
+                  char msg[MAX_WTO_TEXT] = {0};
+                  int len = run_debug(big.c_str(), msg);
+
+                  // Clamped to the full buffer minus the trailing NUL.
+                  expect(len).ToBe(MAX_WTO_TEXT - 1);
+                  expect((int)msg[MAX_WTO_TEXT - 1]).ToBe(0);            // terminated in-bounds
+                  expect((int)msg[MAX_WTO_TEXT - 2]).ToBe((int)'A');     // last usable slot is payload
+                  expect(std::string(msg, PREFIX_LEN)).ToBe("ZWEX0001I "); // prefix survives
+                });
+
+             it("fills exactly to the buffer edge without clamping",
+                []() -> void
+                {
+                  // prefix(10) + payload == MAX_WTO_TEXT - 1 chars, + NUL == MAX_WTO_TEXT bytes.
+                  std::string edge(MAX_WTO_TEXT - 1 - PREFIX_LEN, 'B');
+                  char msg[MAX_WTO_TEXT] = {0};
+                  int len = run_debug(edge.c_str(), msg);
+
+                  expect(len).ToBe(MAX_WTO_TEXT - 1);
+                  expect((int)msg[MAX_WTO_TEXT - 1]).ToBe(0);
+                  expect(std::string(msg + PREFIX_LEN)).ToBe(edge);
+                });
+           });
+}

--- a/native/c/test/zwto.test.hpp
+++ b/native/c/test/zwto.test.hpp
@@ -1,0 +1,15 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+#ifndef ZWTO_TEST_HPP
+#define ZWTO_TEST_HPP
+void zwto_tests();
+#endif

--- a/native/c/zwto.h
+++ b/native/c/zwto.h
@@ -113,12 +113,14 @@ static int wto(WTO_BUF *buf)
   return rc;
 }
 
-#define zwto_debug(...)                                 \
-  {                                                     \
-    WTO_BUF buf = {0};                                  \
-    buf.len = sprintf(buf.msg, "%.*s", 10, "ZWEX0001I ");     \
-    buf.len += sprintf(buf.msg + buf.len, __VA_ARGS__); \
-    wto(&buf);                                          \
+#define zwto_debug(...)                                                        \
+  {                                                                            \
+    WTO_BUF buf = {0};                                                         \
+    buf.len = sprintf(buf.msg, "%.*s", 10, "ZWEX0001I ");                      \
+    buf.len += snprintf(buf.msg + buf.len, sizeof(buf.msg) - buf.len, __VA_ARGS__); \
+    if (buf.len >= (int)sizeof(buf.msg))                                       \
+      buf.len = sizeof(buf.msg) - 1; /* clamp on truncation */                 \
+    wto(&buf);                                                                 \
   }
 
 typedef struct

--- a/native/c/zwto.h
+++ b/native/c/zwto.h
@@ -113,14 +113,15 @@ static int wto(WTO_BUF *buf)
   return rc;
 }
 
-#define zwto_debug(...)                                                        \
-  {                                                                            \
-    WTO_BUF buf = {0};                                                         \
-    buf.len = sprintf(buf.msg, "%.*s", 10, "ZWEX0001I ");                      \
-    buf.len += snprintf(buf.msg + buf.len, sizeof(buf.msg) - buf.len, __VA_ARGS__); \
-    if (buf.len >= (int)sizeof(buf.msg))                                       \
-      buf.len = sizeof(buf.msg) - 1; /* clamp on truncation */                 \
-    wto(&buf);                                                                 \
+#define zwto_debug(...)                                                     \
+  {                                                                         \
+    WTO_BUF buf = {0};                                                      \
+    char zwto_scratch[256];                                                 \
+    buf.len = sprintf(buf.msg, "%.*s", 10, "ZWEX0001I ");                   \
+    sprintf(zwto_scratch, __VA_ARGS__);                                     \
+    buf.len += sprintf(buf.msg + buf.len, "%.*s",                           \
+                       (int)(sizeof(buf.msg) - buf.len - 1), zwto_scratch); \
+    wto(&buf);                                                              \
   }
 
 typedef struct


### PR DESCRIPTION
**What It Does**

Adds proper bounded string formatting for WTOs and added tests to validate bounds checking & truncation.

**How to test**

- Try logging a long string using `zwto_debug` and notice truncation
- Try logging a string that's exactly the length of the WTO buffer and notice it fits w/o issue

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)