### PR TITLE
Fix handling of control bytes in zjson library

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -7,7 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Recent Changes
 
 - `c`: Added support to return information for current linklist. [#1061](https://github.com/zowe/zowex/pull/1061)
-- `c`: Made handling of control bytes (`0x0`-`0x1f`) in JSON safer. Now when an object is serialized control bytes are replaced with the Unicode substitution character, and when an string is deserialized control bytes are rejected as invalid. [#1078](https://github.com/zowe/zowex/pull/1078)
+- `c`: Made handling of control bytes (`0x0`-`0x1f`) in JSON safer. Now when an object is serialized, control bytes are replaced with the Unicode substitution character, and when a string is deserialized, control bytes are rejected as invalid. [#1078](https://github.com/zowe/zowex/pull/1078)
 
 ## `0.6.1`
 

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Recent Changes
 
 - `c`: Added support to return information for current linklist. [#1061](https://github.com/zowe/zowex/pull/1061)
+- `c`: Made handling of control bytes (`0x0`-`0x1f`) in JSON safer. Now when an object is serialized control bytes are replaced with the Unicode substitution character, and when an string is deserialized control bytes are rejected as invalid. [#1078](https://github.com/zowe/zowex/pull/1078)
 
 ## `0.6.1`
 

--- a/native/c/test/server/validator.test.cpp
+++ b/native/c/test/server/validator.test.cpp
@@ -43,10 +43,10 @@ void test_basic_validation()
                 FieldDescriptor("name", FieldType::TYPE_STRING, true),
                 FieldDescriptor("age", FieldType::TYPE_NUMBER, true)
             };
-            
+
             auto params = create_test_object(R"({"name": "John"})");
             auto result = validate_schema(params, schema, 2, false);
-            
+
             Expect(result.is_valid).ToBe(false);
             Expect(result.error_message.find("Missing required field: age") != std::string::npos).ToBe(true);
         });
@@ -56,10 +56,10 @@ void test_basic_validation()
                 FieldDescriptor("name", FieldType::TYPE_STRING, true),
                 FieldDescriptor("age", FieldType::TYPE_NUMBER, true)
             };
-            
+
             auto params = create_test_object(R"({"name": "John", "age": 30})");
             auto result = validate_schema(params, schema, 2, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -68,10 +68,10 @@ void test_basic_validation()
                 FieldDescriptor("name", FieldType::TYPE_STRING, true),
                 FieldDescriptor("email", FieldType::TYPE_STRING, false)
             };
-            
+
             auto params = create_test_object(R"({"name": "John"})");
             auto result = validate_schema(params, schema, 2, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -80,10 +80,10 @@ void test_basic_validation()
                 FieldDescriptor("name", FieldType::TYPE_STRING, true),
                 FieldDescriptor("email", FieldType::TYPE_STRING, false)
             };
-            
+
             auto params = create_test_object(R"({"name": "John", "email": null})");
             auto result = validate_schema(params, schema, 2, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         }); });
 }
@@ -100,10 +100,10 @@ void test_type_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("name", FieldType::TYPE_STRING, true)
             };
-            
+
             auto params = create_test_object(R"({"name": "John"})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -111,10 +111,10 @@ void test_type_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("name", FieldType::TYPE_STRING, true)
             };
-            
+
             auto params = create_test_object(R"({"name": 123})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(false);
             Expect(result.error_message.find("Expected string, got number") != std::string::npos).ToBe(true);
         });
@@ -123,10 +123,10 @@ void test_type_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("age", FieldType::TYPE_NUMBER, true)
             };
-            
+
             auto params = create_test_object(R"({"age": 30})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -134,10 +134,10 @@ void test_type_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("price", FieldType::TYPE_NUMBER, true)
             };
-            
+
             auto params = create_test_object(R"({"price": 29.99})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -145,10 +145,10 @@ void test_type_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("active", FieldType::TYPE_BOOL, true)
             };
-            
+
             auto params = create_test_object(R"({"active": true})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -156,10 +156,10 @@ void test_type_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("items", FieldType::TYPE_ARRAY, true)
             };
-            
+
             auto params = create_test_object(R"({"items": [1, 2, 3]})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -167,10 +167,10 @@ void test_type_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("config", FieldType::TYPE_OBJECT, true)
             };
-            
+
             auto params = create_test_object(R"({"config": {"key": "value"}})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -178,15 +178,15 @@ void test_type_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("data", FieldType::TYPE_ANY, true)
             };
-            
+
             auto params1 = create_test_object(R"({"data": "string"})");
             auto result1 = validate_schema(params1, schema, 1, false);
             Expect(result1.is_valid).ToBe(true);
-            
+
             auto params2 = create_test_object(R"({"data": 123})");
             auto result2 = validate_schema(params2, schema, 1, false);
             Expect(result2.is_valid).ToBe(true);
-            
+
             auto params3 = create_test_object(R"({"data": {"nested": true}})");
             auto result3 = validate_schema(params3, schema, 1, false);
             Expect(result3.is_valid).ToBe(true);
@@ -205,10 +205,10 @@ void test_unknown_fields()
             FieldDescriptor schema[] = {
                 FieldDescriptor("name", FieldType::TYPE_STRING, true)
             };
-            
+
             auto params = create_test_object(R"({"name": "John", "unknown": "value"})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(false);
             Expect(result.error_message.find("Unknown field: unknown") != std::string::npos).ToBe(true);
         });
@@ -217,10 +217,10 @@ void test_unknown_fields()
             FieldDescriptor schema[] = {
                 FieldDescriptor("name", FieldType::TYPE_STRING, true)
             };
-            
+
             auto params = create_test_object(R"({"name": "John", "unknown": "value"})");
             auto result = validate_schema(params, schema, 1, true);
-            
+
             Expect(result.is_valid).ToBe(true);
         }); });
 }
@@ -237,10 +237,10 @@ void test_array_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("numbers", FieldType::TYPE_ARRAY, true, FieldType::TYPE_NUMBER)
             };
-            
+
             auto params = create_test_object(R"({"numbers": [1, 2, 3]})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -248,10 +248,10 @@ void test_array_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("numbers", FieldType::TYPE_ARRAY, true, FieldType::TYPE_NUMBER)
             };
-            
+
             auto params = create_test_object(R"({"numbers": ["not", "numbers"]})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(false);
             Expect(result.error_message.find("numbers[0]") != std::string::npos).ToBe(true);
             Expect(result.error_message.find("Expected number, got string") != std::string::npos).ToBe(true);
@@ -261,10 +261,10 @@ void test_array_validation()
             FieldDescriptor schema[] = {
                 FieldDescriptor("numbers", FieldType::TYPE_ARRAY, true, FieldType::TYPE_NUMBER)
             };
-            
+
             auto params = create_test_object(R"({"numbers": []})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         }); });
 }
@@ -282,16 +282,16 @@ void test_nested_validation()
                 FieldDescriptor("host", FieldType::TYPE_STRING, true),
                 FieldDescriptor("port", FieldType::TYPE_NUMBER, true)
             };
-            
+
             FieldDescriptor schema[] = {
                 FieldDescriptor("config", FieldType::TYPE_OBJECT, true)
             };
             schema[0].nested_schema = nested_schema;
             schema[0].nested_schema_count = 2;
-            
+
             auto params = create_test_object(R"({"config": {"host": "localhost", "port": 8080}})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -300,16 +300,16 @@ void test_nested_validation()
                 FieldDescriptor("host", FieldType::TYPE_STRING, true),
                 FieldDescriptor("port", FieldType::TYPE_NUMBER, true)
             };
-            
+
             FieldDescriptor schema[] = {
                 FieldDescriptor("config", FieldType::TYPE_OBJECT, true)
             };
             schema[0].nested_schema = nested_schema;
             schema[0].nested_schema_count = 2;
-            
+
             auto params = create_test_object(R"({"config": {"host": "localhost"}})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(false);
             Expect(result.error_message.find("Missing required field: config.port") != std::string::npos).ToBe(true);
         });
@@ -319,16 +319,16 @@ void test_nested_validation()
                 FieldDescriptor("host", FieldType::TYPE_STRING, true),
                 FieldDescriptor("port", FieldType::TYPE_NUMBER, true)
             };
-            
+
             FieldDescriptor schema[] = {
                 FieldDescriptor("config", FieldType::TYPE_OBJECT, true)
             };
             schema[0].nested_schema = nested_schema;
             schema[0].nested_schema_count = 2;
-            
+
             auto params = create_test_object(R"({"config": {"host": "localhost", "port": "8080"}})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(false);
             Expect(result.error_message.find("config.port") != std::string::npos).ToBe(true);
             Expect(result.error_message.find("Expected number, got string") != std::string::npos).ToBe(true);
@@ -339,16 +339,16 @@ void test_nested_validation()
                 FieldDescriptor("id", FieldType::TYPE_NUMBER, true),
                 FieldDescriptor("name", FieldType::TYPE_STRING, true)
             };
-            
+
             FieldDescriptor schema[] = {
                 FieldDescriptor("users", FieldType::TYPE_ARRAY, true, FieldType::TYPE_OBJECT)
             };
             schema[0].nested_schema = nested_schema;
             schema[0].nested_schema_count = 2;
-            
+
             auto params = create_test_object(R"({"users": [{"id": 1, "name": "John"}]})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
@@ -357,16 +357,16 @@ void test_nested_validation()
                 FieldDescriptor("id", FieldType::TYPE_NUMBER, true),
                 FieldDescriptor("name", FieldType::TYPE_STRING, true)
             };
-            
+
             FieldDescriptor schema[] = {
                 FieldDescriptor("users", FieldType::TYPE_ARRAY, true, FieldType::TYPE_OBJECT)
             };
             schema[0].nested_schema = nested_schema;
             schema[0].nested_schema_count = 2;
-            
+
             auto params = create_test_object(R"({"users": [{"id": "not_number", "name": "John"}]})");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(false);
             Expect(result.error_message.find("users[0].id") != std::string::npos).ToBe(true);
             Expect(result.error_message.find("Expected number, got string") != std::string::npos).ToBe(true);
@@ -385,10 +385,10 @@ void test_error_cases()
             FieldDescriptor schema[] = {
                 FieldDescriptor("name", FieldType::TYPE_STRING, true)
             };
-            
-            auto params = create_test_object(R"("not an object")");
+
+            zjson::Value params("not an object");
             auto result = validate_schema(params, schema, 1, false);
-            
+
             Expect(result.is_valid).ToBe(false);
             Expect(result.error_message.find("Parameters must be an object") != std::string::npos).ToBe(true);
         });
@@ -396,14 +396,14 @@ void test_error_cases()
         it("should handle empty schema correctly", []() {
             auto params = create_test_object(R"({})");
             auto result = validate_schema(params, nullptr, 0, false);
-            
+
             Expect(result.is_valid).ToBe(true);
         });
 
         it("should detect unknown fields with empty schema", []() {
             auto params = create_test_object(R"({"unknown": "value"})");
             auto result = validate_schema(params, nullptr, 0, false);
-            
+
             Expect(result.is_valid).ToBe(false);
             Expect(result.error_message.find("Unknown field: unknown") != std::string::npos).ToBe(true);
         });
@@ -414,16 +414,16 @@ void test_error_cases()
             };
             nested_schema[0].nested_schema = nested_schema;
             nested_schema[0].nested_schema_count = 1;
-            
+
             FieldDescriptor schema[] = {
                 FieldDescriptor("config", FieldType::TYPE_OBJECT, true)
             };
             schema[0].nested_schema = nested_schema;
             schema[0].nested_schema_count = 1;
-            
+
             auto params = create_test_object(R"({"config": {"deep": {"deeper": "value"}}})");
             auto result = validate_schema(params, schema, 1, false, "parent");
-            
+
             Expect(result.is_valid).ToBe(false);
             Expect(result.error_message.find("Nested schemas beyond 1 level deep are not supported") != std::string::npos).ToBe(true);
         }); });

--- a/native/c/test/zjson.test.cpp
+++ b/native/c/test/zjson.test.cpp
@@ -328,16 +328,16 @@ void test_optional_types()
                 std::optional<std::string>(), // empty - should include as null
                 std::optional<int>()          // empty - should skip due to attribute
             };
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should include include_null as null
             bool has_include_null = json_str.find("include_null") != std::string::npos;
             Expect(has_include_null).ToBe(true);
-            
+
             // Should NOT include skip_if_none field
             bool has_skip_if_none = json_str.find("skip_if_none") != std::string::npos;
             Expect(has_skip_if_none).ToBe(false);
@@ -349,13 +349,13 @@ void test_optional_types()
                 std::optional<std::string>("present_value"),
                 std::optional<int>(42)
             };
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             auto restored_result = zjson::from_str<OptionalBehaviorStruct>(json_result.value());
             Expect(restored_result.has_value()).ToBe(true);
-            
+
             OptionalBehaviorStruct restored = restored_result.value();
             Expect(restored.include_null.has_value()).ToBe(true);
             Expect(restored.include_null.value()).ToBe(std::string("present_value"));
@@ -427,6 +427,48 @@ void test_basic_api()
             const auto &error = result.error();
             std::string error_msg = error.what();
             Expect(error_msg.length() > 0).ToBe(true);
+        });
+
+        it("should reject a control character escape when it is the entire parsed value", []() {
+            // A bare JSON string value containing a disallowed control character
+            // escape must fail the whole parse rather than silently producing a
+            // null/partial value.
+            std::string json = "\"bad\\u0001value\"";
+            auto result = zjson::from_str<zjson::Value>(json);
+            Expect(result.has_value()).ToBe(false);
+        });
+
+        it("should reject a control character escape nested inside an object field", []() {
+            // Previously, a bad nested string field was silently dropped from the
+            // object and the rest of the request still parsed. It must now fail
+            // the whole parse instead.
+            std::string json = "{\"dataset\": \"MY.DATA\\u0001SET\", \"member\": \"OK\"}";
+            auto result = zjson::from_str<zjson::Value>(json);
+            Expect(result.has_value()).ToBe(false);
+        });
+
+        it("should reject a control character escape nested inside an array element", []() {
+            std::string json = "[\"fine\", \"also fine\", \"bad\\u000Bvalue\"]";
+            auto result = zjson::from_str<zjson::Value>(json);
+            Expect(result.has_value()).ToBe(false);
+        });
+
+        it("should fail the whole parse when JSON nesting exceeds the depth limit", []() {
+            // Build JSON nested well past MAX_JSON_DEPTH (64). Previously this
+            // silently truncated to a null value at the depth limit; it must now
+            // fail the whole parse.
+            const int depth = 66;
+            std::string json;
+            for (int i = 0; i < depth; i++) {
+                json += "{\"a\":";
+            }
+            json += "1";
+            for (int i = 0; i < depth; i++) {
+                json += "}";
+            }
+
+            auto result = zjson::from_str<zjson::Value>(json);
+            Expect(result.has_value()).ToBe(false);
         });
 
         it("should support chained access patterns", []() {
@@ -606,18 +648,18 @@ void test_serialization_round_trips()
            {
         it("should serialize and deserialize SimpleStruct correctly", []() {
             SimpleStruct original{42, "test_name"};
-            
+
             // Serialize to JSON
             auto json_result = zjson::to_string(original);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
             Expect(json_str.length() > 0).ToBe(true);
-            
+
             // Deserialize back
             auto struct_result = zjson::from_str<SimpleStruct>(json_str);
             Expect(struct_result.has_value()).ToBe(true);
-            
+
             SimpleStruct restored = struct_result.value();
             Expect(restored.id).ToBe(original.id);
             Expect(restored.name).ToBe(original.name);
@@ -625,21 +667,21 @@ void test_serialization_round_trips()
 
         it("should handle pretty printing correctly", []() {
             SimpleStruct original{123, "pretty_test"};
-            
+
             auto pretty_result = zjson::to_string_pretty(original);
             Expect(pretty_result.has_value()).ToBe(true);
-            
+
             std::string pretty_json = pretty_result.value();
             Expect(pretty_json.length() > 0).ToBe(true);
-            
+
             // Should contain newlines and spaces for formatting
             bool has_newlines = pretty_json.find('\n') != std::string::npos;
             Expect(has_newlines).ToBe(true);
-            
+
             // Should still be parseable
             auto parsed_result = zjson::from_str<SimpleStruct>(pretty_json);
             Expect(parsed_result.has_value()).ToBe(true);
-            
+
             SimpleStruct restored = parsed_result.value();
             Expect(restored.id).ToBe(original.id);
             Expect(restored.name).ToBe(original.name);
@@ -650,13 +692,13 @@ void test_serialization_round_trips()
                 std::optional<int>(42),
                 std::optional<std::string>("test_string")
             };
-            
+
             auto json_result = zjson::to_string(original);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             auto restored_result = zjson::from_str<TestOptional>(json_result.value());
             Expect(restored_result.has_value()).ToBe(true);
-            
+
             TestOptional restored = restored_result.value();
             Expect(restored.opt_int.has_value()).ToBe(true);
             Expect(restored.opt_int.value()).ToBe(42);
@@ -669,60 +711,86 @@ void test_serialization_round_trips()
                 std::optional<int>(),        // empty
                 std::optional<std::string>() // empty
             };
-            
+
             auto json_result = zjson::to_string(original);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             auto restored_result = zjson::from_str<TestOptional>(json_result.value());
             Expect(restored_result.has_value()).ToBe(true);
-            
+
             TestOptional restored = restored_result.value();
             Expect(restored.opt_int.has_value()).ToBe(false);
             Expect(restored.opt_string.has_value()).ToBe(false);
         });
 
-        it("should properly escape and unescape all EBCDIC characters (0-255)", []() {
+        it("should escape a control character without a named JSON escape using the Unicode replacement character", []() {
+            // 0x01 (SOH) has no named JSON escape (unlike backspace/formfeed/newline/cr/tab).
+            // Its native byte value does not correspond to the same Unicode code point on
+            // this EBCDIC platform, so echoing its raw numeric value as a generic
+            // code-point escape would misrepresent it to a spec-compliant JSON reader.
+            // It should be replaced with the Unicode replacement character instead.
+            std::string input = "A";
+            input += static_cast<char>(0x01);
+            input += "B";
+
+            SimpleStruct original{42, input};
+
+            auto json_result = zjson::to_string(original);
+            Expect(json_result.has_value()).ToBe(true);
+
+            std::string json_str = json_result.value();
+            Expect(json_str.find("\\u0001") != std::string::npos).ToBe(false);
+            Expect(json_str.find("\\ufffd") != std::string::npos).ToBe(true);
+
+            // The Unicode replacement character (U+FFFD) is outside the single-byte
+            // range this decoder can represent, so re-parsing this repo's own output
+            // through its own strict unescape_json_string correctly fails rather than
+            // silently keeping the escape text. A standard, permissive JSON parser
+            // (e.g. the SDK client's JSON.parse) would decode it without issue - this
+            // decoder is intentionally stricter about what it accepts as input.
+            auto restored_result = zjson::from_str<SimpleStruct>(json_str);
+            Expect(restored_result.has_value()).ToBe(false);
+        });
+
+        it("should escape all EBCDIC characters (0-255) to a form with no raw control bytes", []() {
             // Build a string containing all EBCDIC characters from 0 to 255
             std::string all_chars;
             all_chars.reserve(256);
             for (int i = 0; i < 256; i++) {
                 all_chars += static_cast<char>(i);
             }
-            
+
             SimpleStruct original{42, all_chars};
-            
+
             // Serialize to JSON
             auto json_result = zjson::to_string(original);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
-            // Verify that control and special characters are properly escaped
-            bool has_escaped_chars = json_str.find("\\u0000") != std::string::npos;
-            has_escaped_chars &= json_str.find("\\n") != std::string::npos;
+
+            // Verify that named escapes and quote/backslash are still present.
+            // Control characters without a named escape are no longer echoed via a
+            // numeric code-point escape (see the test above), so an old-style
+            // byte-value escape must not appear.
+            bool has_escaped_chars = json_str.find("\\n") != std::string::npos;
             has_escaped_chars &= json_str.find("\\t") != std::string::npos;
             has_escaped_chars &= json_str.find("\\\"") != std::string::npos;
             has_escaped_chars &= json_str.find("\\\\") != std::string::npos;
             Expect(has_escaped_chars).ToBe(true);
-            
-            // Deserialize back - all characters should be preserved
-            auto restored_result = zjson::from_str<SimpleStruct>(json_str);
-            Expect(restored_result.has_value()).ToBe(true);
-            
-            SimpleStruct restored = restored_result.value();
-            Expect(restored.id).ToBe(original.id);
-            
-            // Verify all 256 characters are preserved exactly
-            Expect(restored.name.size()).ToBe(256);
-            
-            for (int i = 0; i < 256; i++) {
-                unsigned char original_char = static_cast<unsigned char>(original.name[i]);
-                unsigned char restored_char = static_cast<unsigned char>(restored.name[i]);
-                Expect(restored_char).ToBe(original_char);
+            Expect(json_str.find("\\u0000") != std::string::npos).ToBe(false);
+            Expect(json_str.find("\\ufffd") != std::string::npos).ToBe(true);
+
+            // No raw control byte survives serialization: every control character,
+            // named-escape or not, is represented as printable escape text (e.g. the
+            // two characters backslash and 'n', not an actual newline byte).
+            for (unsigned char c : json_str) {
+                Expect(iscntrl(c)).ToBe(false);
             }
-            
-            // Verify the entire string matches
-            Expect(restored.name).ToBe(original.name);
+
+            // This text is not expected to round-trip through this repo's own strict
+            // decoder - see "should reject a control character escape..." and the
+            // Unicode replacement character test above for why re-parsing it
+            // correctly fails rather than silently accepting lossy data back in.
         });
 
         it("should handle large string serialization and deserialization", []() {
@@ -732,48 +800,48 @@ void test_serialization_round_trips()
             const size_t target_size = 16 * 1024 * 1024 - 1;
             const std::string pattern = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz"; // 62 bytes
             const size_t repeats = target_size / pattern.length();
-            
+
             std::string large_string;
             large_string.reserve(target_size);
-            
+
             for (size_t i = 0; i < repeats; ++i) {
                 large_string += pattern;
             }
-            
+
             // Add any remaining bytes to reach exact size
             size_t remaining = target_size - large_string.length();
             if (remaining > 0) {
                 large_string += pattern.substr(0, remaining);
             }
-            
+
             Expect(large_string.length()).ToBe(target_size);
-            
+
             SimpleStruct original{99, large_string};
-            
+
             // Test serialization
             auto json_result = zjson::to_string(original);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Test deserialization
             auto restored_result = zjson::from_str<SimpleStruct>(json_str);
             Expect(restored_result.has_value()).ToBe(true);
-            
+
             SimpleStruct restored = restored_result.value();
-            
+
             // Verify the ID matches
             Expect(restored.id).ToBe(original.id);
-            
+
             // Verify the string length matches exactly
             Expect(restored.name.length()).ToBe(target_size);
             Expect(restored.name.size()).ToBe(large_string.size());
-            
+
             // Verify the start of the string (first 100 bytes)
             std::string original_start = large_string.substr(0, 100);
             std::string restored_start = restored.name.substr(0, 100);
             Expect(restored_start).ToBe(original_start);
-            
+
             // Verify the end of the string using the ORIGINAL string's length as reference
             // This ensures we're checking the actual end, not a truncated position
             std::string original_end = large_string.substr(large_string.length() - 100);
@@ -810,16 +878,16 @@ void test_field_attributes()
            {
         it("should skip fields marked with zjson_skip", []() {
             AttributeTestStruct original{"testuser", "secret123", 12345, "Test User", 3000};
-            
+
             auto json_result = zjson::to_string(original);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Password field should not appear in JSON
             bool has_password = json_str.find("password") != std::string::npos;
             Expect(has_password).ToBe(false);
-            
+
             // Other fields should be present
             bool has_username = json_str.find("username") != std::string::npos;
             Expect(has_username).ToBe(true);
@@ -827,18 +895,18 @@ void test_field_attributes()
 
         it("should rename fields correctly", []() {
             AttributeTestStruct original{"testuser", "secret", 12345, "Test User", 3000};
-            
+
             auto json_result = zjson::to_string(original);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should use renamed fields
             bool has_userId = json_str.find("userId") != std::string::npos;
             bool has_displayName = json_str.find("displayName") != std::string::npos;
             Expect(has_userId).ToBe(true);
             Expect(has_displayName).ToBe(true);
-            
+
             // Should not have original field names
             bool has_user_id = json_str.find("user_id") != std::string::npos;
             bool has_display_name = json_str.find("display_name") != std::string::npos;
@@ -849,10 +917,10 @@ void test_field_attributes()
         it("should use default values for missing fields", []() {
             // JSON without default_port field
             std::string json_without_port = R"({"username":"testuser","userId":12345,"displayName":"Test User"})";
-            
+
             auto result = zjson::from_str<AttributeTestStruct>(json_without_port);
             Expect(result.has_value()).ToBe(true);
-            
+
             AttributeTestStruct restored = result.value();
             Expect(restored.username).ToBe(std::string("testuser"));
             Expect(restored.user_id).ToBe(12345);
@@ -871,17 +939,17 @@ void test_value_conversions()
            {
         it("should convert typed objects to Value using to_value", []() {
             SimpleStruct obj{42, "test_name"};
-            
+
             auto value_result = zjson::to_value(obj);
             Expect(value_result.has_value()).ToBe(true);
-            
+
             zjson::Value value = value_result.value();
             Expect(value.is_object()).ToBe(true);
-            
+
             // Should be able to access fields dynamically
             int64_t id = value["id"].as_int64();
             std::string name = value["name"].as_string();
-            
+
             Expect(id).ToBe(42);
             Expect(name).ToBe(std::string("test_name"));
         });
@@ -891,10 +959,10 @@ void test_value_conversions()
             zjson::Value value = zjson::Value::create_object();
             value.add_to_object("id", zjson::Value(123));
             value.add_to_object("name", zjson::Value("converted_name"));
-            
+
             auto struct_result = zjson::from_value<SimpleStruct>(value);
             Expect(struct_result.has_value()).ToBe(true);
-            
+
             SimpleStruct obj = struct_result.value();
             Expect(obj.id).ToBe(123);
             Expect(obj.name).ToBe(std::string("converted_name"));
@@ -902,15 +970,15 @@ void test_value_conversions()
 
         it("should handle round-trip conversion: object -> Value -> object", []() {
             SimpleStruct original{999, "round_trip_test"};
-            
+
             // Object -> Value
             auto value_result = zjson::to_value(original);
             Expect(value_result.has_value()).ToBe(true);
-            
+
             // Value -> Object
             auto object_result = zjson::from_value<SimpleStruct>(value_result.value());
             Expect(object_result.has_value()).ToBe(true);
-            
+
             SimpleStruct restored = object_result.value();
             Expect(restored.id).ToBe(original.id);
             Expect(restored.name).ToBe(original.name);
@@ -920,7 +988,7 @@ void test_value_conversions()
             auto int_result = zjson::to_value(42);
             Expect(int_result.has_value()).ToBe(true);
             Expect(int_result.value().as_int64()).ToBe(42);
-            
+
             auto str_result = zjson::to_value(std::string("hello"));
             Expect(str_result.has_value()).ToBe(true);
             Expect(str_result.value().as_string()).ToBe(std::string("hello"));
@@ -931,10 +999,10 @@ void test_value_conversions()
             zjson::Value int_val(42);
             Expect(int_val.is_integer()).ToBe(true);
             Expect(int_val.is_double()).ToBe(false);
-            
+
             zjson::Value max_i64(9223372036854775807LL);
             Expect(max_i64.is_integer()).ToBe(true);
-            
+
             // Floats stored as f64 (double)
             zjson::Value float_val(3.14);
             Expect(float_val.is_double()).ToBe(true);
@@ -945,10 +1013,10 @@ void test_value_conversions()
             long long max_i64 = 9223372036854775807LL;
             zjson::Value obj = zjson::Value::create_object();
             obj["maxInt"] = zjson::Value(max_i64);
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             auto parsed = zjson::from_str(json_result.value());
             Expect(parsed.has_value()).ToBe(true);
             Expect(parsed.value()["maxInt"].is_integer()).ToBe(true);
@@ -960,7 +1028,7 @@ void test_value_conversions()
             zjson::Value small_u64(1000ULL);
             Expect(small_u64.is_integer()).ToBe(true);
             Expect(small_u64.as_uint64()).ToBe(1000ULL);
-            
+
             // u64 values > i64::MAX stored as f64 (precision loss acceptable)
             zjson::Value large_u64(18446744073709551615ULL);
             Expect(large_u64.is_double()).ToBe(true);
@@ -970,11 +1038,11 @@ void test_value_conversions()
             // i64 -> f64 conversion
             zjson::Value int_val(42);
             Expect(int_val.as_double()).ToBe(42.0);
-            
+
             // f64 -> i64 conversion (whole numbers only)
             zjson::Value whole_double(100.0);
             Expect(whole_double.as_int64()).ToBe(100);
-            
+
             // f64 with fraction -> i64 should error
             zjson::Value fractional(3.14);
             try {
@@ -1022,13 +1090,13 @@ void test_complex_nested_structures()
         it("should serialize and deserialize nested objects", []() {
             Address addr{"123 Main St", "Boston", "USA"};
             Person person{"John Doe", 30, addr};
-            
+
             auto json_result = zjson::to_string(person);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             auto person_result = zjson::from_str<Person>(json_result.value());
             Expect(person_result.has_value()).ToBe(true);
-            
+
             Person restored = person_result.value();
             Expect(restored.name).ToBe(std::string("John Doe"));
             Expect(restored.age).ToBe(30);
@@ -1039,18 +1107,18 @@ void test_complex_nested_structures()
 
         it("should handle arrays of complex objects", []() {
             Address hq{"456 Corporate Blvd", "Seattle", "USA"};
-            
+
             Person emp1{"Alice Smith", 28, {"111 First St", "Boston", "USA"}};
             Person emp2{"Bob Jones", 35, {"222 Second Ave", "Seattle", "USA"}};
-            
+
             Company company{"Tech Corp", {emp1, emp2}, hq};
-            
+
             auto json_result = zjson::to_string_pretty(company);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             auto company_result = zjson::from_str<Company>(json_result.value());
             Expect(company_result.has_value()).ToBe(true);
-            
+
             Company restored = company_result.value();
             Expect(restored.name).ToBe(std::string("Tech Corp"));
             Expect(restored.employees.size()).ToBe(2);
@@ -1060,20 +1128,20 @@ void test_complex_nested_structures()
         });
 
         it("should support deep nested access with dynamic indexing", []() {
-            Company company{"Test Corp", 
-                          {{"John", 30, {"123 St", "Boston", "USA"}}}, 
+            Company company{"Test Corp",
+                          {{"John", 30, {"123 St", "Boston", "USA"}}},
                           {"456 HQ Ave", "Seattle", "USA"}};
-            
+
             auto value_result = zjson::to_value(company);
             Expect(value_result.has_value()).ToBe(true);
-            
+
             zjson::Value root = value_result.value();
-            
+
             // Deep chained access
             std::string emp_name = root["employees"][0]["name"].as_string();
             std::string emp_city = root["employees"][0]["address"]["city"].as_string();
             std::string hq_country = root["headquarters"]["country"].as_string();
-            
+
             Expect(emp_name).ToBe(std::string("John"));
             Expect(emp_city).ToBe(std::string("Boston"));
             Expect(hq_country).ToBe(std::string("USA"));
@@ -1111,26 +1179,26 @@ void test_large_struct_support()
             large.f21 = 21; large.f22 = 22; large.f23 = 23; large.f24 = 24;
             large.f25 = 25; large.f26 = 26; large.f27 = 27; large.f28 = 28;
             large.f29 = 29; large.f30 = 30; large.f31 = 31; large.f32 = 32;
-            
+
             // Test serialization
             auto json_result = zjson::to_string(large);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should contain all fields
             bool has_f1 = json_str.find("f1") != std::string::npos;
             bool has_f17 = json_str.find("f17") != std::string::npos;  // Test new macro range
             bool has_f32 = json_str.find("f32") != std::string::npos;
-            
+
             Expect(has_f1).ToBe(true);
             Expect(has_f17).ToBe(true);
             Expect(has_f32).ToBe(true);
-            
+
             // Test deserialization
             auto restored_result = zjson::from_str<LargeStruct>(json_str);
             Expect(restored_result.has_value()).ToBe(true);
-            
+
             LargeStruct restored = restored_result.value();
             Expect(restored.f1).ToBe(std::string("field1"));
             Expect(restored.f17).ToBe(std::string("field17"));  // Test new macro range
@@ -1140,7 +1208,7 @@ void test_large_struct_support()
         it("should validate serializable trait works for large structs", []() {
             bool is_serializable = zjson::Serializable<LargeStruct>::value;
             bool is_deserializable = zjson::Deserializable<LargeStruct>::value;
-            
+
             Expect(is_serializable).ToBe(true);
             Expect(is_deserializable).ToBe(true);
         }); });
@@ -1247,26 +1315,26 @@ void test_container_attributes()
            {
         it("should apply camelCase rename_all transformation", []() {
             CamelCaseStruct obj{"john_doe", 123, "John Doe"};
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should use camelCase field names
             bool has_userName = json_str.find("userName") != std::string::npos;
             bool has_userId = json_str.find("userId") != std::string::npos;
             bool has_displayName = json_str.find("displayName") != std::string::npos;
-            
+
             Expect(has_userName).ToBe(true);
             Expect(has_userId).ToBe(true);
             Expect(has_displayName).ToBe(true);
-            
+
             // Should NOT use original field names
             bool has_user_name = json_str.find("user_name") != std::string::npos;
             bool has_user_id = json_str.find("user_id") != std::string::npos;
             bool has_display_name = json_str.find("display_name") != std::string::npos;
-            
+
             Expect(has_user_name).ToBe(false);
             Expect(has_user_id).ToBe(false);
             Expect(has_display_name).ToBe(false);
@@ -1274,17 +1342,17 @@ void test_container_attributes()
 
         it("should apply PascalCase rename_all transformation", []() {
             PascalCaseStruct obj{"John", "Doe", 5};
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should use PascalCase field names
             bool has_FirstName = json_str.find("FirstName") != std::string::npos;
             bool has_LastName = json_str.find("LastName") != std::string::npos;
             bool has_UserCount = json_str.find("UserCount") != std::string::npos;
-            
+
             Expect(has_FirstName).ToBe(true);
             Expect(has_LastName).ToBe(true);
             Expect(has_UserCount).ToBe(true);
@@ -1292,17 +1360,17 @@ void test_container_attributes()
 
         it("should apply kebab-case rename_all transformation", []() {
             KebabCaseStruct obj{"test_user", "test@example.com", 3600};
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should use kebab-case field names
             bool has_user_name = json_str.find("user-name") != std::string::npos;
             bool has_email_address = json_str.find("email-address") != std::string::npos;
             bool has_session_timeout = json_str.find("session-timeout") != std::string::npos;
-            
+
             Expect(has_user_name).ToBe(true);
             Expect(has_email_address).ToBe(true);
             Expect(has_session_timeout).ToBe(true);
@@ -1310,17 +1378,17 @@ void test_container_attributes()
 
         it("should apply UPPERCASE rename_all transformation", []() {
             UppercaseStruct obj{"testuser", "secret123", 100};
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should use UPPERCASE field names
             bool has_USER_NAME = json_str.find("USER_NAME") != std::string::npos;
             bool has_API_KEY = json_str.find("API_KEY") != std::string::npos;
             bool has_MAX_CONNECTIONS = json_str.find("MAX_CONNECTIONS") != std::string::npos;
-            
+
             Expect(has_USER_NAME).ToBe(true);
             Expect(has_API_KEY).ToBe(true);
             Expect(has_MAX_CONNECTIONS).ToBe(true);
@@ -1328,17 +1396,17 @@ void test_container_attributes()
 
         it("should apply lowercase rename_all transformation", []() {
             LowercaseStruct obj{"TESTUSER", "SECRET123", 100};
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should use lowercase field names
             bool has_user_name = json_str.find("user_name") != std::string::npos;
             bool has_api_key = json_str.find("api_key") != std::string::npos;
             bool has_max_connections = json_str.find("max_connections") != std::string::npos;
-            
+
             Expect(has_user_name).ToBe(true);
             Expect(has_api_key).ToBe(true);
             Expect(has_max_connections).ToBe(true);
@@ -1346,17 +1414,17 @@ void test_container_attributes()
 
         it("should apply snake_case rename_all transformation", []() {
             SnakeCaseStruct obj{"testUser", "testEmail", 1800};
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should use snake_case field names (camelCase -> snake_case)
             bool has_user_name = json_str.find("userName") != std::string::npos;
             bool has_email_address = json_str.find("emailAddress") != std::string::npos;
             bool has_session_timeout = json_str.find("sessionTimeout") != std::string::npos;
-            
+
             Expect(has_user_name).ToBe(true);
             Expect(has_email_address).ToBe(true);
             Expect(has_session_timeout).ToBe(true);
@@ -1364,17 +1432,17 @@ void test_container_attributes()
 
         it("should apply SCREAMING_SNAKE_CASE rename_all transformation", []() {
             ScreamingSnakeCaseStruct obj{"testuser", "secret", 50};
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should use SCREAMING_SNAKE_CASE field names
             bool has_USER_NAME = json_str.find("USER_NAME") != std::string::npos;
             bool has_API_KEY = json_str.find("API_KEY") != std::string::npos;
             bool has_MAX_CONNECTIONS = json_str.find("MAX_CONNECTIONS") != std::string::npos;
-            
+
             Expect(has_USER_NAME).ToBe(true);
             Expect(has_API_KEY).ToBe(true);
             Expect(has_MAX_CONNECTIONS).ToBe(true);
@@ -1382,17 +1450,17 @@ void test_container_attributes()
 
         it("should apply SCREAMING-KEBAB-CASE rename_all transformation", []() {
             ScreamingKebabCaseStruct obj{"testuser", "secret", 50};
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should use SCREAMING-KEBAB-CASE field names
             bool has_USER_NAME = json_str.find("USER-NAME") != std::string::npos;
             bool has_API_KEY = json_str.find("API-KEY") != std::string::npos;
             bool has_MAX_CONNECTIONS = json_str.find("MAX-CONNECTIONS") != std::string::npos;
-            
+
             Expect(has_USER_NAME).ToBe(true);
             Expect(has_API_KEY).ToBe(true);
             Expect(has_MAX_CONNECTIONS).ToBe(true);
@@ -1401,10 +1469,10 @@ void test_container_attributes()
         it("should deserialize with renamed fields correctly", []() {
             // Test round-trip with camelCase
             std::string camel_json = R"({"userName":"test","userId":42,"displayName":"Test User"})";
-            
+
             auto result = zjson::from_str<CamelCaseStruct>(camel_json);
             Expect(result.has_value()).ToBe(true);
-            
+
             CamelCaseStruct restored = result.value();
             Expect(restored.user_name).ToBe(std::string("test"));
             Expect(restored.user_id).ToBe(42);
@@ -1416,12 +1484,12 @@ void test_container_attributes()
             std::string valid_json = R"({"name":"test","id":123})";
             auto valid_result = zjson::from_str<StrictValidationStruct>(valid_json);
             Expect(valid_result.has_value()).ToBe(true);
-            
+
             // JSON with extra fields should fail
             std::string invalid_json = R"({"name":"test","id":123,"extra_field":"should_fail"})";
             auto invalid_result = zjson::from_str<StrictValidationStruct>(invalid_json);
             Expect(invalid_result.has_value()).ToBe(false);
-            
+
             // Should be unknown field error
             auto error = invalid_result.error();
             Expect(error.kind() == zjson::Error::UnknownField).ToBe(true);
@@ -1433,7 +1501,7 @@ void test_container_attributes()
             std::string json_with_extra = R"({"id":123,"name":"test","extra_field":"ignored"})";
             auto result = zjson::from_str<SimpleStruct>(json_with_extra);
             Expect(result.has_value()).ToBe(true);
-            
+
             SimpleStruct restored = result.value();
             Expect(restored.id).ToBe(123);
             Expect(restored.name).ToBe(std::string("test"));
@@ -1442,16 +1510,16 @@ void test_container_attributes()
         it("should use 'none' transformation by default (no rename_all)", []() {
             // SimpleStruct doesn't have ZJSON_RENAME_ALL, so should use original field names
             SimpleStruct obj{42, "test"};
-            
+
             auto json_result = zjson::to_string(obj);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should use original field names (no transformation)
             bool has_id = json_str.find("id") != std::string::npos;
             bool has_name = json_str.find("name") != std::string::npos;
-            
+
             Expect(has_id).ToBe(true);
             Expect(has_name).ToBe(true);
         }); });
@@ -1471,21 +1539,21 @@ void test_struct_flattening()
             config.connection.port = 5432;
             config.database_name = "myapp";
             config.ssl_enabled = true;
-            
+
             auto json_result = zjson::to_string(config);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             std::string json_str = json_result.value();
-            
+
             // Should contain flattened fields directly, not nested
             bool has_host = json_str.find("\"host\"") != std::string::npos;
             bool has_port = json_str.find("\"port\"") != std::string::npos;
             bool has_database_name = json_str.find("\"database_name\"") != std::string::npos;
             bool has_ssl_enabled = json_str.find("\"ssl_enabled\"") != std::string::npos;
-            
+
             // Should NOT contain nested "connection" object
             bool has_connection = json_str.find("\"connection\"") != std::string::npos;
-            
+
             Expect(has_host).ToBe(true);
             Expect(has_port).ToBe(true);
             Expect(has_database_name).ToBe(true);
@@ -1495,10 +1563,10 @@ void test_struct_flattening()
 
         it("should deserialize flattened JSON back to nested struct", []() {
             std::string json_str = R"({"host":"db.example.com","port":3306,"database_name":"production","ssl_enabled":false})";
-            
+
             auto result = zjson::from_str<DatabaseConfig>(json_str);
             Expect(result.has_value()).ToBe(true);
-            
+
             DatabaseConfig config = result.value();
             Expect(config.connection.host).ToBe(std::string("db.example.com"));
             Expect(config.connection.port).ToBe(3306);
@@ -1512,15 +1580,15 @@ void test_struct_flattening()
             original.connection.port = 9999;
             original.database_name = "test_db";
             original.ssl_enabled = true;
-            
+
             // Serialize
             auto json_result = zjson::to_string(original);
             Expect(json_result.has_value()).ToBe(true);
-            
+
             // Deserialize
             auto restored_result = zjson::from_str<DatabaseConfig>(json_result.value());
             Expect(restored_result.has_value()).ToBe(true);
-            
+
             DatabaseConfig restored = restored_result.value();
             Expect(restored.connection.host).ToBe(original.connection.host);
             Expect(restored.connection.port).ToBe(original.connection.port);

--- a/native/c/zjson.hpp
+++ b/native/c/zjson.hpp
@@ -1404,7 +1404,7 @@ inline std::string unescape_json_string(const std::string &s)
           char *endptr;
           unsigned long val = std::strtoul(hex.c_str(), &endptr, 16);
           bool valid_hex = endptr == hex.c_str() + 4;
-          if (valid_hex && val <= 0x1F)
+          if (valid_hex && val < 256 && iscntrl(static_cast<unsigned char>(val)))
           {
             // \n, \t, \r, \b, \f have named escapes and are handled above, where
             // they are deliberately mapped to this platform's native control byte
@@ -1582,12 +1582,13 @@ inline Value json_handle_to_value(JSON_INSTANCE *instance, KEY_HANDLE *key_handl
       int key_buffer_length = sizeof(key_buffer);
       KEY_HANDLE value_handle = {0};
       int actual_length = 0;
+      std::vector<char> dynamic_buffer;
 
       rc = ZJSMGOEN(instance, key_handle, &i, &key_buffer_ptr, &key_buffer_length, &value_handle, &actual_length);
       if (rc == HWTJ_BUFFER_TOO_SMALL)
       {
         // Allocate larger buffer for long keys
-        std::vector<char> dynamic_buffer(actual_length);
+        dynamic_buffer.resize(actual_length);
         key_buffer_ptr = &dynamic_buffer[0];
         key_buffer_length = actual_length;
 

--- a/native/c/zjson.hpp
+++ b/native/c/zjson.hpp
@@ -1343,7 +1343,7 @@ inline std::string escape_json_string(const std::string &input)
       output += "\\t";
       break;
     default:
-      if (iscntrl(c))
+      if (iscntrl(static_cast<unsigned char>(c)))
       {
         // Native control byte values do not correspond to the same Unicode code
         // points on this EBCDIC platform (e.g. IBM-1047 NL 0x15 vs Unicode NAK
@@ -1403,16 +1403,19 @@ inline std::string unescape_json_string(const std::string &s)
           std::string hex = s.substr(i + 1, 4);
           char *endptr;
           unsigned long val = std::strtoul(hex.c_str(), &endptr, 16);
-          if (endptr != hex.c_str() && val <= 0x1F)
+          bool valid_hex = endptr == hex.c_str() + 4;
+          if (valid_hex && val <= 0x1F)
           {
-            // Control characters have no named escape and, on this platform,
-            // do not necessarily decode to the same value in a reader's encoding
-            // as their raw numeric value would suggest (e.g. IBM-1047 vs Unicode).
-            // There is no reliable way to know if the caller can tolerate a
-            // substitution, so reject outright rather than guess.
+            // \n, \t, \r, \b, \f have named escapes and are handled above, where
+            // they are deliberately mapped to this platform's native control byte
+            // rather than the Unicode code point. A \u00XX escape for the same code
+            // point (named or not) has no such platform-specific mapping to fall
+            // back on: e.g. U+0015 is Unicode NAK, but on this EBCDIC platform (IBM-1047)
+            // byte 0x15 is NL, not NAK, so there is no reliable value to substitute -
+            // reject outright rather than guess.
             throw Error::invalid_value("JSON string contains a disallowed control character escape: \\u" + hex);
           }
-          else if (endptr != hex.c_str() && val < 256)
+          else if (valid_hex && val < 256)
           {
             res += static_cast<char>(val);
           }

--- a/native/c/zjson.hpp
+++ b/native/c/zjson.hpp
@@ -1345,9 +1345,12 @@ inline std::string escape_json_string(const std::string &input)
     default:
       if (iscntrl(c))
       {
-        char buf[7];
-        snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned char>(c));
-        output += buf;
+        // Native control byte values do not correspond to the same Unicode code
+        // points on this EBCDIC platform (e.g. IBM-1047 NL 0x15 vs Unicode NAK
+        // U+0015), so echoing the byte's numeric value via \u00XX would misrepresent
+        // it to a spec-compliant JSON reader. Emit the Unicode replacement character
+        // instead of a specific, likely-wrong code point.
+        output += "\\ufffd";
       }
       else
       {
@@ -1397,26 +1400,34 @@ inline std::string unescape_json_string(const std::string &s)
       case 'u':
         if (i + 4 < s.length())
         {
-          try
+          std::string hex = s.substr(i + 1, 4);
+          char *endptr;
+          unsigned long val = std::strtoul(hex.c_str(), &endptr, 16);
+          if (endptr != hex.c_str() && val <= 0x1F)
           {
-            std::string hex = s.substr(i + 1, 4);
-            char *endptr;
-            unsigned long val = std::strtoul(hex.c_str(), &endptr, 16);
-            if (endptr != hex.c_str() && val < 256)
-            {
-              res += static_cast<char>(val);
-            }
-            else
-            {
-              // For values outside of single byte range, preserve original escape
-              res += "\\u" + hex;
-            }
-            i += 4;
+            // Control characters have no named escape and, on this platform,
+            // do not necessarily decode to the same value in a reader's encoding
+            // as their raw numeric value would suggest (e.g. IBM-1047 vs Unicode).
+            // There is no reliable way to know if the caller can tolerate a
+            // substitution, so reject outright rather than guess.
+            throw Error::invalid_value("JSON string contains a disallowed control character escape: \\u" + hex);
           }
-          catch (...)
+          else if (endptr != hex.c_str() && val < 256)
           {
-            res += "\\u"; // Malformed, just append what we can
+            res += static_cast<char>(val);
           }
+          else
+          {
+            // Either the hex digits themselves are malformed (should already
+            // be rejected as invalid JSON before this text is reached), or the
+            // escape names a code point above the single-byte range (U+0100
+            // and above, including either half of a surrogate pair). This
+            // decoder only ever produces single native bytes, so there is no
+            // correct value to substitute here - reject rather than silently
+            // keeping the escape text as if it had been decoded successfully.
+            throw Error::invalid_value("JSON string contains an unsupported \\u escape: \\u" + hex);
+          }
+          i += 4;
         }
         else
         {
@@ -1442,199 +1453,158 @@ inline std::string unescape_json_string(const std::string &s)
 // Maximum allowed JSON nesting depth to prevent stack overflow
 static constexpr int MAX_JSON_DEPTH = 64;
 
+// Note: this function intentionally does not catch its own exceptions. Any
+// failure - a failed HWTJ call, a malformed number, a disallowed control
+// character, exceeding MAX_JSON_DEPTH - propagates all the way to from_str's
+// try/catch, which normalizes it into a zstd::expected failure and performs
+// cleanup (ZJSMTERM). A single malformed field fails the whole parse rather
+// than being silently dropped, matching how from_value<T> already treats
+// errors one layer up (e.g. numeric overflow).
 inline Value json_handle_to_value(JSON_INSTANCE *instance, KEY_HANDLE *key_handle, int depth = 0)
 {
-  try
+  // Check depth limit to prevent unbounded recursion
+  if (depth >= MAX_JSON_DEPTH)
   {
-    // Check depth limit to prevent unbounded recursion
-    if (depth >= MAX_JSON_DEPTH)
-    {
-      ZLOG_WARN("JSON parsing depth limit reached: %d", depth);
-      return Value();
-    }
+    throw Error(Error::Custom, "JSON exceeds maximum nesting depth of " + std::to_string(MAX_JSON_DEPTH));
+  }
 
-    int type = 0;
-    int rc = ZJSNGJST(instance, key_handle, &type);
+  int type = 0;
+  int rc = ZJSNGJST(instance, key_handle, &type);
+  if (rc != 0)
+  {
+    throw Error(Error::Custom, "Failed to determine JSON value type");
+  }
+
+  switch (type)
+  {
+  case HWTJ_NULL_TYPE:
+    return Value();
+
+  case HWTJ_BOOLEAN_TYPE:
+  {
+    char bool_val = 0;
+    rc = ZJSMGBOV(instance, key_handle, &bool_val);
     if (rc != 0)
     {
-      return Value(); // Return null on error
+      throw Error(Error::Custom, "Failed to read JSON boolean value");
+    }
+    return Value(bool_val == HWTJ_TRUE);
+  }
+
+  case HWTJ_NUMBER_TYPE:
+  {
+    char *value_ptr = 0;
+    int value_length = 0;
+    rc = ZJSMGVAL(instance, key_handle, &value_ptr, &value_length);
+    if (rc != 0)
+    {
+      throw Error(Error::Custom, "Failed to read JSON number value");
+    }
+    std::string str_val(value_ptr, value_length);
+    if (str_val.find('.') != std::string::npos || str_val.find('e') != std::string::npos || str_val.find('E') != std::string::npos)
+    {
+      char *endptr = nullptr;
+      double num_val = std::strtod(str_val.c_str(), &endptr);
+      if (endptr == str_val.c_str() || *endptr != '\0')
+      {
+        throw Error::invalid_value("Malformed JSON number: " + str_val);
+      }
+      return Value(num_val);
+    }
+    else
+    {
+      char *endptr = nullptr;
+      long long int_val = std::strtoll(str_val.c_str(), &endptr, 10);
+      if (endptr == str_val.c_str() || *endptr != '\0')
+      {
+        throw Error::invalid_value("Malformed JSON number: " + str_val);
+      }
+      return Value(int_val);
+    }
+  }
+
+  case HWTJ_STRING_TYPE:
+  {
+    char *value_ptr = 0;
+    int value_length = 0;
+    rc = ZJSMGVAL(instance, key_handle, &value_ptr, &value_length);
+    if (rc != 0)
+    {
+      throw Error(Error::Custom, "Failed to read JSON string value");
+    }
+    std::string raw_str(value_ptr, value_length);
+    return Value(unescape_json_string(raw_str));
+  }
+
+  case HWTJ_ARRAY_TYPE:
+  {
+    Value result = Value::create_array();
+
+    int num_entries = 0;
+    rc = ZJSMGNUE(instance, key_handle, &num_entries);
+    if (rc != 0)
+    {
+      throw Error(Error::Custom, "Failed to determine JSON array size");
     }
 
-    switch (type)
+    for (int i = 0; i < num_entries; i++)
     {
-    case HWTJ_NULL_TYPE:
-      return Value();
-
-    case HWTJ_BOOLEAN_TYPE:
-    {
-      char bool_val = 0;
-      rc = ZJSMGBOV(instance, key_handle, &bool_val);
+      KEY_HANDLE element_handle = {0};
+      rc = ZJSMGAEN(instance, key_handle, &i, &element_handle);
       if (rc != 0)
       {
-        return Value();
+        throw Error(Error::Custom, "Failed to read JSON array element at index " + std::to_string(i));
       }
-      return Value(bool_val == HWTJ_TRUE);
+      Value element = json_handle_to_value(instance, &element_handle, depth + 1);
+      result.add_to_array(element);
+    }
+    return result;
+  }
+
+  case HWTJ_OBJECT_TYPE:
+  {
+    Value result = Value::create_object();
+
+    int num_entries = 0;
+    rc = ZJSMGNUE(instance, key_handle, &num_entries);
+    if (rc != 0)
+    {
+      throw Error(Error::Custom, "Failed to determine JSON object size");
     }
 
-    case HWTJ_NUMBER_TYPE:
+    for (int i = 0; i < num_entries; i++)
     {
-      char *value_ptr = 0;
-      int value_length = 0;
-      rc = ZJSMGVAL(instance, key_handle, &value_ptr, &value_length);
-      if (rc != 0)
-      {
-        return Value();
-      }
-      try
-      {
-        std::string str_val(value_ptr, value_length);
-        if (str_val.find('.') != std::string::npos || str_val.find('e') != std::string::npos || str_val.find('E') != std::string::npos)
-        {
-          char *endptr = nullptr;
-          double num_val = std::strtod(str_val.c_str(), &endptr);
-          if (endptr == str_val.c_str() || *endptr != '\0')
-          {
-            return Value();
-          }
-          return Value(num_val);
-        }
-        else
-        {
-          char *endptr = nullptr;
-          long long int_val = std::strtoll(str_val.c_str(), &endptr, 10);
-          if (endptr == str_val.c_str() || *endptr != '\0')
-          {
-            return Value();
-          }
-          return Value(int_val);
-        }
-      }
-      catch (...)
-      {
-        return Value();
-      }
-    }
+      char key_buffer[256] = {0};
+      char *key_buffer_ptr = key_buffer;
+      int key_buffer_length = sizeof(key_buffer);
+      KEY_HANDLE value_handle = {0};
+      int actual_length = 0;
 
-    case HWTJ_STRING_TYPE:
-    {
-      char *value_ptr = 0;
-      int value_length = 0;
-      rc = ZJSMGVAL(instance, key_handle, &value_ptr, &value_length);
-      if (rc != 0)
+      rc = ZJSMGOEN(instance, key_handle, &i, &key_buffer_ptr, &key_buffer_length, &value_handle, &actual_length);
+      if (rc == HWTJ_BUFFER_TOO_SMALL)
       {
-        return Value();
-      }
-      std::string raw_str(value_ptr, value_length);
-      return Value(unescape_json_string(raw_str));
-    }
-
-    case HWTJ_ARRAY_TYPE:
-    {
-      Value result = Value::create_array();
-
-      int num_entries = 0;
-      rc = ZJSMGNUE(instance, key_handle, &num_entries);
-      if (rc != 0)
-      {
-        return result; // Return empty array
-      }
-
-      for (int i = 0; i < num_entries; i++)
-      {
-        KEY_HANDLE element_handle = {0};
-        rc = ZJSMGAEN(instance, key_handle, &i, &element_handle);
-        if (rc == 0)
-        {
-          try
-          {
-            Value element = json_handle_to_value(instance, &element_handle, depth + 1);
-            result.add_to_array(element);
-          }
-          catch (...)
-          {
-            // Skip problematic array elements
-            ZLOG_WARN("Failed to parse JSON array element at index %d to Value", i);
-            continue;
-          }
-        }
-      }
-      return result;
-    }
-
-    case HWTJ_OBJECT_TYPE:
-    {
-      Value result = Value::create_object();
-
-      int num_entries = 0;
-      rc = ZJSMGNUE(instance, key_handle, &num_entries);
-      if (rc != 0)
-      {
-        return result; // Return empty object
-      }
-
-      for (int i = 0; i < num_entries; i++)
-      {
-        char key_buffer[256] = {0};
-        char *key_buffer_ptr = key_buffer;
-        int key_buffer_length = sizeof(key_buffer);
-        KEY_HANDLE value_handle = {0};
-        int actual_length = 0;
+        // Allocate larger buffer for long keys
+        std::vector<char> dynamic_buffer(actual_length);
+        key_buffer_ptr = &dynamic_buffer[0];
+        key_buffer_length = actual_length;
 
         rc = ZJSMGOEN(instance, key_handle, &i, &key_buffer_ptr, &key_buffer_length, &value_handle, &actual_length);
-        if (rc == 0)
-        {
-          try
-          {
-            std::string key_name(key_buffer_ptr, actual_length);
-            Value value = json_handle_to_value(instance, &value_handle, depth + 1);
-            result.add_to_object(key_name, value);
-          }
-          catch (...)
-          {
-            // Skip problematic object fields
-            ZLOG_WARN("Failed to parse JSON object field at index %d to Value", i);
-            continue;
-          }
-        }
-        else if (rc == HWTJ_BUFFER_TOO_SMALL)
-        {
-          // Allocate larger buffer for long keys
-          std::vector<char> dynamic_buffer(actual_length);
-          key_buffer_ptr = &dynamic_buffer[0];
-          key_buffer_length = actual_length;
-
-          rc = ZJSMGOEN(instance, key_handle, &i, &key_buffer_ptr, &key_buffer_length, &value_handle, &actual_length);
-          if (rc == 0)
-          {
-            try
-            {
-              std::string key_name(key_buffer_ptr, actual_length);
-              Value value = json_handle_to_value(instance, &value_handle, depth + 1);
-              result.add_to_object(key_name, value);
-            }
-            catch (...)
-            {
-              // Skip problematic object fields
-              ZLOG_WARN("Failed to parse JSON object field at index %d to Value", i);
-              continue;
-            }
-          }
-        }
       }
-      return result;
-    }
 
-    default:
-      return Value();
+      if (rc != 0)
+      {
+        throw Error(Error::Custom, "Failed to read JSON object field at index " + std::to_string(i));
+      }
+
+      std::string key_name(key_buffer_ptr, actual_length);
+      Value value = json_handle_to_value(instance, &value_handle, depth + 1);
+      result.add_to_object(key_name, value);
     }
+    return result;
   }
-  catch (const std::exception &e)
-  {
-    return Value();
-  }
-  catch (...)
-  {
-    return Value();
+
+  default:
+    throw Error(Error::Custom, "Unknown JSON value type encountered during parsing");
   }
 }
 


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fixes serialization/deserialization of control bytes (`0x0`-`0x1f`) in our z/OS JSON library:
* When serializing an RPC response, replace control bytes with Unicode substitution character
* When parsing an RPC request, throw error if control bytes are found since they can't be parsed reliably

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Build `zowex` from this branch, connect to it using ZE, and list DS members that contain control bytes in the name.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
