### PR TITLE
feat(ds): Add `--exact-match` option for listing data sets

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -7,7 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Recent Changes
 
 - `c`: Fixed an issue with `zowex ds list-members` when reading PDS directory blocks. [#1070] (https://github.com/zowe/zowex/pull/1070)
-- `c`: Added `--exact-match` option to the `zowex ds list` command. This option defaults to true for backwards compatibility, but can be set to false to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
+- `c`: Added `--exact-match` option to the `zowex ds list` command. This option defaults to false for backwards compatibility, but can be set to true to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
 
 ## `0.7.0`
 

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Recent Changes
 
 - `c`: Fixed an issue with `zowex ds list-members` when reading PDS directory blocks. [#1070] (https://github.com/zowe/zowex/pull/1070)
+- `c`: Added `--exact-match` option to the `zowex ds list` command. This option defaults to true for backwards compatibility, but can be set to false to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
 
 ## `0.7.0`
 

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to the native code for "zowex" are documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- `c`: Added `--exact-match` option to the `zowex ds list` command. This option defaults to false for backwards compatibility, but can be set to true to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
+
 ## `0.7.1`
 
 - `c`: Fixed `zowex server` resource leaks that could exhaust a z/OS LPAR after a request timed out or a connection dropped. The shutdown signal handler no longer calls into the worker pool or logger, which could deadlock and leave the process running forever; the number of live force-detached worker threads is now bounded, and the server exits when the limit is exceeded so the system can reclaim them; late responses from a detached worker are discarded instead of being sent for an ID the client already failed; notifications are serialized with responses so concurrent writes cannot corrupt the JSON stream; and worker initializer threads are drained before the pool is destroyed. [#537](https://github.com/zowe/zowex/issues/537)
 - `c`: Fixed an issue with `zowex ds list-members` when reading PDS directory blocks. [#1070] (https://github.com/zowe/zowex/pull/1070)
-- `c`: Added `--exact-match` option to the `zowex ds list` command. This option defaults to false for backwards compatibility, but can be set to true to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
 
 ## `0.7.0`
 

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -469,7 +469,11 @@ int handle_data_set_list(InvocationContext &context)
     return RTNCD_FAILURE;
   }
 
-  dsn += ".**";
+  bool exact_match = context.get<bool>("exact-match", false);
+  if (!exact_match)
+  {
+    dsn += ".**";
+  }
 
   long long max_entries = context.get<long long>("max-entries", 0);
   bool warn = context.get<bool>("warn", true);
@@ -1110,6 +1114,7 @@ void register_commands(parser::Command &root_command)
   ds_list_cmd->add_alias("ls");
   ds_list_cmd->add_positional_arg(DSN_PATTERN);
   ds_list_cmd->add_keyword_arg("attributes", make_aliases("--attributes", "-a"), "display data set attributes", ArgType_Flag, false, ArgValue(false));
+  ds_list_cmd->add_keyword_arg("exact-match", make_aliases("--exact-match"), "match the pattern exactly without appending a trailing wildcard", ArgType_Flag, false, ArgValue(false));
   ds_list_cmd->add_keyword_arg(MAX_ENTRIES);
   ds_list_cmd->add_keyword_arg(WARN);
   ds_list_cmd->add_keyword_arg(RESPONSE_FORMAT_CSV);

--- a/native/c/server/schemas/requests.hpp
+++ b/native/c/server/schemas/requests.hpp
@@ -81,7 +81,8 @@ ZJSON_SCHEMA(ListDatasetsRequest,
     FIELD_OPTIONAL(responseTimeout, NUMBER),
     FIELD_OPTIONAL(start, STRING),
     FIELD_REQUIRED(pattern, STRING),
-    FIELD_OPTIONAL(attributes, BOOL)
+    FIELD_OPTIONAL(attributes, BOOL),
+    FIELD_OPTIONAL(exactMatch, BOOL)
 );
 
 struct ListDsMembersRequest {};

--- a/native/c/test/zowex.ds.server.test.cpp
+++ b/native/c/test/zowex.ds.server.test.cpp
@@ -298,13 +298,49 @@ void zowex_ds_server_tests()
       it("should properly list data sets via RPC", [&]() -> void {
         int req_id;
         std::string request = make_rpc_request("listDatasets", "{\"pattern\":\"" + ds_pattern + "\"}", req_id);
-        
+
         write_to_server(server, request);
         std::string response = read_rpc_response(server);
 
         Expect(response).ToContain("\"success\":true");
         Expect(response).ToContain("\"id\":" + std::to_string(req_id));
         Expect(response).ToContain("\"items\"");
+      });
+
+      it("should honor exactMatch via RPC", [&]() -> void {
+        const std::string ds_name = get_test_ds();
+        const std::string child_ds = ds_name + ".T00";
+
+        std::string setup_response;
+        execute_command_with_output(zowex_command + " ds create " + ds_name, setup_response);
+        execute_command_with_output(zowex_command + " ds create " + child_ds, setup_response);
+
+        int inclusive_id;
+        std::string inclusive_request = make_rpc_request(
+            "listDatasets", "{\"pattern\":\"" + ds_name + "\"}", inclusive_id);
+        write_to_server(server, inclusive_request);
+        const std::string inclusive_response = read_rpc_response(server);
+
+        int exact_id;
+        std::string exact_request = make_rpc_request(
+            "listDatasets", "{\"pattern\":\"" + ds_name + "\",\"exactMatch\":true}", exact_id);
+        write_to_server(server, exact_request);
+        const std::string exact_response = read_rpc_response(server);
+
+        // Clean up before asserting so a failure cannot leak data sets
+        execute_command_with_output(zowex_command + " ds delete " + child_ds, setup_response);
+        execute_command_with_output(zowex_command + " ds delete " + ds_name, setup_response);
+
+        // Default: trailing ".**" is appended, so the descendant matches too
+        Expect(inclusive_response).ToContain("\"success\":true");
+        Expect(inclusive_response).ToContain(ds_name);
+        Expect(inclusive_response).ToContain(child_ds);
+
+        // exactMatch: the pattern is used verbatim
+        Expect(exact_response).ToContain("\"success\":true");
+        Expect(exact_response).ToContain("\"id\":" + std::to_string(exact_id));
+        Expect(exact_response).ToContain(ds_name);
+        Expect(exact_response).Not().ToContain(child_ds);
       });
     });
 

--- a/native/c/test/zowex.ds.test.cpp
+++ b/native/c/test/zowex.ds.test.cpp
@@ -783,6 +783,58 @@ void zowex_ds_tests()
                              Expect(response).Not().ToContain(ds + ".T00");
                            });
 
+                        it("should match descendant data sets by default",
+                           [&]() -> void
+                           {
+                             std::string ds = _ds.back();
+                             _create_ds(ds);
+                             _create_ds(ds + ".T00");
+                             _ds.push_back(ds + ".T00");
+
+                             // Without --exact-match the pattern gains a trailing
+                             // ".**", so descendants are matched too.
+                             std::string response;
+                             std::string command = zowex_command + " data-set list " + ds;
+                             int rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain(ds);
+                             Expect(response).ToContain(ds + ".T00");
+                           });
+
+                        it("should match only the given data set with --exact-match",
+                           [&]() -> void
+                           {
+                             std::string ds = _ds.back();
+                             _create_ds(ds);
+                             _create_ds(ds + ".T00");
+                             _ds.push_back(ds + ".T00");
+
+                             // With --exact-match the pattern is used verbatim, so
+                             // the descendant is excluded.
+                             std::string response;
+                             std::string command = zowex_command + " data-set list " + ds + " --exact-match";
+                             int rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain(ds);
+                             Expect(response).Not().ToContain(ds + ".T00");
+                           });
+
+                        it("should warn when --exact-match finds no exact match",
+                           [&]() -> void
+                           {
+                             std::string ds = _ds.back();
+                             _create_ds(ds + ".T00");
+                             _ds.push_back(ds + ".T00");
+
+                             // The parent qualifier only exists as a prefix of the
+                             // child, so an exact match must find nothing.
+                             std::string response;
+                             std::string command = zowex_command + " data-set list " + ds + " --exact-match";
+                             int rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(RTNCD_WARNING);
+                             Expect(response).ToContain("Warning: no matching results found");
+                           });
+
                         it("should warn when listing a non-existent data set",
                            [&]() -> void
                            {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Recent Changes
 
 - Added `--exact-match` option to the `zssh list data-set` command. This option defaults to false for backwards compatibility, but can be set to true to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
+- Fixed attribute columns being displayed when `zssh list data-set` is run without the `--attributes` option. [#1012](https://github.com/zowe/zowex/issues/1012)
 
 ## `0.6.1`
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Client code for "zowex-for-zowe-cli" are documented i
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- Added `--exact-match` option to the `zssh list data-set` command. This option defaults to true for backwards compatibility, but can be set to false to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
+
 ## `0.6.1`
 
 - Added `--encoding` flag to `zssh submit local-file` and `zssh submit stdin` commands to specify the encoding of the submitted JCL. [#1050](https://github.com/zowe/zowex/pull/1050)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- Added `--exact-match` option to the `zssh list data-set` command. This option defaults to true for backwards compatibility, but can be set to false to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
+- Added `--exact-match` option to the `zssh list data-set` command. This option defaults to false for backwards compatibility, but can be set to true to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
 
 ## `0.6.1`
 

--- a/packages/cli/src/list/data-set/DataSet.definition.ts
+++ b/packages/cli/src/list/data-set/DataSet.definition.ts
@@ -57,6 +57,12 @@ export const ListDataSetDefinition: ICommandDefinition = {
             description: "Fetch attributes of the data sets being listed.",
             type: "boolean",
         },
+        {
+            name: "exact-match",
+            description: "Match the pattern exactly instead of appending a trailing wildcard.",
+            type: "boolean",
+            defaultValue: false,
+        },
     ],
     profile: { optional: ["ssh"] },
     outputFormatOptions: true,

--- a/packages/cli/src/list/data-set/DataSet.handler.ts
+++ b/packages/cli/src/list/data-set/DataSet.handler.ts
@@ -50,28 +50,32 @@ export default class ListDataSetsHandler extends SshBaseHandler {
             response.returnedRows,
             params.arguments.pattern,
         );
-        params.response.format.output({
-            output: response.items.map((item) => ({
-                ...item,
-                migrated: item.migrated ? "YES" : "NO",
-                volser: item.multivolume ? `${item.volser}+` : item.volser,
-            })),
-            format: "table",
-            fields: [
-                "name",
-                "volser",
-                "devtype",
-                "dsorg",
-                "recfm",
-                "lrecl",
-                "blksize",
-                "primary",
-                "secondary",
-                "dsntype",
-                "migrated",
-            ],
-            header: true,
-        });
+        if (params.arguments.attributes) {
+            params.response.format.output({
+                output: response.items.map((item) => ({
+                    ...item,
+                    migrated: item.migrated ? "YES" : "NO",
+                    volser: item.multivolume ? `${item.volser}+` : item.volser,
+                })),
+                format: "table",
+                fields: [
+                    "name",
+                    "volser",
+                    "devtype",
+                    "dsorg",
+                    "recfm",
+                    "lrecl",
+                    "blksize",
+                    "primary",
+                    "secondary",
+                    "dsntype",
+                    "migrated",
+                ],
+                header: true,
+            });
+        } else {
+            params.response.console.log(response.items.map((item) => item.name).join("\n"));
+        }
         return response;
     }
 }

--- a/packages/cli/src/list/data-set/DataSet.handler.ts
+++ b/packages/cli/src/list/data-set/DataSet.handler.ts
@@ -20,6 +20,7 @@ export default class ListDataSetsHandler extends SshBaseHandler {
             response = await client.ds.listDatasets({
                 pattern: params.arguments.pattern,
                 attributes: params.arguments.attributes,
+                exactMatch: params.arguments.exactMatch,
             });
         } catch (err) {
             const errText = (err instanceof ImperativeError ? err.additionalDetails : err.toString()).replace(

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- Added `exactMatch` property to the `ListDatasetsRequest` type. This option defaults to true for backwards compatibility, but can be set to false to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
+- Added `exactMatch` property to the `ListDatasetsRequest` type. This option defaults to false for backwards compatibility, but can be set to true to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
 
 ## `0.7.0`
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Client code for "@zowe/zowex-for-zowe-sdk" are docume
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- Added `exactMatch` property to the `ListDatasetsRequest` type. This option defaults to true for backwards compatibility, but can be set to false to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
+
 ## `0.7.0`
 
 - **Breaking:** Updated the `checkIfOutdated()` utility to compare version numbers with semantic versioning rather than comparing checksums of the `zowex` program. Its parameter is changed to accept the version number of `zowex` on the remote system rather than checksums, and it is no longer an `async` method. [#1073](https://github.com/zowe/zowex/pull/1073/)

--- a/packages/sdk/src/doc/rpc/ds.ts
+++ b/packages/sdk/src/doc/rpc/ds.ts
@@ -93,6 +93,10 @@ export interface ListDatasetsRequest
      * Whether to include attributes in the response
      */
     attributes?: boolean;
+    /**
+     * Whether to match the pattern exactly instead of appending a trailing wildcard
+     */
+    exactMatch?: boolean;
 }
 
 export interface ListDatasetsResponse extends common.CommandResponse {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Resolves #914 and #1012

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
On z/OS, run `zowex ds ls SYS1.PARMLIB` with and without the `--exact-match` argument.
On local machine, run `zowe zssh ls ds SYS1.PARMLIB` with and without the `--exact-match` argument.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
