### PR TITLE
chore: bump zowex to 0.7.1, add `version:bump` script

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the native code for "zowex" are documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## Recent Changes
+## `0.7.1`
 
 - `c`: Fixed `zowex server` resource leaks that could exhaust a z/OS LPAR after a request timed out or a connection dropped. The shutdown signal handler no longer calls into the worker pool or logger, which could deadlock and leave the process running forever; the number of live force-detached worker threads is now bounded, and the server exits when the limit is exceeded so the system can reclaim them; late responses from a detached worker are discarded instead of being sent for an ID the client already failed; notifications are serialized with responses so concurrent writes cannot corrupt the JSON stream; and worker initializer threads are drained before the pool is destroyed. [#537](https://github.com/zowe/zowex/issues/537)
 - `c`: Fixed an issue with `zowex ds list-members` when reading PDS directory blocks. [#1070] (https://github.com/zowe/zowex/pull/1070)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zowex",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zowex",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "EPL-2.0",
       "workspaces": [
         "packages/*"
@@ -4895,7 +4895,7 @@
     },
     "packages/cli": {
       "name": "zowex-for-zowe-cli",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "bundleDependencies": [
         "@zowe/zos-uss-for-zowe-sdk",
         "@zowe/zowex-for-zowe-sdk",
@@ -4904,7 +4904,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/zos-uss-for-zowe-sdk": "^8.24.0",
-        "@zowe/zowex-for-zowe-sdk": "0.7.0",
+        "@zowe/zowex-for-zowe-sdk": "0.7.1",
         "terminal-kit": "^3.1.2"
       },
       "devDependencies": {
@@ -4916,29 +4916,9 @@
         "@zowe/imperative": "^8.0.0"
       }
     },
-    "packages/cli/node_modules/@zowe/zowex-for-zowe-sdk": {
-      "version": "0.7.0",
-      "integrity": "sha512-+uY5TZ1fUEnyG6G6xXD/vV0dGZGNi4Kg4YA0xrUvPr9o6rFtDa3ZufSZ3b0m0OkUrzjZaKqhjmCnlRkxP8QoZw==",
-      "inBundle": true,
-      "license": "EPL-2.0",
-      "dependencies": {
-        "base64-stream": "^1.0.0",
-        "es-toolkit": "^1.39.10",
-        "node-ssh": "^13.2.0",
-        "ssh-config": "^5.0.3",
-        "ssh2": "^1.16.0"
-      },
-      "optionalDependencies": {
-        "russh": "0.1.37"
-      },
-      "peerDependencies": {
-        "@zowe/imperative": "^8.11.0",
-        "@zowe/zos-uss-for-zowe-sdk": "^8.11.0"
-      }
-    },
     "packages/sdk": {
       "name": "@zowe/zowex-for-zowe-sdk",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "EPL-2.0",
       "dependencies": {
         "base64-stream": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zowex",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "scripts": {
     "all": "npm run z:rebuild && concurrently \"npm run z:artifacts\" \"npm run build\"",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepare": "husky",
     "test": "npm run test --workspaces --if-present",
     "tools": "tsx scripts/buildTools.ts",
+    "version:bump": "tsx scripts/bumpVersion.ts",
     "watch": "npm run watch --workspaces",
     "watch:all": "concurrently \"npm run z:watch\" \"npm run watch\"",
     "z:all": "npm run z:rebuild && npm run z:package && npm run z:test",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zowex-for-zowe-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc -b",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@zowe/zos-uss-for-zowe-sdk": "^8.24.0",
-    "@zowe/zowex-for-zowe-sdk": "0.7.0",
+    "@zowe/zowex-for-zowe-sdk": "0.7.1",
     "terminal-kit": "^3.1.2"
   },
   "devDependencies": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Client code for "@zowe/zowex-for-zowe-sdk" are docume
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## Recent Changes
+## `0.7.1`
 
 - Fixed SSH connection softlocks and resource leaks when a connection drops or stalls during startup: the `ZSshClient.create` function now rejects when the connection closes before the server is ready or when a `serverStartupTimeout` (default 60s) elapses, cleans up the SSH connection on startup failure, rejects pending requests fast when the connection closes, and supports the `keepAliveCountMax` option (default 3). [#1076](https://github.com/zowe/zowex/pull/1076)
 - Fixed requests hanging until the response timeout when the Zowe Remote SSH server process ended while the SSH transport stayed healthy. `ZSshClient` now watches the server channel for the lifetime of the client and rejects requests written to a channel that is no longer writable. [#1076](https://github.com/zowe/zowex/pull/1076)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/zowex-for-zowe-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "lib/index.js",
   "scripts": {
     "generate-constants": "tsx generateConstants.ts",

--- a/packages/sdk/src/ZSshConstants.ts
+++ b/packages/sdk/src/ZSshConstants.ts
@@ -10,4 +10,4 @@
  */
 
 // Generated via generateConstants.ts
-export const BUNDLED_SSH_SERVER_VERSION = "0.7.0";
+export const BUNDLED_SSH_SERVER_VERSION = "0.7.1";

--- a/scripts/bumpVersion.ts
+++ b/scripts/bumpVersion.ts
@@ -1,0 +1,98 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// bumpVersion.ts - Bumps the version across package.json, CHANGELOG.md, and ZSshConstants.ts files
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT_DIR = path.resolve(__dirname, "..");
+const BUMP_TYPES = ["patch", "minor", "major"] as const;
+type BumpType = (typeof BUMP_TYPES)[number];
+
+const PACKAGE_JSON_PATHS = [
+    path.join(ROOT_DIR, "package.json"),
+    path.join(ROOT_DIR, "packages", "cli", "package.json"),
+    path.join(ROOT_DIR, "packages", "sdk", "package.json"),
+];
+const CHANGELOG_PATHS = [
+    path.join(ROOT_DIR, "native", "CHANGELOG.md"),
+    path.join(ROOT_DIR, "packages", "cli", "CHANGELOG.md"),
+    path.join(ROOT_DIR, "packages", "sdk", "CHANGELOG.md"),
+];
+const SSH_CONSTANTS_PATH = path.join(ROOT_DIR, "packages", "sdk", "src", "ZSshConstants.ts");
+const SDK_PACKAGE_NAME = "@zowe/zowex-for-zowe-sdk";
+
+function nextVersion(currentVersion: string, bumpType: BumpType): string {
+    const [major, minor, patch] = currentVersion.split(".").map(Number);
+    switch (bumpType) {
+        case "major":
+            return `${major + 1}.0.0`;
+        case "minor":
+            return `${major}.${minor + 1}.0`;
+        case "patch":
+            return `${major}.${minor}.${patch + 1}`;
+    }
+}
+
+function updatePackageJson(filePath: string, newVersion: string) {
+    const pkg = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    pkg.version = newVersion;
+    if (pkg.dependencies?.[SDK_PACKAGE_NAME] != null) {
+        pkg.dependencies[SDK_PACKAGE_NAME] = newVersion;
+    }
+    fs.writeFileSync(filePath, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+function updateChangelog(filePath: string, newVersion: string) {
+    const content = fs.readFileSync(filePath, "utf-8");
+    if (!content.includes("## Recent Changes")) {
+        return;
+    }
+    fs.writeFileSync(filePath, content.replace("## Recent Changes", `## \`${newVersion}\``));
+}
+
+function updateSshConstants(filePath: string, oldVersion: string, newVersion: string) {
+    const content = fs.readFileSync(filePath, "utf-8");
+    fs.writeFileSync(
+        filePath,
+        content.replace(
+            `export const BUNDLED_SSH_SERVER_VERSION = "${oldVersion}";`,
+            `export const BUNDLED_SSH_SERVER_VERSION = "${newVersion}";`,
+        ),
+    );
+}
+
+function main() {
+    const bumpType = process.argv[2] as BumpType;
+    if (!BUMP_TYPES.includes(bumpType)) {
+        console.error(`Usage: npm run version:bump -- <${BUMP_TYPES.join("|")}>`);
+        process.exit(1);
+    }
+
+    const rootPackageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATHS[0], "utf-8"));
+    const oldVersion = rootPackageJson.version;
+    const newVersion = nextVersion(oldVersion, bumpType);
+
+    for (const packageJsonPath of PACKAGE_JSON_PATHS) {
+        updatePackageJson(packageJsonPath, newVersion);
+    }
+    for (const changelogPath of CHANGELOG_PATHS) {
+        updateChangelog(changelogPath, newVersion);
+    }
+    updateSshConstants(SSH_CONSTANTS_PATH, oldVersion, newVersion);
+
+    execSync("npm install --package-lock-only", { cwd: ROOT_DIR, stdio: "inherit" });
+
+    console.log(`Bumped version: ${oldVersion} -> ${newVersion}`);
+}
+
+main();


### PR DESCRIPTION
**What It Does**

- Bumps zowex from `0.7.0` -> `0.7.1` to publish recent SSH client connection fixes in advance of ZE 3.6
- Adds an NPM `version:bump` script to make it really easy to bump the `zowex` version automatically: provide `patch`, `minor`, or `major` and the script handles the rest

**How to Test**

You can test the version bumping script locally without pushing the changes:
- `npm run version:bump -- patch` bumps from `0.7.1 -> 0.7.2`
- `npm run version:bump -- minor` bumps from `0.7.2 -> 0.8.0`
- `npm run version:bump -- major` bumps from `0.7.1 -> 1.0.0`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)