### PR TITLE
Fix minor bugs in recovery

### DIFF
--- a/native/asmmac/ZWEEPILG
+++ b/native/asmmac/ZWEEPILG
@@ -31,6 +31,11 @@
          GBLB  &ZG_SAM64
 .*
 &MACNM   SETC  '&SYSMAC(0)'
+.*
+.*       Re-enable the compiler-generated F4SA signature store in
+.*       case the paired ZWEPROLG SAVE=NO suppressed it
+.*
+&CCN_SASIG SETB 1
 
 &IS_64   SETB  (&CCN_LP64 OR &ZG_SAM64)
 &IS_AR   SETB  ('&CCN_ASCM' EQ 'AR')

--- a/native/asmmac/ZWEPROLG
+++ b/native/asmmac/ZWEPROLG
@@ -33,7 +33,8 @@
 .*       SAVE=[SA,BAKR,NO]
 .*         SA: (default) save input regs
 .*         BAKR: save registers on linkage stack
-.*         NO: do not save save input registers
+.*         NO: do not save save input registers; also suppresses
+.*             the compiler-generated F4SA save area signature
 .*
 .*       USENAB=[NO,YES]
 .*         NO: (default) do not attempt to use NAB
@@ -133,8 +134,20 @@
 .*
 .*       Process SAVE=
 .*
+.*       &CCN_SASIG gates the compiler-generated F4SA signature store
+.*       (ST x,4(,13)) emitted after this prolog. A SAVE=NO function
+.*       has no save area and R13 may not address usable storage, so
+.*       we suppress the store. 
+.*       IBM Doc: Metal C and MVS linkage conventions
+.*
+.*       Allow compiler-generated F4SA signature store by default.
+&CCN_SASIG SETB 1
          AIF   ('&SAVE' EQ 'BAKR').CONT120
-         AIF   ('&SAVE' EQ 'NO').CONT200
+         AIF   ('&SAVE' NE 'NO').CONT110
+&CCN_SASIG SETB 0
+         AGO   .CONT200
+.*
+.CONT110 ANOP  ,
 &ZG_SAVE SETB  1
          AGO   .CONT130
 .*

--- a/native/c/zrecovery.h
+++ b/native/c/zrecovery.h
@@ -212,7 +212,7 @@ typedef struct
 typedef void (*PTR64 ROUTINE)(ZRCVY_ENV *);
 typedef int (*PTR64 RECOVERY_ROUTINE)(SDWA);
 
-#pragma prolog(ZRCVYRTY, " ZWEPROLG NEWDSA=NO ")
+#pragma prolog(ZRCVYRTY, " ZWEPROLG NEWDSA=NO,SAVE=NO ")
 #pragma epilog(ZRCVYRTY, " ZWEEPILG ")
 typedef void (*RETRY_ROUTINE)(ZRCVY_ENV);
 static void ZRCVYRTY(ZRCVY_ENV zenv)
@@ -264,23 +264,29 @@ static int ZRCVYARR(SDWA sdwa)
   zenv->recovery_entered = 1;
 
   // capture abend information from SDWA using IBM standards
-  // Extract completion code from SDWAABCC (4 bytes)  
+  // Extract completion code from SDWAABCC (4 bytes)
   unsigned int temp_abend_code = 0;
-  memcpy(&temp_abend_code, &sdwa.sdwafiob.sdwaabcc, sizeof(unsigned int)); //4 bytes
+  memcpy(&temp_abend_code, &sdwa.sdwafiob.sdwaabcc, sizeof(unsigned int)); // 4 bytes
   zenv->abend_rc = temp_abend_code;
-  
+
   // Extract reason code from SDWAOCRC using the DSECT definition
-  if (sdwa.sdwaxpad) {
+  if (sdwa.sdwaxpad)
+  {
     struct sdwaptrs *ptrs = (struct sdwaptrs *)sdwa.sdwaxpad;
-    if (ptrs->sdwasrvp) {
+    if (ptrs->sdwasrvp)
+    {
       const struct sdwarc1 *rc1 = (const struct sdwarc1 *)ptrs->sdwasrvp;
       // Use the DSECT macro directly, which expands to sdwaserv.sdwarc1p.sdwart12._sdwaocrc
       zenv->abend_rsn = rc1->sdwaocrc;
-    } else {
+    }
+    else
+    {
       zenv->abend_rsn = 0;
     }
-  } else {
-    zenv->abend_rsn = 0; 
+  }
+  else
+  {
+    zenv->abend_rsn = 0;
   }
 
   if (sdwa.sdwaerrd & sdwaclup) // clean up only

--- a/native/c/zrecovery.h
+++ b/native/c/zrecovery.h
@@ -270,22 +270,16 @@ static int ZRCVYARR(SDWA sdwa)
   zenv->abend_rc = temp_abend_code;
 
   // Extract reason code from SDWAOCRC using the DSECT definition
-  if (sdwa.sdwaxpad)
-  {
+  if (sdwa.sdwaxpad) {
     struct sdwaptrs *ptrs = (struct sdwaptrs *)sdwa.sdwaxpad;
-    if (ptrs->sdwasrvp)
-    {
+    if (ptrs->sdwasrvp) {
       const struct sdwarc1 *rc1 = (const struct sdwarc1 *)ptrs->sdwasrvp;
       // Use the DSECT macro directly, which expands to sdwaserv.sdwarc1p.sdwart12._sdwaocrc
       zenv->abend_rsn = rc1->sdwaocrc;
-    }
-    else
-    {
+    } else {
       zenv->abend_rsn = 0;
     }
-  }
-  else
-  {
+  } else {
     zenv->abend_rsn = 0;
   }
 


### PR DESCRIPTION
**What It Does**
These changes are intended to prevent possible crashes during recovery situations where there's garbage in the R2-R13 registers. This PR copies a `SAVE=NO` update already made in `ZRCVYRTE` to `ZRCVYRTY`.

The existing `SAVE=NO` fix had an open issue: the Metal C complier was issuing a store off R13 as part of it's save area signature generation (F4SA). In the listing for ZRCVYRTE, with SAVE=NO, Metal C generates: `ST    2,4(,13)` when R13 is garbage. So we can still run into a crash during recovery.

This PR updates `ZWEPROLG` and `ZWEEPILG` to remove Metal C's signature generation when `SAVE=NO`.  This is done by toggling and restoring `&CCN_SASIG`.

All tests pass and there should be no side effects, but a second set of eyes appreciated.

Doc on linkage and Metal C save area F4SA signature -> https://www.ibm.com/docs/en/zos/3.1.0?topic=c-metal-mvs-linkage-conventions
Doc on `CCN_SASIG` ->  https://www.ibm.com/docs/en/zos/3.1.0?topic=code-compiler-generated-global-set-symbols#autosetdecls__tblsetdecls2

**How to Test**
- Run zrecovery test suite.
- I do not have test cases which create the crash-during-recovery scenario described above.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)