### PR TITLE
fix: coerce encoding into a string

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Fixed an issue where passing numeric values to the `encoding` or `local-encoding` arguments would result in an empty string, as their argument definitions did not enable string coercion. Now, values provided to these options are converted to strings to ensure proper codepage conversion. [#1095](https://github.com/zowe/zowex/issues/1095)
 - `c`: Added ESM (RACF or equivalent) certificate and key ring management to the `system` command group, migrating the `keyring-utilities` functionality (R_datalib and System SSL) into `zowex` as two subgroups: `system keyring create|delete|list|list-rings|count` and `system cert import|export|delete|show|connect|set-default|trust|rename|refresh`. [#1079](https://github.com/zowe/zowex/pull/1079)
 - **Breaking:** `c`: Changed the plug-in SDK types `ast::ObjMap` and `plugin::ArgumentMap` from `std::unordered_map` to `std::map`, and added the `ZOWEX_PLUGIN_ABI_VERSION` constant with a matching load-time check. Plug-ins must now be rebuilt against the current `extend/plugin.hpp` and must expand `ZOWEX_PLUGIN_DECLARE_ABI()` alongside `register_plugin()`; a plug-in built against an earlier header is rejected at load time with a diagnostic instead of being loaded with mismatched type layouts. [#871](https://github.com/zowe/zowex/issues/871)
 - `c`: Replaced the string-keyed `std::unordered_map`/`std::unordered_set` containers in `zjson.hpp` and the JSON-RPC server with the ordered `std::map`/`std::set`, removing the binary's dependency on the out-of-line libc++ symbol `std::__1_e::__hash_memory`. That symbol is absent from `CRTEQCXE` on z/OS systems below the required Language Environment maintenance level, where it caused `CEE3561S` at load time. JSON object members are now emitted in alphabetical key order rather than hash order; member order was never part of the API contract. [#871](https://github.com/zowe/zowex/issues/871)
@@ -295,4 +296,3 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 - Initial release
-

--- a/native/c/commands/common_args.hpp
+++ b/native/c/commands/common_args.hpp
@@ -94,7 +94,7 @@ const ArgTemplate LOCAL_ENCODING = {
     ArgType_Single,
     false,
     ArgValue(),
-    make_aliases()};
+    make_aliases(), false, true};
 
 const ArgTemplate RESPONSE_FORMAT_CSV = {
     "response-format-csv",

--- a/native/c/commands/common_args.hpp
+++ b/native/c/commands/common_args.hpp
@@ -85,7 +85,7 @@ const ArgTemplate ENCODING = {
     ArgType_Single,
     false,
     ArgValue(),
-    make_aliases()};
+    make_aliases(), false, true};
 
 const ArgTemplate LOCAL_ENCODING = {
     "local-encoding",


### PR DESCRIPTION
**What It Does**

Fixes #1095 

Sets `coerce_to_string` for `ENCODING` and `LOCAL_ENCODING` arguments

**How to Test**

- `zowex job view-file-by-id JOBID KEY --encoding 1146` provides the same output as `zowex job view-file-by-id JOBID KEY --encoding IBM-1146`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)