### PR TITLE
fix searching sequential data sets via sdk

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Client code for "@zowe/zowex-for-zowe-sdk" are docume
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- Fixed the `SearchParser.parseSearchOutput` function silently dropping matches when searching a sequential data set [#1104](https://github.com/zowe/zowex/pull/1104)
+
 ## `0.8.0`
 
 - Added detection of available disk space on the z/OS Unix deployment directory in the `ZSshUtils.installServer` method, giving the user the opportunity to cancel deployment if they have less than the recommended amount of available space. [#1088](https://github.com/zowe/zowex/pull/1088)
@@ -13,7 +17,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added a verification step to `installServer()` that runs the installed server binary and reports whether the remote system can load it, so a runtime mismatch surfaces during installation rather than on the next operation. The target system level from the `uname -srv` command is included in the error details. [#871](https://github.com/zowe/zowex/issues/871)
 - Added `exactMatch` property to the `ListDatasetsRequest` type. This option defaults to false for backwards compatibility, but can be set to true to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
 - When a command fails, a structured error payload attached by the server (e.g. the `safReturns` SAF/ESM codes from certificate commands) is now delivered to SDK consumers via the `ImperativeError`'s `causeErrors`, instead of being flattened into the error text. [#1079](https://github.com/zowe/zowex/pull/1079)
-- Fixed the `SearchParser.parseSearchOutput` function silently dropping matches when searching a sequential data set [#1104](https://github.com/zowe/zowex/pull/1104)
 
 ## `0.7.1`
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -13,6 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Added a verification step to `installServer()` that runs the installed server binary and reports whether the remote system can load it, so a runtime mismatch surfaces during installation rather than on the next operation. The target system level from the `uname -srv` command is included in the error details. [#871](https://github.com/zowe/zowex/issues/871)
 - Added `exactMatch` property to the `ListDatasetsRequest` type. This option defaults to false for backwards compatibility, but can be set to true to avoid appending `.**` to the end of data set patterns. [#914](https://github.com/zowe/zowex/issues/914)
 - When a command fails, a structured error payload attached by the server (e.g. the `safReturns` SAF/ESM codes from certificate commands) is now delivered to SDK consumers via the `ImperativeError`'s `causeErrors`, instead of being flattened into the error text. [#1079](https://github.com/zowe/zowex/pull/1079)
+- Fixed the `SearchParser.parseSearchOutput` function silently dropping matches when searching a sequential data set [#1104](https://github.com/zowe/zowex/pull/1104)
 
 ## `0.7.1`
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -17,5 +17,6 @@ export * from "./RpcClientApi";
 export * from "./SshConfigUtils";
 export * from "./SshErrors";
 export * from "./UtilsApi";
+export * from "./utils";
 export * from "./ZSshClient";
 export * from "./ZSshUtils";

--- a/packages/sdk/src/utils/tools/SearchParser.ts
+++ b/packages/sdk/src/utils/tools/SearchParser.ts
@@ -17,7 +17,8 @@ export interface SearchMatch {
 }
 
 export interface SearchMember {
-    name: string;
+    /** Absent when the search target is a sequential data set rather than a PDS member */
+    name?: string;
     matches: SearchMatch[];
 }
 
@@ -57,6 +58,17 @@ export function parseSearchOutput(output: string): SearchResult {
     let processOptions = "";
     let searchPattern = "";
 
+    // Closes out the section in progress
+    const closeCurrentMember = (): void => {
+        if (currentMember && (currentMember.name != null || currentMember.matches.length > 0)) {
+            const lastMatch = currentMember.matches.at(-1);
+            if (lastMatch) lastMatch.afterContext.push(...pendingContext);
+            members.push(currentMember);
+        }
+        pendingContext = [];
+        currentMember = null;
+    };
+
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
 
@@ -71,32 +83,21 @@ export function parseSearchOutput(output: string): SearchResult {
             dataset = dsMatch[1];
 
             if (line.includes("SOURCE SECTION")) {
-                const memParse = dsMatch[1].match(/^(.+)\(([^)]+)\)\s*$/); // Parse member name from dataset name if present
-                if (memParse) {
-                    if (currentMember) {
-                        const lastMatch = currentMember.matches.at(-1);
-                        if (lastMatch) lastMatch.afterContext.push(...pendingContext);
-                        members.push(currentMember);
-                    }
-                    pendingContext = [];
-                    currentMember = {
-                        name: memParse[2],
-                        matches: [],
-                    };
-                    continue;
-                }
+                // Parse member name from dataset name if present; sequential data sets have no member
+                const memParse = dsMatch[1].match(/^(.+)\(([^)]+)\)\s*$/);
+                closeCurrentMember();
+                currentMember = {
+                    name: memParse?.[2],
+                    matches: [],
+                };
+                continue;
             }
         }
 
         // Parse member header: " <member name>                    --------- STRING(S) FOUND -------------------"
         const memberMatch = line.match(/^\s+(\S+)\s+[-]+\s+STRING\(S\) FOUND\s+[-]+/);
         if (memberMatch) {
-            if (currentMember) {
-                const lastMatch = currentMember.matches.at(-1);
-                if (lastMatch) lastMatch.afterContext.push(...pendingContext);
-                members.push(currentMember);
-            }
-            pendingContext = [];
+            closeCurrentMember();
             currentMember = {
                 name: memberMatch[1],
                 matches: [],
@@ -107,13 +108,7 @@ export function parseSearchOutput(output: string): SearchResult {
         // parse summary
         const summaryMatch = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+:\d+)\s+(\d+)\s*$/);
         if (summaryMatch) {
-            if (currentMember) {
-                const lastMatch = currentMember.matches.at(-1);
-                if (lastMatch) lastMatch.afterContext.push(...pendingContext);
-                pendingContext = [];
-                members.push(currentMember);
-                currentMember = null;
-            }
+            closeCurrentMember();
             linesFound = parseInt(summaryMatch[1], 10);
             linesProcessed = parseInt(summaryMatch[2], 10);
             membersWithLines = parseInt(summaryMatch[3], 10);
@@ -160,11 +155,7 @@ export function parseSearchOutput(output: string): SearchResult {
         }
     }
 
-    if (currentMember) {
-        const lastMatch = currentMember.matches.at(-1);
-        if (lastMatch) lastMatch.afterContext.push(...pendingContext);
-        members.push(currentMember);
-    }
+    closeCurrentMember();
 
     return {
         dataset,

--- a/packages/sdk/src/utils/tools/SearchParser.ts
+++ b/packages/sdk/src/utils/tools/SearchParser.ts
@@ -84,7 +84,7 @@ export function parseSearchOutput(output: string): SearchResult {
 
             if (line.includes("SOURCE SECTION")) {
                 // Parse member name from dataset name if present; sequential data sets have no member
-                const memParse = dsMatch[1].match(/^(.+)\(([^)]+)\)\s*$/);
+                const memParse = dsMatch[1].match(/^([^()]+)\(([^)]+)\)\s*$/);
                 closeCurrentMember();
                 currentMember = {
                     name: memParse?.[2],

--- a/packages/sdk/tests/SearchParser.test.ts
+++ b/packages/sdk/tests/SearchParser.test.ts
@@ -115,4 +115,48 @@ describe("parseSearchOutput", () => {
         expect(result.members[1].name).toBe("MEMBER2");
         expect(result.members[1].matches[0].afterContext).toContain("Some context in member 2");
     });
+
+    it("should parse a sequential (non-PDS) data set search with no member name", () => {
+        const output = [
+            "\f  ASMFSUPC    -     MVS FILE/LINE/WORD/BYTE/SFOR COMPARE UTILITY- V1R6M0  (2021/11/01)  2026/04/21   8.53    PAGE     1",
+            " LINE-#  SOURCE SECTION                    SRCH DSN: IBMUSER.SEQ",
+            "",
+            "      3  //IEFBR14$ JOB (IZUACCT),'mainframer',REGION=0M                        JOB00730",
+            "\f  ASMFSUPC    -     MVS FILE/LINE/WORD/BYTE/SFOR COMPARE UTILITY- V1R6M0  (2021/11/01)  2026/04/21   8.53    PAGE     2",
+            "     SEARCH-FOR SUMMARY SECTION            SRCH DSN: IBMUSER.SEQ",
+            "",
+            "LINES-FOUND  LINES-PROC  DATASET-W/LNS  DATASET-WO/LNS  COMPARE-COLS  LONGEST-LINE",
+            "        1           50            1              0           1:80           80",
+            "",
+            "THE FOLLOWING PROCESS STATEMENTS (USING COLUMNS 1:72) WERE PROCESSED:",
+            "    SRCHFOR 'ief'",
+            "",
+            "",
+        ].join("\n");
+
+        const result = parseSearchOutput(output);
+
+        expect(result.dataset).toBe("IBMUSER.SEQ");
+        expect(result.members).toHaveLength(1);
+        expect(result.members[0].name).toBeUndefined();
+        expect(result.members[0].matches.map((m) => m.lineNumber)).toEqual([3]);
+        expect(result.summary.linesFound).toBe(1);
+    });
+
+    it("should not create an empty section for a full-PDS scan's leading banner line", () => {
+        const output = [
+            "\f  ASMFSUPC    -     MVS FILE/LINE/WORD/BYTE/SFOR COMPARE UTILITY- V1R6M0  (2021/11/01)  2026/04/21   8.53    PAGE     1",
+            " LINE-#  SOURCE SECTION                    SRCH DSN: IBMUSER.JCL",
+            "",
+            "",
+            " IEFBR14                     --------- STRING(S) FOUND -------------------",
+            "",
+            "      4  //EXEC     EXEC PGM=IEFBR14",
+        ].join("\n");
+
+        const result = parseSearchOutput(output);
+
+        expect(result.members).toHaveLength(1);
+        expect(result.members[0].name).toBe("IEFBR14");
+    });
 });


### PR DESCRIPTION
**What It Does**
Fixes searching sequential data sets in the zowex sdk. This fix is purely towards direct sdk callers rather than Zowe Explorer since there is not an exposed way to invoke this function on a sequential data set.

**How to Test**
1. Replace the `TEST_TARGETS` with sequential dataset name in the below script. (Save it as `search-test.ts`)
2. Run `npx tsx /path/to/search-test.ts <ssh-profile> <search-string>`

Observe that on the `main` branch, it will never find any instances of the search string.
On the PR branch, it should properly find these instances.

<details>
<summary>Example Script</summary>

```typescript
// search-test.ts
import { type IProfile, ProfileInfo } from "@zowe/imperative";
import { UtilsApi, ZSshClient, ZSshUtils } from "@zowe/zowex-for-zowe-sdk/src";

const TEST_TARGETS = ["<SEQ.DS>"];

async function loadSshProfile(profileName: string): Promise<IProfile> {
    const profInfo = new ProfileInfo("zowe");
    await profInfo.readProfilesFromDisk();
    const profAttrs = profInfo.getAllProfiles("ssh").find((prof) => prof.profName === profileName);
    if (!profAttrs) {
        console.error(`SSH profile "${profileName}" not found. Available profiles:`);
        for (const p of profInfo.getAllProfiles("ssh")) {
            console.error(`  - ${p.profName}`);
        }
        process.exit(1);
    }
    const mergedArgs = profInfo.mergeArgsForProfile(profAttrs, { getSecureVals: true });
    return Object.fromEntries(mergedArgs.knownArgs.map((arg) => [arg.argName, arg.argValue]));
}

async function main() {
    const [profileName, searchString] = process.argv.slice(2);
    if (!profileName || !searchString) {
        console.error("Usage: npx tsx examples/search-test.ts <ssh-profile> <search-string>");
        process.exit(1);
    }

    const sshProfile = await loadSshProfile(profileName);
    const session = ZSshUtils.buildSession(sshProfile);
    using client = await ZSshClient.create(session);

    for (const dsname of TEST_TARGETS) {
        console.log(`\n=== Searching ${dsname} for "${searchString}" ===`);
        const response = await client.tool.search({ dsname, string: searchString });
        const result = UtilsApi.tools.parseSearchOutput(response.data);

        console.log(`Dataset: ${result.dataset}`);
        console.log(`Members with matches: ${result.members.length}`);
        for (const member of result.members) {
            console.log(`  ${member.name ?? "(sequential)"}: ${member.matches.length} match(es)`);
            for (const match of member.matches) {
                console.log(`    line ${match.lineNumber}: ${match.content}`);
            }
        }
        console.log(`Summary: ${JSON.stringify(result.summary)}`);
    }
}

main().catch((err) => {
    console.error(err);
    process.exit(1);
});
```
</details>

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
Also needed to export `./utils`