### PR TITLE
Fix for percolating caller key in `auth_off()`

### DIFF
--- a/native/c/commands/core.cpp
+++ b/native/c/commands/core.cpp
@@ -15,6 +15,7 @@
 #include "../zutm.h"
 #include <dirent.h>
 #include <algorithm>
+#include <mutex>
 #include <set>
 #include <vector>
 
@@ -222,8 +223,11 @@ Command &setup_root_command(char *argv[])
       return true;
     }
 
-    ZUTNOAUT(); 
-    return true; });
+    // Serialize against concurrent callers and fail closed: never run a
+    // non-privileged command while the job step is still APF-authorized
+    static std::mutex noaut_mutex;
+    std::lock_guard<std::mutex> lock(noaut_mutex);
+    return 0 == ZUTNOAUT(); });
   auto &root_command = g_arg_parser->get_root_command();
 
   root_command.add_keyword_arg("interactive",

--- a/native/c/test/parser.test.cpp
+++ b/native/c/test/parser.test.cpp
@@ -44,6 +44,21 @@ int sample_handler(plugin::InvocationContext &context)
   return 7;
 }
 
+bool g_priv_handler_called = false;
+bool g_plain_handler_called = false;
+
+int priv_probe_handler(plugin::InvocationContext &)
+{
+  g_priv_handler_called = true;
+  return 0;
+}
+
+int plain_probe_handler(plugin::InvocationContext &)
+{
+  g_plain_handler_called = true;
+  return 0;
+}
+
 } // namespace
 
 void parser_tests()
@@ -582,6 +597,98 @@ void parser_tests()
                Expect(hook1_called).ToBe(true);
                Expect(hook2_called).ToBe(false); // Second hook shouldn't run
                Expect(g_handler_called).ToBe(false); // Handler shouldn't run
+             });
+
+             it("exposes the privileged flag of the executing subcommand to hooks", []() {
+               bool hook_called = false;
+               bool hook_saw_privileged = false;
+
+               ArgumentParser arg_parser("prog", "privileged flag sample");
+               arg_parser.add_pre_command_hook([&](const Command &cmd, bool is_help_request) -> bool {
+                 hook_called = true;
+                 hook_saw_privileged = cmd.is_privileged();
+                 return true;
+               });
+
+               auto group = command_ptr(new Command("secure", "privileged group"));
+               auto sub_before = command_ptr(new Command("early", "added before set_privileged"));
+               sub_before->set_handler(&priv_probe_handler);
+               group->add_command(sub_before);
+               group->set_privileged(true);
+               auto sub_after = command_ptr(new Command("late", "added after set_privileged"));
+               sub_after->set_handler(&priv_probe_handler);
+               group->add_command(sub_after);
+               arg_parser.get_root_command().add_command(group);
+
+               {
+                 g_priv_handler_called = false;
+                 std::vector<std::string> raw = {"prog", "secure", "early"};
+                 std::vector<char *> argv = to_argv(raw);
+                 ParseResult result = arg_parser.parse(static_cast<int>(argv.size()), argv.data());
+                 Expect(result.exit_code).ToBe(0);
+                 Expect(hook_called).ToBe(true);
+                 Expect(hook_saw_privileged).ToBe(true);
+                 Expect(g_priv_handler_called).ToBe(true);
+               }
+
+               {
+                 g_priv_handler_called = false;
+                 hook_called = false;
+                 hook_saw_privileged = false;
+                 std::vector<std::string> raw = {"prog", "secure", "late"};
+                 std::vector<char *> argv = to_argv(raw);
+                 ParseResult result = arg_parser.parse(static_cast<int>(argv.size()), argv.data());
+                 Expect(result.exit_code).ToBe(0);
+                 Expect(hook_called).ToBe(true);
+                 Expect(hook_saw_privileged).ToBe(true);
+                 Expect(g_priv_handler_called).ToBe(true);
+               }
+             });
+
+             it("supports fail-closed authorization hooks: privileged bypasses, non-privileged aborts", []() {
+               // mirrors the zowex authorization-drop hook when the drop fails:
+               // privileged commands skip the drop and run; everything else aborts
+               ArgumentParser arg_parser("prog", "fail closed sample");
+               arg_parser.add_pre_command_hook([](const Command &cmd, bool is_help_request) -> bool {
+                 if (!is_help_request && cmd.is_privileged())
+                 {
+                   return true;
+                 }
+                 return false; // simulated failure to relinquish authorization
+               });
+
+               auto group = command_ptr(new Command("secure", "privileged group"));
+               auto sub = command_ptr(new Command("run", "privileged action"));
+               sub->set_handler(&priv_probe_handler);
+               group->add_command(sub);
+               group->set_privileged(true);
+               arg_parser.get_root_command().add_command(group);
+
+               auto plain = command_ptr(new Command("list", "non-privileged action"));
+               plain->set_handler(&plain_probe_handler);
+               arg_parser.get_root_command().add_command(plain);
+
+               {
+                 g_priv_handler_called = false;
+                 std::vector<std::string> raw = {"prog", "secure", "run"};
+                 std::vector<char *> argv = to_argv(raw);
+                 ParseResult result = arg_parser.parse(static_cast<int>(argv.size()), argv.data());
+                 Expect(result.exit_code).ToBe(0);
+                 Expect(g_priv_handler_called).ToBe(true);
+               }
+
+               {
+                 g_plain_handler_called = false;
+                 std::vector<std::string> raw = {"prog", "list"};
+                 std::vector<char *> argv = to_argv(raw);
+                 ParseResult result;
+                 {
+                   test_utils::ErrorStreamCapture error_capture;
+                   result = arg_parser.parse(static_cast<int>(argv.size()), argv.data());
+                 }
+                 Expect(result.exit_code).ToBe(1);
+                 Expect(g_plain_handler_called).ToBe(false); // fail closed: handler never ran
+               }
              });
              
              it("executes hooks before help is shown", []() {

--- a/native/c/test/zmetal.metal.test.c
+++ b/native/c/test/zmetal.metal.test.c
@@ -26,3 +26,32 @@ int ZMTLDEL(const char *name)
 {
     return delete_module(name);
 }
+
+// returns 1 if the IEAVJAOF service (used by auth_off) is available via ECVTJAOF
+#pragma prolog(ZMTLJAOF, " ZWEPROLG NEWDSA=(YES,1) ")
+#pragma epilog(ZMTLJAOF, " ZWEEPILG ")
+int ZMTLJAOF()
+{
+    PSA *psa = (PSA *)0;
+    struct cvt *PTR32 cvt_a = (struct cvt * PTR32) psa->flccvt;
+    struct ecvt *PTR32 ecvt_a = (struct ecvt * PTR32) cvt_a->cvtecvt;
+    return 0 != ecvt_a->ecvtjaof ? 1 : 0;
+}
+
+// returns 1 if the caller is running in problem state
+#pragma prolog(ZMTLPST, " ZWEPROLG NEWDSA=(YES,1) ")
+#pragma epilog(ZMTLPST, " ZWEEPILG ")
+int ZMTLPST()
+{
+    PSW psw = {0};
+    get_psw(&psw);
+    return psw.data.bits.p ? 1 : 0;
+}
+
+// returns the TESTAUTH result (0 = authorized)
+#pragma prolog(ZMTLTAUT, " ZWEPROLG NEWDSA=(YES,1) ")
+#pragma epilog(ZMTLTAUT, " ZWEEPILG ")
+int ZMTLTAUT()
+{
+    return test_auth();
+}

--- a/native/c/test/zmetal.metal.test.h
+++ b/native/c/test/zmetal.metal.test.h
@@ -22,6 +22,9 @@ extern "C"
 
   void *ZMTLLOAD(const char *);
   int ZMTLDEL(const char *);
+  int ZMTLJAOF();
+  int ZMTLPST();
+  int ZMTLTAUT();
 
 #if defined(__cplusplus)
 }

--- a/native/c/test/zmetal.test.cpp
+++ b/native/c/test/zmetal.test.cpp
@@ -11,9 +11,12 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <thread>
+#include <vector>
 
 #include "ztest.hpp"
 #include "zmetal.metal.test.h"
+#include "../zutm.h"
 
 using namespace ztst;
 
@@ -47,6 +50,67 @@ void zmetal_tests()
                   std::string name = "IEFBR15";
                   int rc = ZMTLDEL(name.c_str());
                   Expect(rc).ToBe(4);
+                });
+           });
+
+  describe("auth relinquish (ZUTNOAUT) tests",
+           []() -> void
+           {
+             it("should find the IEAVJAOF service (ECVTJAOF) available on this system",
+                []()
+                {
+                  // auth_off fails closed when ECVTJAOF is zero; this guards that
+                  // assumption on every system the tests run on
+                  Expect(ZMTLJAOF()).ToBe(1);
+                });
+
+             it("should succeed as a no-op without changing PSW state or key when not APF-authorized",
+                []()
+                {
+                  // premise: the test runner is not APF-authorized
+                  Expect(ZMTLTAUT()).Not().ToBe(0);
+
+                  int key_before = static_cast<int>(ZUTMGKEY());
+                  Expect(ZMTLPST()).ToBe(1); // problem state
+
+                  Expect(ZUTNOAUT()).ToBe(0);
+
+                  Expect(static_cast<int>(ZUTMGKEY())).ToBe(key_before);
+                  Expect(ZMTLPST()).ToBe(1); // still problem state
+                });
+
+             it("should be idempotent",
+                []()
+                {
+                  Expect(ZUTNOAUT()).ToBe(0);
+                  Expect(ZUTNOAUT()).ToBe(0);
+                });
+
+             it("should handle concurrent calls from multiple threads",
+                []()
+                {
+                  constexpr int num_threads = 5;
+                  std::vector<std::thread> threads;
+                  std::vector<int> rcs(num_threads, -1);
+
+                  for (int i = 0; i < num_threads; ++i)
+                  {
+                    threads.push_back(std::thread([i, &rcs]() -> void
+                                                  { rcs[i] = ZUTNOAUT(); }));
+                  }
+
+                  for (auto &t : threads)
+                  {
+                    if (t.joinable())
+                    {
+                      t.join();
+                    }
+                  }
+
+                  for (int i = 0; i < num_threads; ++i)
+                  {
+                    Expect(rcs[i]).ToBe(0);
+                  }
                 });
            });
 }

--- a/native/c/test/zoweax.console.test.cpp
+++ b/native/c/test/zoweax.console.test.cpp
@@ -79,4 +79,45 @@ void zoweax_console_tests()
             Expect(response).ToContain("Error: could not activate console:");
 
         }); });
+
+  describe("APF authorization drop (ZUTNOAUT) tests", [&]() -> void
+           {
+        it("should run a non-privileged command from the APF-authorized binary", []() -> void
+        {
+            // exercises the live authorization drop (IEAVJAOF under IEAARR recovery);
+            // the pre-command hook fails closed, so a broken drop would exit non-zero
+            std::string response;
+            std::string command = zoweax_command + " version";
+            int rc = execute_command_with_output(command, response);
+
+            ExpectWithContext(rc, response).ToBe(0);
+            Expect(response).ToContain("Version:");
+        });
+
+        it("should run a non-privileged command from the unauthorized binary", []() -> void
+        {
+            std::string response;
+            std::string command = zowex_command + " version";
+            int rc = execute_command_with_output(command, response);
+
+            ExpectWithContext(rc, response).ToBe(0);
+            Expect(response).ToContain("Version:");
+        });
+
+        it("should drop authorization for the whole job step in an interactive session", []() -> void
+        {
+            // entering interactive mode runs the non-privileged root command, which
+            // drops JSCBAUTH for the job step; a console command in the same process
+            // must then fail with a TESTAUTH error even though the binary is
+            // APF-authorized, while non-privileged commands keep working
+            std::string response;
+            std::string command = "printf 'console issue DTIME\\nversion\\nquit\\n' | " +
+                                  zoweax_command + " --it";
+            int rc = execute_command_with_output(command, response);
+
+            ExpectWithContext(rc, response).ToBe(0);
+            Expect(response).ToContain("Error: could not activate console:");
+            Expect(response).ToContain("Not authorized");
+            Expect(response).ToContain("Version:");
+        }); });
 }

--- a/native/c/zmetal.h
+++ b/native/c/zmetal.h
@@ -20,6 +20,8 @@
 #include "ihapsa.h"
 #include "ikjtcb.h"
 #include "iezjscb.h"
+#include "cvt.h"
+#include "ihaecvt.h"
 #endif
 
 #define MAX_PARM_LENGTH 100 + 1
@@ -288,17 +290,48 @@ typedef struct psa PSA;
 typedef struct tcb TCB;
 typedef struct iezjscb IEZJSCB;
 
-static void auth_off()
-{
 #if defined(__IBM_METAL__)
-  PSA *psa = (PSA *)0;
-  TCB *PTR32 tcb = (TCB * PTR32) psa->psatold;
-  unsigned int ujjscb = 0;
-  memcpy(&ujjscb, &tcb->tcbjscb, sizeof(tcb->tcbjscb));
-  IEZJSCB *PTR32 jscb = (IEZJSCB * PTR32)(ujjscb & 0x00FFFFFF);
+#define IEAVJAOF(ep, rc)                                      \
+  __asm(                                                      \
+      "*                                                  \n" \
+      " LLGF 15,%1        -> IEAVJAOF                     \n" \
+      " SLGR 1,1          R1 = 0                          \n" \
+      " BASSM 14,15       Call IEAVJAOF                   \n" \
+      " ST   15,%0        Save RC                         \n" \
+      "*                                                    " \
+      : "=m"(rc)                                              \
+      : "m"(ep)                                               \
+      : "r0", "r1", "r14", "r15");
+#else
+#define IEAVJAOF(ep, rc)
+#endif
 
+/**
+ * @brief Turn off JSCBAUTH (relinquish job step APF authorization) via the
+ * IEAVJAOF system service located through ECVTJAOF. IEAVJAOF requires
+ * supervisor state and key 0; callers should establish recovery (e.g.
+ * enable_recovery) around this call so an abend in the elevated window
+ * cannot percolate in supervisor state / key 0.
+ *
+ * @return 0 on success, non-zero if the service is unavailable or failed
+ */
+static int auth_off()
+{
+  int rc = RTNCD_SUCCESS;
+#if defined(__IBM_METAL__)
   if (0 == test_auth())
   {
+    PSA *psa = (PSA *)0;
+    struct cvt *PTR32 cvt_a = (struct cvt * PTR32) psa->flccvt;
+    struct ecvt *PTR32 ecvt_a = (struct ecvt * PTR32) cvt_a->cvtecvt;
+    void *PTR32 jaof = ecvt_a->ecvtjaof;
+
+    if (0 == jaof)
+    {
+      return RTNCD_FAILURE; // service unavailable; caller must not proceed unauthorized
+    }
+
+    int service_rc = 0;
     PSW psw = {0};
     get_psw(&psw);
     int mode_switch = psw.data.bits.p ? 1 : 0;
@@ -309,14 +342,20 @@ static void auth_off()
       mode_sup();
     }
     set_key(&key_zero);
-    jscb->jscbopts &= (0xFF - jscbauth);
+    IEAVJAOF(jaof, service_rc);
     set_key(&key);
     if (mode_switch)
     {
       mode_prob();
     }
+
+    if (0 != service_rc)
+    {
+      rc = RTNCD_FAILURE;
+    }
   }
 #endif
+  return rc;
 }
 
 /**

--- a/native/c/zutm.c
+++ b/native/c/zutm.c
@@ -26,6 +26,7 @@
 #include "csvdlaa.h"
 #include "zwto.h"
 #include "zdbg.h"
+#include "zrecovery.h"
 
 #define ZUT_BPXWDYN_SERVICE_FAILURE -2
 
@@ -549,12 +550,36 @@ int ZUTSSIQ(ZDIAG *diag, JQRY_HEADER **area, const char *filter)
   return rc;
 }
 
-#pragma prolog(ZUTNOAUT, " ZWEPROLG NEWDSA=(YES,1) ")
+#pragma prolog(ZUTNOAUT, " ZWEPROLG NEWDSA=(YES,4) ")
 #pragma epilog(ZUTNOAUT, " ZWEEPILG ")
 int ZUTNOAUT()
 {
-  auth_off();
-  return 0;
+  if (0 != test_auth())
+  {
+    return RTNCD_SUCCESS; // not APF-authorized; nothing to relinquish
+  }
+
+  int rc = RTNCD_SUCCESS;
+  ZRCVY_ENV zenv = {0};
+
+  if (0 == enable_recovery(&zenv))
+  {
+    rc = auth_off();
+  }
+  else
+  {
+    rc = RTNCD_FAILURE; // abend in elevated window; retry restored problem state & key
+  }
+
+  disable_recovery(&zenv);
+
+  // fail closed - confirm authorization was actually relinquished
+  if (RTNCD_SUCCESS == rc && 0 == test_auth())
+  {
+    rc = RTNCD_FAILURE;
+  }
+
+  return rc;
 }
 
 #pragma prolog(ZUTMSREL, " ZWEPROLG NEWDSA=(YES,4) ")

--- a/native/c/zutm.h
+++ b/native/c/zutm.h
@@ -188,6 +188,15 @@ extern "C"
 
   int ZUTSSIQ(ZDIAG *, JQRY_HEADER **, const char *filter);
   int ZUTCVTD(const char *ptr, char *time_out);
+
+  /**
+   * @brief Relinquish job step APF authorization (turn off JSCBAUTH) under
+   * ESTAE-type (IEAARR) recovery. Verifies with TESTAUTH that authorization
+   * was actually dropped.
+   * @return RTNCD_SUCCESS if the job step is (now) unauthorized,
+   * RTNCD_FAILURE if authorization could not be relinquished (callers must
+   * fail closed and not run unprivileged work)
+   */
   int ZUTNOAUT();
 
 #if defined(__cplusplus)


### PR DESCRIPTION
**What It Does**
Addresses an issue where an abend during `auth_off()` could percolate key to recovery routines.

**How to Test**
Test cases coming

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
This is a Dan PR