### PR TITLE
Fix: Flip to and from encoding arguments in error message

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the native code for "zowex" are documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes
+
+- `c`: Flipped to and from encoding arguments in error message to be accurate. [#1106](https://github.com/zowe/zowex/pull/1106)
+
 ## `0.8.0`
 
 - `c`: Stripped ASA control characters when reading spool files. [#114](https://github.com/zowe/zowex/issues/114)

--- a/native/c/test/zds.test.cpp
+++ b/native/c/test/zds.test.cpp
@@ -1908,6 +1908,34 @@ void zds_tests()
                              Expect(content_default).ToBe(content_explicit);
                            });
 
+                        it("should report from=file encoding, to=local encoding when iconv fails on read",
+                           [&]() -> void
+                           {
+                             std::string dsn = get_random_ds(3);
+                             created_dsns.push_back(dsn);
+                             ZDS zds = {0};
+                             create_seq(&zds, dsn);
+
+                             ZDS write_zds{};
+                             write_zds.encoding_opts.data_type = eDataTypeBinary;
+                             const std::string invalid_utf8 = "invalid utf8: \xff\xfe\xfd";
+                             ZDSWriteOpts write_opts{.zds = &write_zds, .dsname = dsn};
+                             int wrc = zds_write(write_opts, invalid_utf8);
+                             ExpectWithContext(wrc, write_zds.diag.e_msg).ToBe(0);
+
+                             ZDS read_zds{};
+                             strcpy(read_zds.encoding_opts.codepage, "UTF-8");
+                             strcpy(read_zds.encoding_opts.source_codepage, "IBM-1047");
+                             read_zds.encoding_opts.data_type = eDataTypeText;
+                             ZDSReadOpts read_opts{.zds = &read_zds, .dsname = dsn};
+                             std::string content;
+                             int rc = zds_read(read_opts, content);
+
+                             Expect(rc).ToBe(RTNCD_FAILURE);
+                             const std::string msg(read_zds.diag.e_msg);
+                             Expect(msg).ToContain("from UTF-8 to IBM-1047");
+                           });
+
                         it("should produce a consistent etag after write and read",
                            [&]() -> void
                            {

--- a/native/c/test/zusf.test.cpp
+++ b/native/c/test/zusf.test.cpp
@@ -1693,6 +1693,29 @@ void zusf_tests()
                   // Verify error message was set but encoding preserved
                   Expect(std::strlen(zusf.diag.e_msg)).ToBeGreaterThan(0);
                 });
+                it("should report from=file encoding, to=local encoding when iconv fails on read",
+                [&]() -> void
+                {
+                  ZUSF zusf{};
+                  const std::string test_file = "/tmp/zusf_iconv_fail_" + get_random_string(8) + ".txt";
+                  {
+                    std::ofstream out(test_file, std::ios::binary);
+                    out << "invalid utf8: \xff\xfe\xfd";
+                    out.close();
+                  }
+                  strcpy(zusf.encoding_opts.source_codepage, "UTF-8");
+                  strcpy(zusf.encoding_opts.codepage, "IBM-1047");
+                  zusf.encoding_opts.data_type = eDataTypeText;
+
+                  std::string content;
+                  int rc = zusf_read_from_uss_file(&zusf, test_file, content);
+
+                  Expect(rc).ToBe(RTNCD_FAILURE);
+                  const std::string msg(zusf.diag.e_msg);
+                  Expect(msg).ToContain("from UTF-8 to IBM-1047");
+
+                  unlink(test_file.c_str());
+                });
            });
 
   describe("zusf_move_uss_file_or_dir tests",

--- a/native/c/test/zusf.test.cpp
+++ b/native/c/test/zusf.test.cpp
@@ -1703,8 +1703,8 @@ void zusf_tests()
                     out << "invalid utf8: \xff\xfe\xfd";
                     out.close();
                   }
-                  strcpy(zusf.encoding_opts.source_codepage, "UTF-8");
-                  strcpy(zusf.encoding_opts.codepage, "IBM-1047");
+                  strcpy(zusf.encoding_opts.codepage, "UTF-8");
+                  strcpy(zusf.encoding_opts.source_codepage, "IBM-1047");
                   zusf.encoding_opts.data_type = eDataTypeText;
 
                   std::string content;

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -930,7 +930,7 @@ int zds_read(const ZDSReadOpts &opts, std::string &response)
     }
     catch (std::exception &e)
     {
-      ZDIAG_SET_MSG(&zds->diag, "Failed to convert input data from %s to %s", source_encoding.c_str(), zds->encoding_opts.codepage);
+      ZDIAG_SET_MSG(&zds->diag, "Failed to convert input data from %s to %s", zds->encoding_opts.codepage, source_encoding.c_str());
       return RTNCD_FAILURE;
     }
     if (!temp.empty())

--- a/native/c/ztype.h
+++ b/native/c/ztype.h
@@ -95,6 +95,11 @@ enum DataType
 typedef struct _ZEncode
 {
   char codepage[16];
+  /**
+   * Represents the local user/CLI encoding (--local-encoding).
+   * WRITE (local -> remote): acts as the source encoding.
+   * READ  (remote -> local): acts as the destination encoding.
+   */
   char source_codepage[16];
   int64_t data_type;
 } ZEncode;

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -1348,14 +1348,14 @@ int zusf_read_from_uss_file(ZUSF *zusf, const std::string &file, std::string &re
   in.close();
 
   // Use file tag encoding if available, otherwise fall back to provided encoding
-  std::string encoding_to_use;
+  std::string from_encoding;
   bool has_encoding = false;
 
   if (zusf->encoding_opts.data_type == eDataTypeText)
   {
     if (std::strlen(zusf->encoding_opts.codepage) > 0)
     {
-      encoding_to_use = std::string(zusf->encoding_opts.codepage);
+      from_encoding = std::string(zusf->encoding_opts.codepage);
       has_encoding = true;
     }
     else
@@ -1364,7 +1364,7 @@ int zusf_read_from_uss_file(ZUSF *zusf, const std::string &file, std::string &re
       int file_ccsid = zusf_get_file_ccsid(zusf, file);
       if (file_ccsid > 0 && file_ccsid != 1208 && file_ccsid != 65535)
       {
-        encoding_to_use = std::to_string(file_ccsid);
+        from_encoding = std::to_string(file_ccsid);
         has_encoding = true;
       }
     }
@@ -1373,15 +1373,15 @@ int zusf_read_from_uss_file(ZUSF *zusf, const std::string &file, std::string &re
   if (size > 0 && has_encoding)
   {
     std::string temp = response;
-    const auto source_encoding = std::strlen(zusf->encoding_opts.source_codepage) > 0 ? std::string(zusf->encoding_opts.source_codepage) : "UTF-8";
+    const auto target_encoding = std::strlen(zusf->encoding_opts.source_codepage) > 0 ? std::string(zusf->encoding_opts.source_codepage) : "UTF-8";
     try
     {
-      const auto bytes_with_encoding = zut_encode(temp, encoding_to_use, source_encoding, zusf->diag);
+      const auto bytes_with_encoding = zut_encode(temp, from_encoding, target_encoding, zusf->diag);
       temp = bytes_with_encoding;
     }
     catch (std::exception &e)
     {
-      ZDIAG_SET_MSG(&zusf->diag, "Failed to convert input data from %s to %s", encoding_to_use.c_str(), source_encoding.c_str());
+      ZDIAG_SET_MSG(&zusf->diag, "Failed to convert input data from %s to %s", from_encoding.c_str(), target_encoding.c_str());
       return RTNCD_FAILURE;
     }
     if (!temp.empty())

--- a/native/c/zusf.cpp
+++ b/native/c/zusf.cpp
@@ -1381,7 +1381,7 @@ int zusf_read_from_uss_file(ZUSF *zusf, const std::string &file, std::string &re
     }
     catch (std::exception &e)
     {
-      ZDIAG_SET_MSG(&zusf->diag, "Failed to convert input data from %s to %s", source_encoding.c_str(), encoding_to_use.c_str());
+      ZDIAG_SET_MSG(&zusf->diag, "Failed to convert input data from %s to %s", encoding_to_use.c_str(), source_encoding.c_str());
       return RTNCD_FAILURE;
     }
     if (!temp.empty())


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
From my understanding, the "--local-encoding" ("source_encoding" in the code) is the destination encoding that the user wants the output to be displayed in and the "--encoding" is the remote encoding. In that case, the error message arguments should be flipped to reflect that.

Should we change the name "source_encoding" to "dest/to/target_encoding" to make it more clear? Or add a comment to clarify?

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
