### PR TITLE
Resolve alias + IDCAMS utility

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,4 +37,4 @@ jobs:
           repo-root: native
           style: file
           tidy-checks: "-*"
-          version: 21
+          version: 22

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Added the `zowex ds resolve-alias <dsn>` command. [#1108](https://github.com/zowe/zowex/pull/1108)
+- `c`: Added `zds_idcams` utility function which allows the caller to execute the z/OS IDCAMS program and retrieve its output. [#1108](https://github.com/zowe/zowex/pull/1108)
 - `c`: Preserve LRECL on PS write operations. [#1109](https://github.com/zowe/zowex/issues/1109)
 - `c`: Flipped to and from encoding arguments in error message to be accurate. [#1106](https://github.com/zowe/zowex/pull/1106)
 

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- `c`: Added the `zowex ds resolve-alias <dsn>` command. [#1108](https://github.com/zowe/zowex/pull/1108)
+- `c`: Added the `zowex ds resolve-alias <dsn>` command which allows the user to resolve data set aliases. [#1108](https://github.com/zowe/zowex/pull/1108)
 - `c`: Added `zds_idcams` utility function which allows the caller to execute the z/OS IDCAMS program and retrieve its output. [#1108](https://github.com/zowe/zowex/pull/1108)
 
 ## `0.9.0`

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -682,18 +682,18 @@ int handle_data_set_resolve_alias(InvocationContext &context)
 {
   int rc = 0;
   std::string aliasDsn = context.get<std::string>("dsn", "");
+  std::transform(aliasDsn.begin(), aliasDsn.end(), aliasDsn.begin(), ::toupper);
   const auto result = obj();
   std::string idcamsOutput = "";
-  std::string idcamsInput = "LISTCAT ENTRIES('" + aliasDsn + "') ALL`";
+  // must prepend control statements with a space on each line's zeroth character
+  std::string idcamsInput = " LISTCAT ENTRIES('" + aliasDsn + "') ALL\n";
   std::string idcamsError = "";
   rc = zds_idcams(idcamsInput, idcamsOutput, idcamsError);
-  context.error_stream() << "TODO idcams err string: " << idcamsError << std::endl;
   if (rc != 0)
   {
     context.error_stream() << "Error: " << idcamsError << std::endl;
     return RTNCD_FAILURE;
   }
-  context.error_stream() << "Idcams output: " << idcamsOutput << std::endl;
   result->set("targetDsn", str("todo"));
   context.set_object(result);
   return rc;

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -678,6 +678,40 @@ int handle_data_set_list_members(InvocationContext &context)
   return (!warn && rc == RTNCD_WARNING) ? RTNCD_SUCCESS : rc;
 }
 
+int handle_data_set_resolve_alias(InvocationContext &context)
+{
+  int rc = 0;
+  std::string aliasDsn = context.get<std::string>("dsn", "");
+  unsigned int bpxwdynCode = 0;
+  std::string sysinDdName = "";
+  std::string bpxwdynResponse = "";
+  rc = zut_bpxwdyn_rtdd("alloc lrecl(80) recfm(f,b)", &bpxwdynCode, bpxwdynResponse, sysinDdName);
+  if (rc != 0)
+  {
+    context.error_stream() << "failed to allocate SYSIN dd for IDCAMS" << sysinDdName << std::endl;
+    return RTNCD_FAILURE;
+  }
+  context.error_stream() << "bpx response is: " << bpxwdynResponse << std::endl;
+  context.error_stream() << "unique dd name is " << sysinDdName << std::endl;
+  const auto result = obj();
+  std::string data = "LISTCAT ENTRIES('" + aliasDsn + "') ALL`";
+
+  ZDS idcamsSysinZds{};
+  ZDSWriteOpts write_opts{.zds = &idcamsSysinZds, .ddname = sysinDdName};
+  rc = zds_write(write_opts, data);
+  if (rc != 0)
+  {
+    context.error_stream() << "failed to write IDCAMS commands to dynamic dd " << sysinDdName << std::endl;
+    return RTNCD_FAILURE;
+  }
+
+  context.error_stream() << "write to dataset succeeded" << std::endl;
+
+  result->set("targetDsn", str("todo"));
+  context.set_object(result);
+  return rc;
+}
+
 int handle_data_set_write(InvocationContext &context)
 {
   int rc = 0;
@@ -1139,6 +1173,13 @@ void register_commands(parser::Command &root_command)
   ds_list_members_cmd->add_keyword_arg(RESPONSE_FORMAT_CSV);
   ds_list_members_cmd->set_handler(handle_data_set_list_members);
   data_set_cmd->add_command(ds_list_members_cmd);
+
+  // Resolve alias subcommand
+  auto ds_list_alias_cmd = command_ptr(new Command("resolve-alias", "Resolve a data set alias"));
+  ds_list_alias_cmd->add_alias("ra");
+  ds_list_alias_cmd->add_positional_arg(DSN);
+  ds_list_alias_cmd->set_handler(handle_data_set_resolve_alias);
+  data_set_cmd->add_command(ds_list_alias_cmd);
 
   // Write subcommand
   auto ds_write_cmd = command_ptr(new Command("write", "write to data set"));

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -693,6 +693,7 @@ int handle_data_set_resolve_alias(InvocationContext &context)
     context.error_stream() << "Error: " << idcamsError << std::endl;
     return RTNCD_FAILURE;
   }
+  context.error_stream() << "Idcams output: " << idcamsOutput << std::endl;
   result->set("targetDsn", str("todo"));
   context.set_object(result);
   return rc;

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -682,31 +682,17 @@ int handle_data_set_resolve_alias(InvocationContext &context)
 {
   int rc = 0;
   std::string aliasDsn = context.get<std::string>("dsn", "");
-  unsigned int bpxwdynCode = 0;
-  std::string sysinDdName = "";
-  std::string bpxwdynResponse = "";
-  rc = zut_bpxwdyn_rtdd("alloc lrecl(80) recfm(f,b)", &bpxwdynCode, bpxwdynResponse, sysinDdName);
-  if (rc != 0)
-  {
-    context.error_stream() << "failed to allocate SYSIN dd for IDCAMS" << sysinDdName << std::endl;
-    return RTNCD_FAILURE;
-  }
-  context.error_stream() << "bpx response is: " << bpxwdynResponse << std::endl;
-  context.error_stream() << "unique dd name is " << sysinDdName << std::endl;
   const auto result = obj();
-  std::string data = "LISTCAT ENTRIES('" + aliasDsn + "') ALL`";
-
-  ZDS idcamsSysinZds{};
-  ZDSWriteOpts write_opts{.zds = &idcamsSysinZds, .ddname = sysinDdName};
-  rc = zds_write(write_opts, data);
+  std::string idcamsOutput = "";
+  std::string idcamsInput = "LISTCAT ENTRIES('" + aliasDsn + "') ALL`";
+  std::string idcamsError = "";
+  rc = zds_idcams(idcamsInput, idcamsOutput, idcamsError);
+  context.error_stream() << "TODO idcams err string: " << idcamsError << std::endl;
   if (rc != 0)
   {
-    context.error_stream() << "failed to write IDCAMS commands to dynamic dd " << sysinDdName << std::endl;
+    context.error_stream() << "Error: " << idcamsError << std::endl;
     return RTNCD_FAILURE;
   }
-
-  context.error_stream() << "write to dataset succeeded" << std::endl;
-
   result->set("targetDsn", str("todo"));
   context.set_object(result);
   return rc;

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -714,6 +714,7 @@ int handle_data_set_resolve_alias(InvocationContext &context)
   {
     context.output_stream() << failMsg;
     result->set("targetDsn", str(""));
+    rc = RTNCD_FAILURE;
   }
   context.set_object(result);
 

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -686,16 +686,14 @@ int handle_data_set_resolve_alias(InvocationContext &context)
   std::transform(aliasDsn.begin(), aliasDsn.end(), aliasDsn.begin(), ::toupper);
   const auto result = obj();
   std::string idcamsOutput = "";
-  // must prepend control statements with a space on each line's zeroth character
-  std::string idcamsInput = " LISTCAT ENTRIES('" + aliasDsn + "') ALL\n";
+  // must prepend control statements with a space on each line's first character
+  std::string idcamsInput = " LISTCAT -\n ENTRIES('" + aliasDsn + "') -\n ALL\n";
   std::string idcamsError = "";
   std::string failMsg = "Could not determine the target data set for the specified alias. Ensure the alias exists and is cataloged.\n";
   rc = zds_idcams(idcamsInput, idcamsOutput, idcamsError);
   if (rc != 0)
   {
-    context.error_stream() << "Error: "
-                           << idcamsOutput << std::endl
-                           << idcamsError << std::endl;
+    ZLOG_ERROR("Error resolving data set alias '%s': %s\n%s", aliasDsn, idcamsOutput, idcamsError);
     context.error_stream() << failMsg;
     return RTNCD_FAILURE;
   }

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -689,11 +689,11 @@ int handle_data_set_resolve_alias(InvocationContext &context)
   // must prepend control statements with a space on each line's first character
   std::string idcamsInput = " LISTCAT -\n ENTRIES('" + aliasDsn + "') -\n ALL\n";
   std::string idcamsError = "";
-  std::string failMsg = "Could not determine the target data set for the specified alias. Ensure the alias exists and is cataloged.\n";
+  const std::string failMsg = "Could not determine the target data set for the specified alias. Ensure the alias exists and is cataloged.\n";
   rc = zds_idcams(idcamsInput, idcamsOutput, idcamsError);
   if (rc != 0)
   {
-    ZLOG_ERROR("Error resolving data set alias '%s': %s\n%s", aliasDsn, idcamsOutput, idcamsError);
+    ZLOG_ERROR("Error resolving data set alias '%s': %s\n%s", aliasDsn.c_str(), idcamsOutput.c_str(), idcamsError.c_str());
     context.error_stream() << failMsg;
     return RTNCD_FAILURE;
   }
@@ -702,7 +702,7 @@ int handle_data_set_resolve_alias(InvocationContext &context)
   // ASSOCIATIONS
   //     NONVSAM--CHRIS.PUBLIC.CNTL
   static const std::regex resolvedDsPattern(R"(ASSOCIATIONS[\s\S]+VSAM-{2,}(\S+))");
-  std::smatch mv;
+  std::smatch mv{};
 
   if (std::regex_search(idcamsOutput, mv, resolvedDsPattern))
   {
@@ -712,7 +712,7 @@ int handle_data_set_resolve_alias(InvocationContext &context)
   }
   else
   {
-    context.output_stream() << failMsg;
+    context.error_stream() << failMsg;
     result->set("targetDsn", str(""));
     rc = RTNCD_FAILURE;
   }

--- a/native/c/commands/ds.cpp
+++ b/native/c/commands/ds.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <cstdio>
+#include <regex>
 #ifndef _OPEN_SYS_FILE_EXT
 #define _OPEN_SYS_FILE_EXT 1
 #endif
@@ -688,14 +689,36 @@ int handle_data_set_resolve_alias(InvocationContext &context)
   // must prepend control statements with a space on each line's zeroth character
   std::string idcamsInput = " LISTCAT ENTRIES('" + aliasDsn + "') ALL\n";
   std::string idcamsError = "";
+  std::string failMsg = "Could not determine the target data set for the specified alias. Ensure the alias exists and is cataloged.\n";
   rc = zds_idcams(idcamsInput, idcamsOutput, idcamsError);
   if (rc != 0)
   {
-    context.error_stream() << "Error: " << idcamsError << std::endl;
+    context.error_stream() << "Error: "
+                           << idcamsOutput << std::endl
+                           << idcamsError << std::endl;
+    context.error_stream() << failMsg;
     return RTNCD_FAILURE;
   }
-  result->set("targetDsn", str("todo"));
+
+  // Example output excerpt:
+  // ASSOCIATIONS
+  //     NONVSAM--CHRIS.PUBLIC.CNTL
+  static const std::regex resolvedDsPattern(R"(ASSOCIATIONS[\s\S]+VSAM-{2,}(\S+))");
+  std::smatch mv;
+
+  if (std::regex_search(idcamsOutput, mv, resolvedDsPattern))
+  {
+    const std::string targetDsn = mv[1].str();
+    context.output_stream() << "Alias '" + aliasDsn + "' resolved to data set '" + targetDsn + "'" << std::endl;
+    result->set("targetDsn", str(targetDsn));
+  }
+  else
+  {
+    context.output_stream() << failMsg;
+    result->set("targetDsn", str(""));
+  }
   context.set_object(result);
+
   return rc;
 }
 

--- a/native/c/commands/ds.hpp
+++ b/native/c/commands/ds.hpp
@@ -22,6 +22,7 @@ int handle_data_set_create_loadlib(InvocationContext &result);
 int handle_data_set_view(InvocationContext &result);
 int handle_data_set_list(InvocationContext &result);
 int handle_data_set_list_members(InvocationContext &result);
+int handle_data_set_resolve_alias(InvocationContext &result);
 int handle_data_set_write(InvocationContext &result);
 int handle_data_set_delete(InvocationContext &result);
 int handle_data_set_restore(InvocationContext &result);

--- a/native/c/server/rpc_commands.cpp
+++ b/native/c/server/rpc_commands.cpp
@@ -67,6 +67,9 @@ void register_ds_commands(CommandDispatcher &dispatcher)
                                   .rename_arg("maxItems", "max-entries")
                                   .set_default("warn", false)
                                   .set_default("pattern", ""));
+  dispatcher.register_command("resolveDsAlias",
+                              create_ds_builder(ds::handle_data_set_resolve_alias)
+                                  .validate<ResolveDsAliasRequest, ResolveDsAliasResponse>());
   dispatcher.register_command("readDataset",
                               create_ds_builder(ds::handle_data_set_view)
                                   .validate<ReadDatasetRequest, ReadDatasetResponse>()

--- a/native/c/server/schemas/requests.hpp
+++ b/native/c/server/schemas/requests.hpp
@@ -201,6 +201,11 @@ ZJSON_SCHEMA(ListDsMembersRequest,
     FIELD_OPTIONAL(pattern, STRING)
 );
 
+struct ResolveDsAliasRequest {};
+ZJSON_SCHEMA(ResolveDsAliasRequest,
+    FIELD_REQUIRED(dsname, STRING)
+);
+
 struct ReadDatasetRequest {};
 ZJSON_SCHEMA(ReadDatasetRequest,
     FIELD_OPTIONAL(stream, ANY),

--- a/native/c/server/schemas/responses.hpp
+++ b/native/c/server/schemas/responses.hpp
@@ -294,6 +294,12 @@ ZJSON_SCHEMA(ListDsMembersResponse,
     FIELD_REQUIRED(returnedRows, NUMBER)
 );
 
+struct ResolveDsAliasResponse {};
+ZJSON_SCHEMA(ResolveDsAliasResponse,
+    FIELD_REQUIRED(success, BOOL),
+    FIELD_REQUIRED(targetDsn, STRING)
+);
+
 struct ReadDatasetResponse {};
 ZJSON_SCHEMA(ReadDatasetResponse,
     FIELD_REQUIRED(success, BOOL),

--- a/native/c/test/zds.test.cpp
+++ b/native/c/test/zds.test.cpp
@@ -2471,7 +2471,6 @@ void zds_tests()
                                             });
                                  });
                       });
-
              describe("DCB abend",
                       [&]() -> void
                       {

--- a/native/c/test/zds.test.cpp
+++ b/native/c/test/zds.test.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <stdexcept>
 #include "../zbase64.h"
+#include <string>
 #include <vector>
 #include <thread>
 #include <chrono>
@@ -1382,20 +1383,23 @@ void zds_tests()
 
                         beforeAll([&]() -> void
                                   {
-                                    std::string cleanup_jcl;
-                                    cleanup_jcl += "//CLEANUP$ JOB IZUACCT\n";
-                                    cleanup_jcl += "//STEP1    EXEC PGM=IDCAMS\n";
-                                    cleanup_jcl += "//SYSPRINT DD SYSOUT=*\n";
-                                    cleanup_jcl += "//SYSIN    DD *\n";
-                                    cleanup_jcl += "  DELETE " + ksds_path_dsn + " PURGE\n";
-                                    cleanup_jcl += "  DELETE " + ksds_aix_dsn + " PURGE\n";
-                                    cleanup_jcl += "  DELETE " + ksds_dsn + " CLUSTER PURGE\n";
-                                    cleanup_jcl += "  DELETE " + esds_path_dsn + " PURGE\n";
-                                    cleanup_jcl += "  DELETE " + esds_aix_dsn + " PURGE\n";
-                                    cleanup_jcl += "  DELETE " + esds_dsn + " CLUSTER PURGE\n";
-                                    cleanup_jcl += "  SET MAXCC = 0\n";
-                                    cleanup_jcl += "/*\n";
-                                    submit_and_wait(cleanup_jcl, 200);
+                                    int rc =0;
+                                    std::string cleanup_idcams;
+                                    std::string cleanup_output;
+                                    std::string cleanup_err;
+                                    cleanup_idcams += "  DELETE " + ksds_path_dsn + " PURGE\n";
+                                    cleanup_idcams += "  DELETE " + ksds_aix_dsn + " PURGE\n";
+                                    cleanup_idcams += "  DELETE " + ksds_dsn + " CLUSTER PURGE\n";
+                                    cleanup_idcams += "  DELETE " + esds_path_dsn + " PURGE\n";
+                                    cleanup_idcams += "  DELETE " + esds_aix_dsn + " PURGE\n";
+                                    cleanup_idcams += "  DELETE " + esds_dsn + " CLUSTER PURGE\n";
+                                    cleanup_idcams += "  SET MAXCC = 0\n";
+                                    
+                                    rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
+                                    TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
+                                    if (rc != 0 ){
+                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                    }
 
                                     // Volume is required for systems that are not SMS managed
                                     ZDS zds = {0};
@@ -1403,72 +1407,74 @@ void zds_tests()
                                     created_dsns.push_back(temp_dsn);
                                     create_seq(&zds, temp_dsn);
                                     std::vector<ZDSEntry> entries;
-                                    int rc = zds_list_data_sets(&zds, temp_dsn, entries, true);
+                                    rc = zds_list_data_sets(&zds, temp_dsn, entries, true);
                                     if (rc != 0 || entries.empty())
                                       throw std::runtime_error("Failed to list data sets: " + std::string(zds.diag.e_msg));
                                     std::string vsam_vol = entries[0].volser;
 
-                                    std::string setup_jcl;
-                                    setup_jcl += "//VSAMSET$ JOB IZUACCT\n";
-                                    setup_jcl += "//STEP1    EXEC PGM=IDCAMS\n";
-                                    setup_jcl += "//SYSPRINT DD SYSOUT=*\n";
-                                    setup_jcl += "//SYSIN    DD *\n";
-                                    setup_jcl += "  DEFINE CLUSTER ( -\n";
-                                    setup_jcl += "    NAME(" + ksds_dsn + ") -\n";
-                                    setup_jcl += "    INDEXED -\n";
-                                    setup_jcl += "    KEYS(8 0) -\n";
-                                    setup_jcl += "    RECORDSIZE(80 80) -\n";
-                                    setup_jcl += "    TRACKS(5 5) -\n";
-                                    setup_jcl += "    VOLUMES(" + vsam_vol + ") -\n";
-                                    setup_jcl += "    SHAREOPTIONS(2 3) )\n";
-                                    setup_jcl += "  DEFINE AIX ( -\n";
-                                    setup_jcl += "    NAME(" + ksds_aix_dsn + ") -\n";
-                                    setup_jcl += "    RELATE(" + ksds_dsn + ") -\n";
-                                    setup_jcl += "    KEYS(8 32) -\n";
-                                    setup_jcl += "    RECORDSIZE(80 80) -\n";
-                                    setup_jcl += "    TRACKS(5 5) -\n";
-                                    setup_jcl += "    VOLUMES(" + vsam_vol + ") -\n";
-                                    setup_jcl += "    SHAREOPTIONS(2 3) -\n";
-                                    setup_jcl += "    UPGRADE )\n";
-                                    setup_jcl += "  DEFINE PATH ( -\n";
-                                    setup_jcl += "    NAME(" + ksds_path_dsn + ") -\n";
-                                    setup_jcl += "    PATHENTRY(" + ksds_aix_dsn + ") -\n";
-                                    setup_jcl += "    UPDATE )\n";
-                                    setup_jcl += "  DEFINE CLUSTER ( -\n";
-                                    setup_jcl += "    NAME(" + esds_dsn + ") -\n";
-                                    setup_jcl += "    NONINDEXED -\n";
-                                    setup_jcl += "    RECORDSIZE(80 80) -\n";
-                                    setup_jcl += "    TRACKS(5 5) -\n";
-                                    setup_jcl += "    VOLUMES(" + vsam_vol + ") -\n";
-                                    setup_jcl += "    SHAREOPTIONS(2 3) )\n";
-                                    setup_jcl += "  DEFINE AIX ( -\n";
-                                    setup_jcl += "    NAME(" + esds_aix_dsn + ") -\n";
-                                    setup_jcl += "    RELATE(" + esds_dsn + ") -\n";
-                                    setup_jcl += "    KEYS(8 0) -\n";
-                                    setup_jcl += "    RECORDSIZE(80 80) -\n";
-                                    setup_jcl += "    TRACKS(5 5) -\n";
-                                    setup_jcl += "    VOLUMES(" + vsam_vol + ") -\n";
-                                    setup_jcl += "    SHAREOPTIONS(2 3) -\n";
-                                    setup_jcl += "    UPGRADE )\n";
-                                    setup_jcl += "  DEFINE PATH ( -\n";
-                                    setup_jcl += "    NAME(" + esds_path_dsn + ") -\n";
-                                    setup_jcl += "    PATHENTRY(" + esds_aix_dsn + ") -\n";
-                                    setup_jcl += "    UPDATE )\n";
-                                    setup_jcl += "/*\n";
-                                    submit_and_wait(setup_jcl, 600, true); },
+                                    std::string setup_idcams;
+                                    std::string setup_output;
+                                    std::string setup_err;
+                                    setup_idcams += "  DEFINE CLUSTER ( -\n";
+                                    setup_idcams += "    NAME(" + ksds_dsn + ") -\n";
+                                    setup_idcams += "    INDEXED -\n";
+                                    setup_idcams += "    KEYS(8 0) -\n";
+                                    setup_idcams += "    RECORDSIZE(80 80) -\n";
+                                    setup_idcams += "    TRACKS(5 5) -\n";
+                                    setup_idcams += "    VOLUMES(" + vsam_vol + ") -\n";
+                                    setup_idcams += "    SHAREOPTIONS(2 3) )\n";
+                                    setup_idcams += "  DEFINE AIX ( -\n";
+                                    setup_idcams += "    NAME(" + ksds_aix_dsn + ") -\n";
+                                    setup_idcams += "    RELATE(" + ksds_dsn + ") -\n";
+                                    setup_idcams += "    KEYS(8 32) -\n";
+                                    setup_idcams += "    RECORDSIZE(80 80) -\n";
+                                    setup_idcams += "    TRACKS(5 5) -\n";
+                                    setup_idcams += "    VOLUMES(" + vsam_vol + ") -\n";
+                                    setup_idcams += "    SHAREOPTIONS(2 3) -\n";
+                                    setup_idcams += "    UPGRADE )\n";
+                                    setup_idcams += "  DEFINE PATH ( -\n";
+                                    setup_idcams += "    NAME(" + ksds_path_dsn + ") -\n";
+                                    setup_idcams += "    PATHENTRY(" + ksds_aix_dsn + ") -\n";
+                                    setup_idcams += "    UPDATE )\n";
+                                    setup_idcams += "  DEFINE CLUSTER ( -\n";
+                                    setup_idcams += "    NAME(" + esds_dsn + ") -\n";
+                                    setup_idcams += "    NONINDEXED -\n";
+                                    setup_idcams += "    RECORDSIZE(80 80) -\n";
+                                    setup_idcams += "    TRACKS(5 5) -\n";
+                                    setup_idcams += "    VOLUMES(" + vsam_vol + ") -\n";
+                                    setup_idcams += "    SHAREOPTIONS(2 3) )\n";
+                                    setup_idcams += "  DEFINE AIX ( -\n";
+                                    setup_idcams += "    NAME(" + esds_aix_dsn + ") -\n";
+                                    setup_idcams += "    RELATE(" + esds_dsn + ") -\n";
+                                    setup_idcams += "    KEYS(8 0) -\n";
+                                    setup_idcams += "    RECORDSIZE(80 80) -\n";
+                                    setup_idcams += "    TRACKS(5 5) -\n";
+                                    setup_idcams += "    VOLUMES(" + vsam_vol + ") -\n";
+                                    setup_idcams += "    SHAREOPTIONS(2 3) -\n";
+                                    setup_idcams += "    UPGRADE )\n";
+                                    setup_idcams += "  DEFINE PATH ( -\n";
+                                    setup_idcams += "    NAME(" + esds_path_dsn + ") -\n";
+                                    setup_idcams += "    PATHENTRY(" + esds_aix_dsn + ") -\n";
+                                    setup_idcams += "    UPDATE )\n";
+                                    rc = zds_idcams(setup_idcams, setup_output, setup_err);
+                                    TestLog("Setup RC from IDCAMS: " + std::to_string(rc));
+                                    if (rc !=0 ){
+                                      throw std::runtime_error("Output and error from failed IDCAMS setup:" + setup_err + "\n" + setup_output +"\n");
+                                    } },
                                   vsam_opts);
 
                         afterAll([ksds_dsn, esds_dsn, &submit_and_wait]() -> void
                                  {
-                                   std::string del_jcl;
-                                   del_jcl += "//VSAMDEL$ JOB IZUACCT\n";
-                                   del_jcl += "//STEP1    EXEC PGM=IDCAMS\n";
-                                   del_jcl += "//SYSPRINT DD SYSOUT=*\n";
-                                   del_jcl += "//SYSIN    DD *\n";
-                                   del_jcl += "  DELETE " + ksds_dsn + " CLUSTER PURGE\n";
-                                   del_jcl += "  DELETE " + esds_dsn + " CLUSTER PURGE\n";
-                                   del_jcl += "/*\n";
-                                   submit_and_wait(del_jcl, 200); },
+                                    std::string cleanup_output;
+                                    std::string cleanup_err;
+                                   std::string cleanup_idcams;
+                                   cleanup_idcams += "  DELETE " + ksds_dsn + " CLUSTER PURGE\n";
+                                   cleanup_idcams += "  DELETE " + esds_dsn + " CLUSTER PURGE\n";
+                                   int rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
+                                    TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
+                                    if (rc !=0 ){
+                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                    } },
                                  vsam_opts);
 
                         it("should report VS dsorg and *VSAM* volser for KSDS cluster",
@@ -1588,31 +1594,33 @@ void zds_tests()
                         beforeAll([&]() -> void
                                   {
                                     // Clean up any leftover data sets from previous test runs
-                                    std::string cleanup_jcl;
-                                    cleanup_jcl += "//GDGCLN$ JOB IZUACCT\n";
-                                    cleanup_jcl += "//STEP1    EXEC PGM=IDCAMS\n";
-                                    cleanup_jcl += "//SYSPRINT DD SYSOUT=*\n";
-                                    cleanup_jcl += "//SYSIN    DD *\n";
-                                    cleanup_jcl += "  DELETE " + gdg_gen1_dsn + " NONVSAM PURGE\n";
-                                    cleanup_jcl += "  DELETE " + gdg_base_dsn + " GDG PURGE\n";
-                                    cleanup_jcl += "  SET MAXCC = 0\n";
-                                    cleanup_jcl += "/*\n";
-                                    submit_and_wait(cleanup_jcl, 200);
 
+                                   std::string cleanup_output;
+                                   std::string cleanup_err;
+                                   std::string cleanup_idcams;
+                           
+                                    cleanup_idcams += "  DELETE " + gdg_gen1_dsn + " NONVSAM PURGE\n";
+                                    cleanup_idcams += "  DELETE " + gdg_base_dsn + " GDG PURGE\n";
+                                    cleanup_idcams += "  SET MAXCC = 0\n";
+                                    int rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
+                                    TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
+                                    if (rc !=0 ){
+                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                    }
                                     // Define the GDG base via IDCAMS
-                                    std::string setup_jcl;
-                                    setup_jcl += "//GDGSET$ JOB IZUACCT\n";
-                                    setup_jcl += "//STEP1    EXEC PGM=IDCAMS\n";
-                                    setup_jcl += "//SYSPRINT DD SYSOUT=*\n";
-                                    setup_jcl += "//SYSIN    DD *\n";
-                                    setup_jcl += "  DEFINE GDG ( -\n";
-                                    setup_jcl += "    NAME(" + gdg_base_dsn + ") -\n";
-                                    setup_jcl += "    LIMIT(5) -\n";
-                                    setup_jcl += "    NOEMPTY -\n";
-                                    setup_jcl += "    NOSCRATCH )\n";
-                                    setup_jcl += "/*\n";
-                                    submit_and_wait(setup_jcl, 200, true);
-
+                                    std::string setup_output;
+                                    std::string setup_err;
+                                    std::string setup_idcams;
+                                    setup_idcams += "  DEFINE GDG ( -\n";
+                                    setup_idcams += "    NAME(" + gdg_base_dsn + ") -\n";
+                                    setup_idcams += "    LIMIT(5) -\n";
+                                    setup_idcams += "    NOEMPTY -\n";
+                                    setup_idcams += "    NOSCRATCH )\n";
+                                    rc = zds_idcams(setup_idcams, setup_output, setup_err);
+                                    TestLog("Setup RC from IDCAMS: " + std::to_string(rc));
+                                    if (rc !=0 ){
+                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + setup_err + "\n" + setup_output +"\n");
+                                    }
                                     // Create one generation via IEBGENER
                                     std::string gen_jcl;
                                     gen_jcl += "//GDGGEN$ JOB IZUACCT\n";
@@ -1630,20 +1638,20 @@ void zds_tests()
 
                         afterAll([&]() -> void
                                  {
-                                   std::string del_jcl;
-                                   del_jcl += "//GDGDEL$ JOB IZUACCT\n";
-                                   del_jcl += "//STEP1    EXEC PGM=IDCAMS\n";
-                                   del_jcl += "//SYSPRINT DD SYSOUT=*\n";
-                                   del_jcl += "//SYSIN    DD *\n";
-                                   del_jcl += "  DELETE " + gdg_gen1_dsn + " NONVSAM PURGE\n";
-                                   del_jcl += "  DELETE " + gdg_base_dsn + " GDG PURGE\n";
-                                   del_jcl += "  SET MAXCC = 0\n";
-                                   del_jcl += "/*\n";
-                                   submit_and_wait(del_jcl, 200); },
+                                   std::string cleanup_idcams;
+                                   std::string cleanup_output;
+                                   std::string cleanup_err;
+                                   cleanup_idcams += "  DELETE " + gdg_gen1_dsn + " NONVSAM PURGE\n";
+                                   cleanup_idcams += "  DELETE " + gdg_base_dsn + " GDG PURGE\n";
+                                   cleanup_idcams += "  SET MAXCC = 0\n";
+                                   int rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
+                                    TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
+                                    if (rc !=0 ){
+                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                    } },
                                  gdg_opts);
 
-                        it("should report ZDS_VOLSER_GDG (?????\?) for a GDG base",
-                           [&]() -> void
+                        it("should report ZDS_VOLSER_GDG (?????\?) for a GDG base", [&]() -> void
                            {
                              ZDS zds = {0};
                              std::vector<ZDSEntry> entries;
@@ -1662,12 +1670,9 @@ void zds_tests()
                                }
                              }
                              Expect(found != nullptr).ToBe(true);
-                             Expect(found->volser).ToBe(std::string(ZDS_VOLSER_GDG));
-                           },
-                           gdg_opts);
+                             Expect(found->volser).ToBe(std::string(ZDS_VOLSER_GDG)); }, gdg_opts);
 
-                        it("should find GDG generations using a wildcard pattern",
-                           [&]() -> void
+                        it("should find GDG generations using a wildcard pattern", [&]() -> void
                            {
                              ZDS zds = {0};
                              std::vector<ZDSEntry> entries;
@@ -1683,24 +1688,18 @@ void zds_tests()
                                if (trimmed == gdg_gen1_dsn)
                                  found_gen1 = true;
                              }
-                             Expect(found_gen1).ToBe(true);
-                           },
-                           gdg_opts);
+                             Expect(found_gen1).ToBe(true); }, gdg_opts);
 
-                        it("should read content from a GDG generation by absolute name",
-                           [&]() -> void
+                        it("should read content from a GDG generation by absolute name", [&]() -> void
                            {
                              ZDS read_zds{};
                              ZDSReadOpts read_opts{.zds = &read_zds, .dsname = gdg_gen1_dsn};
                              std::string content;
                              const int rc = zds_read(read_opts, content);
                              ExpectWithContext(rc, read_zds.diag.e_msg).ToBe(0);
-                             Expect(content.find("GDG GENERATION ONE") != std::string::npos).ToBe(true);
-                           },
-                           gdg_opts);
+                             Expect(content.find("GDG GENERATION ONE") != std::string::npos).ToBe(true); }, gdg_opts);
 
-                        it("should read content from the most recent GDG generation via relative reference",
-                           [&]() -> void
+                        it("should read content from the most recent GDG generation via relative reference", [&]() -> void
                            {
                              const std::string relative_ref = gdg_base_dsn + "(0)";
                              ZDS read_zds{};
@@ -1708,9 +1707,7 @@ void zds_tests()
                              std::string content;
                              const int rc = zds_read(read_opts, content);
                              ExpectWithContext(rc, read_zds.diag.e_msg).ToBe(0);
-                             Expect(content.find("GDG GENERATION ONE") != std::string::npos).ToBe(true);
-                           },
-                           gdg_opts);
+                             Expect(content.find("GDG GENERATION ONE") != std::string::npos).ToBe(true); }, gdg_opts);
                       });
              describe("read",
                       [&]() -> void
@@ -2468,46 +2465,46 @@ void zds_tests()
                              Expect(sizeof(DCB_ABEND_PL)).ToBe(16);
                            });
 
-                       xit("should propagate abend when writing past max space of a PDS",
-                           [&]() -> void
-                           {
-                             ZDS zds = {0};
-                             DS_ATTRIBUTES attr{};
-                             attr.dsorg = "PO";
-                             attr.recfm = "FB";
-                             attr.lrecl = 80;
-                             attr.blksize = 6160;
-                             attr.alcunit = "TRACKS";
-                             attr.primary = 1;
-                             attr.secondary = 0;
-                             attr.dirblk = 1;
+                        xit("should propagate abend when writing past max space of a PDS",
+                            [&]() -> void
+                            {
+                              ZDS zds = {0};
+                              DS_ATTRIBUTES attr{};
+                              attr.dsorg = "PO";
+                              attr.recfm = "FB";
+                              attr.lrecl = 80;
+                              attr.blksize = 6160;
+                              attr.alcunit = "TRACKS";
+                              attr.primary = 1;
+                              attr.secondary = 0;
+                              attr.dirblk = 1;
 
-                             std::string ds = get_random_ds(3);
-                             created_dsns.push_back(ds);
+                              std::string ds = get_random_ds(3);
+                              created_dsns.push_back(ds);
 
-                             std::string response;
-                             int rc = zds_create_dsn(&zds, ds, attr, response);
-                             ExpectWithContext(rc, response).ToBe(0);
+                              std::string response;
+                              int rc = zds_create_dsn(&zds, ds, attr, response);
+                              ExpectWithContext(rc, response).ToBe(0);
 
-                             zds.encoding_opts.data_type = eDataTypeText;
-                             strcpy(zds.encoding_opts.codepage, "IBM-1047");
-                             strcpy(zds.encoding_opts.source_codepage, "IBM-1047");
+                              zds.encoding_opts.data_type = eDataTypeText;
+                              strcpy(zds.encoding_opts.codepage, "IBM-1047");
+                              strcpy(zds.encoding_opts.source_codepage, "IBM-1047");
 
-                             std::string large_data;
-                             large_data.reserve(81 * 1000);
-                             for (int i = 0; i < 1000; i++)
-                             {
-                               large_data += std::string(80, 'A') + "\n";
-                             }
+                              std::string large_data;
+                              large_data.reserve(81 * 1000);
+                              for (int i = 0; i < 1000; i++)
+                              {
+                                large_data += std::string(80, 'A') + "\n";
+                              }
 
-                             ZDSWriteOpts write_opts{.zds = &zds, .dsname = ds + "(M1)"};
+                              ZDSWriteOpts write_opts{.zds = &zds, .dsname = ds + "(M1)"};
 
-                             // This should fail with an abend. DCB abend exit runs as part of the member write process - no mocking available so we can't test the DCB exit itself,
-                             // this just verifies that the abend is percolated and handled by recovery
-                             Expect([&]()
-                                    { rc = zds_write(write_opts, large_data); })
-                                 .ToAbend();
-                           });
+                              // This should fail with an abend. DCB abend exit runs as part of the member write process - no mocking available so we can't test the DCB exit itself,
+                              // this just verifies that the abend is percolated and handled by recovery
+                              Expect([&]()
+                                     { rc = zds_write(write_opts, large_data); })
+                                  .ToAbend();
+                            });
 
                         // Skip this test because forcing DCB abends in tests seems fragile.
                         // On some systems, the DCB abend does not trigger. On others it
@@ -2515,89 +2512,93 @@ void zds_tests()
                         // immediately after the abend.
                         // uncomment when in a zvdt env
                         xit("should release ENQ after DCB abend during write",
-                           [&]() -> void
-                           {
-                             DS_ATTRIBUTES attr{};
-                             attr.dsorg = "PO";
-                             attr.recfm = "FB";
-                             attr.lrecl = 80;
-                             attr.blksize = 6160;
-                             attr.alcunit = "TRACKS";
-                             attr.primary = 5;
-                             attr.secondary = 0;
-                             attr.dirblk = 5;
+                            [&]() -> void
+                            {
+                              DS_ATTRIBUTES attr{};
+                              attr.dsorg = "PO";
+                              attr.recfm = "FB";
+                              attr.lrecl = 80;
+                              attr.blksize = 6160;
+                              attr.alcunit = "TRACKS";
+                              attr.primary = 5;
+                              attr.secondary = 0;
+                              attr.dirblk = 5;
 
-                             const std::string ds = get_random_ds(3);
-                             created_dsns.push_back(ds);
+                              const std::string ds = get_random_ds(3);
+                              created_dsns.push_back(ds);
 
-                             ZDS create_zds = {0};
-                             std::string response;
-                             int rc = zds_create_dsn(&create_zds, ds, attr, response);
-                             ExpectWithContext(rc, response).ToBe(0);
+                              ZDS create_zds = {0};
+                              std::string response;
+                              int rc = zds_create_dsn(&create_zds, ds, attr, response);
+                              ExpectWithContext(rc, response).ToBe(0);
 
-                             ZDS crash_zds{};
-                             crash_zds.encoding_opts.data_type = eDataTypeText;
-                             strcpy(crash_zds.encoding_opts.codepage, "IBM-1047");
-                             strcpy(crash_zds.encoding_opts.source_codepage, "IBM-1047");
+                              ZDS crash_zds{};
+                              crash_zds.encoding_opts.data_type = eDataTypeText;
+                              strcpy(crash_zds.encoding_opts.codepage, "IBM-1047");
+                              strcpy(crash_zds.encoding_opts.source_codepage, "IBM-1047");
 
-                             std::string large_data;
-                             large_data.reserve(81 * 1000);
-                             for (int i = 0; i < 1000; i++)
-                               large_data += std::string(80, 'A') + "\n";
+                              std::string large_data;
+                              large_data.reserve(81 * 1000);
+                              for (int i = 0; i < 1000; i++)
+                                large_data += std::string(80, 'A') + "\n";
 
-                             ZDSWriteOpts crash_opts{.zds = &crash_zds, .dsname = ds + "(M1)"};
-                             Expect([&]() { zds_write(crash_opts, large_data); }).ToAbend();
+                              ZDSWriteOpts crash_opts{.zds = &crash_zds, .dsname = ds + "(M1)"};
+                              Expect([&]()
+                                     { zds_write(crash_opts, large_data); })
+                                  .ToAbend();
 
-                             // After recovery, verify ENQ was released by writing to a different member.
-                             // ZDS_RTNCD_ENQ_ERROR (-14) would indicate the ENQ was not released.
-                             ZDS write_zds{};
-                             write_zds.encoding_opts.data_type = eDataTypeText;
-                             strcpy(write_zds.encoding_opts.codepage, "IBM-1047");
-                             strcpy(write_zds.encoding_opts.source_codepage, "IBM-1047");
-                             ZDSWriteOpts verify_opts{.zds = &write_zds, .dsname = ds + "(M2)"};
-                             const std::string small_data = "ENQ released\n";
-                             rc = zds_write(verify_opts, small_data);
-                             ExpectWithContext(rc, std::string(write_zds.diag.e_msg)).Not().ToBe(ZDS_RTNCD_ENQ_ERROR);
-                           });
+                              // After recovery, verify ENQ was released by writing to a different member.
+                              // ZDS_RTNCD_ENQ_ERROR (-14) would indicate the ENQ was not released.
+                              ZDS write_zds{};
+                              write_zds.encoding_opts.data_type = eDataTypeText;
+                              strcpy(write_zds.encoding_opts.codepage, "IBM-1047");
+                              strcpy(write_zds.encoding_opts.source_codepage, "IBM-1047");
+                              ZDSWriteOpts verify_opts{.zds = &write_zds, .dsname = ds + "(M2)"};
+                              const std::string small_data = "ENQ released\n";
+                              rc = zds_write(verify_opts, small_data);
+                              ExpectWithContext(rc, std::string(write_zds.diag.e_msg)).Not().ToBe(ZDS_RTNCD_ENQ_ERROR);
+                            });
 
                         // uncomment when in a zvdt env
                         xit("should release ENQ after forced S0C3 abend (EXRL) during BPAM write",
-                           [&]() -> void
-                           {
-                             DS_ATTRIBUTES attr{};
-                             attr.dsorg = "PO";
-                             attr.recfm = "FB";
-                             attr.lrecl = 80;
-                             attr.blksize = 800;
-                             attr.dirblk = 5;
-                             attr.primary = 1;
+                            [&]() -> void
+                            {
+                              DS_ATTRIBUTES attr{};
+                              attr.dsorg = "PO";
+                              attr.recfm = "FB";
+                              attr.lrecl = 80;
+                              attr.blksize = 800;
+                              attr.dirblk = 5;
+                              attr.primary = 1;
 
-                             const std::string ds = get_random_ds(3);
-                             created_dsns.push_back(ds);
+                              const std::string ds = get_random_ds(3);
+                              created_dsns.push_back(ds);
 
-                             ZDS create_zds = {0};
-                             std::string response;
-                             int rc = zds_create_dsn(&create_zds, ds, attr, response);
-                             ExpectWithContext(rc, response).ToBe(0);
+                              ZDS create_zds = {0};
+                              std::string response;
+                              int rc = zds_create_dsn(&create_zds, ds, attr, response);
+                              ExpectWithContext(rc, response).ToBe(0);
 
-                             // Open for BPAM write - this acquires the z/OS ENQ on the data set.
-                             // ioc->has_enq is the direct "is this locked" flag (see IO_CTRL in zamtypes.h).
-                             ZDS open_zds{};
-                             IO_CTRL *ioc = nullptr;
-                             rc = zds_open_output_bpam(&open_zds, ds + "(M1)", ioc);
-                             ExpectWithContext(rc, open_zds.diag.e_msg).ToBe(0);
-                             Expect(ioc->has_enq).ToBe(1);
+                              // Open for BPAM write - this acquires the z/OS ENQ on the data set.
+                              // ioc->has_enq is the direct "is this locked" flag (see IO_CTRL in zamtypes.h).
+                              ZDS open_zds{};
+                              IO_CTRL *ioc = nullptr;
+                              rc = zds_open_output_bpam(&open_zds, ds + "(M1)", ioc);
+                              ExpectWithContext(rc, open_zds.diag.e_msg).ToBe(0);
+                              Expect(ioc->has_enq).ToBe(1);
 
-                             // Force a S0C3 abend (EXRL 0,* = execute-type instruction targeting itself)
-                             // while the ENQ is held. ESTAE recovery must call deq_data_set before
-                             // returning to the test for ioc->has_enq to become 0.
-                             Expect([&]() { __asm(" EXRL 0,*"); }).ToAbend();
+                              // Force a S0C3 abend (EXRL 0,* = execute-type instruction targeting itself)
+                              // while the ENQ is held. ESTAE recovery must call deq_data_set before
+                              // returning to the test for ioc->has_enq to become 0.
+                              Expect([&]()
+                                     { __asm(" EXRL 0,*"); })
+                                  .ToAbend();
 
-                             // After recovery: has_enq == 0 means the recovery path properly DEQ'd.
-                             // has_enq == 1 means a forced crash leaves ENQ unreleased (bug).
-                             Expect(ioc->has_enq).ToBe(0);
-                           });
-                        
+                              // After recovery: has_enq == 0 means the recovery path properly DEQ'd.
+                              // has_enq == 1 means a forced crash leaves ENQ unreleased (bug).
+                              Expect(ioc->has_enq).ToBe(0);
+                            });
+
                         // uncomment when in a zvdt env
                         xit("should catch abend when writing past max space of a PDS",
                             [&]() -> void

--- a/native/c/test/zds.test.cpp
+++ b/native/c/test/zds.test.cpp
@@ -1398,7 +1398,7 @@ void zds_tests()
                                     rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
                                     TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
                                     if (rc != 0 ){
-                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                       TestLog("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
                                     }
 
                                     // Volume is required for systems that are not SMS managed
@@ -1473,7 +1473,7 @@ void zds_tests()
                                    int rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
                                     TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
                                     if (rc !=0 ){
-                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                       TestLog("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
                                     } },
                                  vsam_opts);
 
@@ -1605,7 +1605,7 @@ void zds_tests()
                                     int rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
                                     TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
                                     if (rc !=0 ){
-                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                       TestLog("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
                                     }
                                     // Define the GDG base via IDCAMS
                                     std::string setup_output;
@@ -1647,7 +1647,7 @@ void zds_tests()
                                    int rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
                                     TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
                                     if (rc !=0 ){
-                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                       TestLog("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
                                     } },
                                  gdg_opts);
 

--- a/native/c/test/zowex.ds.test.cpp
+++ b/native/c/test/zowex.ds.test.cpp
@@ -2195,7 +2195,7 @@ void zowex_ds_tests()
                                    std::string cleanup_output;
                                                      for (const auto &alias : created_aliases)
                    {
-                                   cleanup_idcams += "  DELETE -\n"+alias+" -\n ALIAS\n";
+                                   cleanup_idcams += "  DELETE -\n "+alias+" -\n ALIAS\n";
                    }
                                    cleanup_idcams += "  SET MAXCC = 0\n";
                                    int rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);

--- a/native/c/test/zowex.ds.test.cpp
+++ b/native/c/test/zowex.ds.test.cpp
@@ -24,7 +24,6 @@
 #include "ztest.hpp"
 #include "zutils.hpp"
 #include "ztype.h"
-#include "zowex.test.hpp"
 #include "zowex.ds.test.hpp"
 #include "../zusf.hpp"
 #include "../zjb.hpp"
@@ -43,6 +42,7 @@ void _create_ds(const std::string &ds_name, const std::string &ds_options = "")
 void zowex_ds_tests()
 {
   std::vector<std::string> _ds;
+  std::vector<std::string> created_aliases;
   describe("data-set",
            [&]() -> void
            {
@@ -2108,5 +2108,101 @@ void zowex_ds_tests()
                                         Expect(matching_threads).ToBe(1); }, concurrent_opts);
                                  });
                       });
+             describe("resolve-alias",
+                      [&]() -> void
+                      {
+                        beforeEach([&]() -> void
+                                   { _ds.push_back(get_random_ds()); });
+                        it("should resolve an alias to a sequential data set",
+                           [&]() -> void
+                           {
+                             std::string target = _ds.back();
+                             _create_ds(target, "--dsorg PS");
+
+                             std::string alias_name = get_random_ds() + ".ALIAS";
+                             std::string makeAliasOutput;
+                             std::string makeAliasError;
+
+                             int rc = zds_idcams(
+                                 " DEFINE ALIAS (NAME(" + alias_name + ") -\n RELATE(" + target + "))\n", makeAliasOutput, makeAliasError);
+
+                             ExpectWithContext(rc, "Failed to create alias with rc " + std::to_string(rc) +
+                                                       ". Idcams output/error:" + makeAliasOutput + "\n" + makeAliasError)
+                                 .ToBe(0);
+
+                             created_aliases.push_back(alias_name);
+                             std::string response;
+                             std::string command = zowex_command + " data-set resolve-alias " + alias_name;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain(target);
+                           });
+
+                        it("should resolve an alias to a PDS",
+                           [&]() -> void
+                           {
+                             std::string target = _ds.back();
+                             _create_ds(target, "--dsorg PO");
+
+                             std::string alias_name = get_random_ds() + ".ALIAS";
+                             std::string makeAliasOutput;
+                             std::string makeAliasError;
+
+                             int rc = zds_idcams(
+                                 " DEFINE ALIAS (NAME(" + alias_name + ") -\n RELATE(" + target + "))\n", makeAliasOutput, makeAliasError);
+
+                             ExpectWithContext(rc, "Failed to create alias with rc " + std::to_string(rc) +
+                                                       ". Idcams output/error:" + makeAliasOutput + "\n" + makeAliasError)
+                                 .ToBe(0);
+
+                             created_aliases.push_back(alias_name);
+                             std::string response;
+                             std::string command = zowex_command + " data-set resolve-alias " + alias_name;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain(target);
+                           });
+
+                        it("should resolve an alias to a PDSE",
+                           [&]() -> void
+                           {
+                             std::string target = _ds.back();
+                             _create_ds(target, "--dsorg PO --dsntype LIBRARY --recfm F,B --dirblk 5");
+
+                             std::string alias_name = get_random_ds() + ".ALIAS";
+                             std::string makeAliasOutput;
+                             std::string makeAliasError;
+
+                             int rc = zds_idcams(
+                                 " DEFINE ALIAS (NAME(" + alias_name + ") -\n RELATE(" + target + "))\n", makeAliasOutput, makeAliasError);
+
+                             ExpectWithContext(rc, "Failed to create alias with rc " + std::to_string(rc) +
+                                                       ". Idcams output/error:" + makeAliasOutput + "\n" + makeAliasError)
+                                 .ToBe(0);
+
+                             created_aliases.push_back(alias_name);
+                             std::string response;
+                             std::string command = zowex_command + " data-set resolve-alias " + alias_name;
+                             rc = execute_command_with_output(command, response);
+                             ExpectWithContext(rc, response).ToBe(0);
+                             Expect(response).ToContain(target);
+                           });
+                      });
+
+             afterAll([&]() -> void
+                      {
+                                   std::string cleanup_idcams;
+                                   std::string cleanup_err;
+                                   std::string cleanup_output;
+                                                     for (const auto &alias : created_aliases)
+                   {
+                                   cleanup_idcams += "  DELETE -\n"+alias+" -\n ALIAS\n";
+                   }
+                                   cleanup_idcams += "  SET MAXCC = 0\n";
+                                   int rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
+                                    TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
+                                    if (rc !=0 ){
+                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                    } });
            });
 }

--- a/native/c/test/zowex.ds.test.cpp
+++ b/native/c/test/zowex.ds.test.cpp
@@ -997,32 +997,32 @@ void zowex_ds_tests()
                         beforeAll([&]() -> void
                                   {
                                     // Clean up any leftover data sets from previous test runs
-                                    std::string cleanup_jcl;
-                                    cleanup_jcl += "//GDGCLN$ JOB IZUACCT\n";
-                                    cleanup_jcl += "//STEP1    EXEC PGM=IDCAMS\n";
-                                    cleanup_jcl += "//SYSPRINT DD SYSOUT=*\n";
-                                    cleanup_jcl += "//SYSIN    DD *\n";
-                                    cleanup_jcl += "  DELETE " + gdg_gen2_dsn + " NONVSAM PURGE\n";
-                                    cleanup_jcl += "  DELETE " + gdg_gen1_dsn + " NONVSAM PURGE\n";
-                                    cleanup_jcl += "  DELETE " + gdg_base_dsn + " GDG PURGE\n";
-                                    cleanup_jcl += "  SET MAXCC = 0\n";
-                                    cleanup_jcl += "/*\n";
-                                    submit_and_wait(cleanup_jcl, 200);
-
+                                    std::string cleanup_output;
+                                    std::string cleanup_err;
+                                    std::string cleanup_idcams;
+                                    cleanup_idcams += "  DELETE " + gdg_gen2_dsn + " NONVSAM PURGE\n";
+                                    cleanup_idcams += "  DELETE " + gdg_gen1_dsn + " NONVSAM PURGE\n";
+                                    cleanup_idcams += "  DELETE " + gdg_base_dsn + " GDG PURGE\n";
+                                    cleanup_idcams += "  SET MAXCC = 0\n";
+                                    int rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
+                                    TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
+                                    if (rc !=0 ){
+                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                    }
                                     // Define the GDG base via IDCAMS
-                                    std::string setup_jcl;
-                                    setup_jcl += "//GDGSET$ JOB IZUACCT\n";
-                                    setup_jcl += "//STEP1    EXEC PGM=IDCAMS\n";
-                                    setup_jcl += "//SYSPRINT DD SYSOUT=*\n";
-                                    setup_jcl += "//SYSIN    DD *\n";
-                                    setup_jcl += "  DEFINE GDG ( -\n";
-                                    setup_jcl += "    NAME(" + gdg_base_dsn + ") -\n";
-                                    setup_jcl += "    LIMIT(5) -\n";
-                                    setup_jcl += "    NOEMPTY -\n";
-                                    setup_jcl += "    NOSCRATCH )\n";
-                                    setup_jcl += "/*\n";
-                                    submit_and_wait(setup_jcl, 200, true);
-
+                                    std::string setup_idcams;
+                                    std::string setup_output;
+                                    std::string setup_err;
+                                    setup_idcams += "  DEFINE GDG ( -\n";
+                                    setup_idcams += "    NAME(" + gdg_base_dsn + ") -\n";
+                                    setup_idcams += "    LIMIT(5) -\n";
+                                    setup_idcams += "    NOEMPTY -\n";
+                                    setup_idcams += "    NOSCRATCH )\n";
+                                    rc = zds_idcams(setup_idcams, setup_output, setup_err);
+                                    TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
+                                    if (rc !=0 ){
+                                       throw std::runtime_error("Output and error from failed IDCAMS setup:" + setup_err + "\n" + setup_output +"\n");
+                                    }
                                     // Create generation 1 via IEBGENER
                                     std::string gen1_jcl;
                                     gen1_jcl += "//GDGGEN1 JOB IZUACCT\n";
@@ -1054,74 +1054,60 @@ void zowex_ds_tests()
 
                         afterAll([&]() -> void
                                  {
-                                   std::string del_jcl;
-                                   del_jcl += "//GDGDEL$ JOB IZUACCT\n";
-                                   del_jcl += "//STEP1    EXEC PGM=IDCAMS\n";
-                                   del_jcl += "//SYSPRINT DD SYSOUT=*\n";
-                                   del_jcl += "//SYSIN    DD *\n";
-                                   del_jcl += "  DELETE " + gdg_gen2_dsn + " NONVSAM PURGE\n";
-                                   del_jcl += "  DELETE " + gdg_gen1_dsn + " NONVSAM PURGE\n";
-                                   del_jcl += "  DELETE " + gdg_base_dsn + " GDG PURGE\n";
-                                   del_jcl += "  SET MAXCC = 0\n";
-                                   del_jcl += "/*\n";
-                                   submit_and_wait(del_jcl, 200); },
+                                   std::string cleanup_idcams;
+                                   std::string cleanup_err;
+                                   std::string cleanup_output;
+                                   cleanup_idcams += "  DELETE " + gdg_gen2_dsn + " NONVSAM PURGE\n";
+                                   cleanup_idcams += "  DELETE " + gdg_gen1_dsn + " NONVSAM PURGE\n";
+                                   cleanup_idcams += "  DELETE " + gdg_base_dsn + " GDG PURGE\n";
+                                   cleanup_idcams += "  SET MAXCC = 0\n";
+                                   int rc = zds_idcams(cleanup_idcams, cleanup_output, cleanup_err);
+                                    TestLog("Cleanup RC from IDCAMS: " + std::to_string(rc));
+                                    if (rc !=0 ){
+                                       throw std::runtime_error("Output and error from failed IDCAMS cleanup:" + cleanup_err + "\n" + cleanup_output +"\n");
+                                    } },
                                  gdg_opts);
 
-                        it("should list the GDG base in the catalog",
-                           [&]() -> void
+                        it("should list the GDG base in the catalog", [&]() -> void
                            {
                              std::string response;
                              const std::string command = zowex_command + " data-set list " + gdg_base_dsn + " --no-warn";
                              const int rc = execute_command_with_output(command, response);
                              ExpectWithContext(rc, response).ToBe(0);
-                             Expect(response).ToContain(gdg_base_dsn);
-                           },
-                           gdg_opts);
+                             Expect(response).ToContain(gdg_base_dsn); }, gdg_opts);
 
-                        it("should report ?????? volser for GDG base when listing with attributes",
-                           [&]() -> void
+                        it("should report ?????? volser for GDG base when listing with attributes", [&]() -> void
                            {
                              std::string response;
                              const std::string command = zowex_command + " data-set list " + gdg_base_dsn + " -a --rfc";
                              const int rc = execute_command_with_output(command, response);
                              ExpectWithContext(rc, response).ToBe(0);
-                             Expect(response).ToContain("??????");
-                           },
-                           gdg_opts);
+                             Expect(response).ToContain("??????"); }, gdg_opts);
 
-                        it("should list GDG generations using a wildcard pattern",
-                           [&]() -> void
+                        it("should list GDG generations using a wildcard pattern", [&]() -> void
                            {
                              std::string response;
                              const std::string command = zowex_command + " data-set list '" + gdg_base_dsn + ".*' --no-warn";
                              const int rc = execute_command_with_output(command, response);
                              ExpectWithContext(rc, response).ToBe(0);
                              Expect(response).ToContain(gdg_gen1_dsn);
-                             Expect(response).ToContain(gdg_gen2_dsn);
-                           },
-                           gdg_opts);
+                             Expect(response).ToContain(gdg_gen2_dsn); }, gdg_opts);
 
-                        it("should view the content of a GDG generation by absolute name",
-                           [&]() -> void
+                        it("should view the content of a GDG generation by absolute name", [&]() -> void
                            {
                              std::string response;
                              const std::string command = zowex_command + " data-set view " + gdg_gen1_dsn;
                              const int rc = execute_command_with_output(command, response);
                              ExpectWithContext(rc, response).ToBe(0);
-                             Expect(response).ToContain("GENERATION ONE CONTENT");
-                           },
-                           gdg_opts);
+                             Expect(response).ToContain("GENERATION ONE CONTENT"); }, gdg_opts);
 
-                        it("should view the most recent GDG generation via relative reference",
-                           [&]() -> void
+                        it("should view the most recent GDG generation via relative reference", [&]() -> void
                            {
                              std::string response;
                              const std::string command = zowex_command + " data-set view '" + gdg_base_dsn + "(0)'";
                              const int rc = execute_command_with_output(command, response);
                              ExpectWithContext(rc, response).ToBe(0);
-                             Expect(response).ToContain("GENERATION TWO CONTENT");
-                           },
-                           gdg_opts);
+                             Expect(response).ToContain("GENERATION TWO CONTENT"); }, gdg_opts);
 
                         // TODO: https://github.com/zowe/zowex/issues/666
                         xit("should delete a specific GDG generation", []() -> void {});
@@ -1164,23 +1150,23 @@ void zowex_ds_tests()
                          // TODO: What do?
                          xit("should fail to restore if not authorized", [&]() -> void {});
                        });
-            // CA Disk archival/restore is tested manually via native/c/test/test.cadisk.sh.
-            // See doc/ref/ds/ca-disk.md for instructions.
-            // Manual test for https://github.com/zowe/zowex/issues/1007
-            // Bug: "data-set restore" returns success for a data set that was never archived.
-            //
-            // To verify manually once the fix is in place:
-            //   1. Create a plain data set (never archived):
-            //        zowex data-set create HLQ.UNARCHIVED --dsorg PS
-            //   2. Attempt to restore it:
-            //        zowex data-set restore HLQ.UNARCHIVED
-            //   3. Expected (after fix): non-zero RC and a message such as
-            //        "Error: data set 'HLQ.UNARCHIVED' is not archived"
-            //   4. Actual (current bug): RC 0 and "Data set 'HLQ.UNARCHIVED' restored"
-            //
-            // For the full end-to-end archival/restore flow, see test.cadisk.sh.
-            xit("should fail to restore a data set that was never archived", []() -> void {});
-            describe("view",
+             // CA Disk archival/restore is tested manually via native/c/test/test.cadisk.sh.
+             // See doc/ref/ds/ca-disk.md for instructions.
+             // Manual test for https://github.com/zowe/zowex/issues/1007
+             // Bug: "data-set restore" returns success for a data set that was never archived.
+             //
+             // To verify manually once the fix is in place:
+             //   1. Create a plain data set (never archived):
+             //        zowex data-set create HLQ.UNARCHIVED --dsorg PS
+             //   2. Attempt to restore it:
+             //        zowex data-set restore HLQ.UNARCHIVED
+             //   3. Expected (after fix): non-zero RC and a message such as
+             //        "Error: data set 'HLQ.UNARCHIVED' is not archived"
+             //   4. Actual (current bug): RC 0 and "Data set 'HLQ.UNARCHIVED' restored"
+             //
+             // For the full end-to-end archival/restore flow, see test.cadisk.sh.
+             xit("should fail to restore a data set that was never archived", []() -> void {});
+             describe("view",
                       [&]() -> void
                       {
                         beforeEach(
@@ -1308,8 +1294,7 @@ void zowex_ds_tests()
                                  {
                                    TEST_OPTIONS concurrent_opts = {false, 60};
 
-                                   it("should not block concurrent reads of different PDSE members: fopen(r) does not take an exclusive ENQ",
-                                      [&]() -> void
+                                   it("should not block concurrent reads of different PDSE members: fopen(r) does not take an exclusive ENQ", [&]() -> void
                                       {
                                         const std::string ds = get_random_ds();
                                         _ds.push_back(ds);
@@ -1349,12 +1334,9 @@ void zowex_ds_tests()
                                         {
                                           ExpectWithContext(results[i], contents[i]).ToBe(0);
                                           Expect(contents[i]).ToContain("content for member " + std::to_string(i));
-                                        }
-                                      },
-                                      concurrent_opts);
+                                        } }, concurrent_opts);
 
-                                   it("should not block concurrent reads of the same PDSE member: fopen(r) uses SHR not exclusive ENQ",
-                                      [&]() -> void
+                                   it("should not block concurrent reads of the same PDSE member: fopen(r) uses SHR not exclusive ENQ", [&]() -> void
                                       {
                                         const std::string ds = get_random_ds();
                                         _ds.push_back(ds);
@@ -1390,9 +1372,7 @@ void zowex_ds_tests()
                                         {
                                           ExpectWithContext(results[i], contents[i]).ToBe(0);
                                           Expect(contents[i]).ToContain(expected);
-                                        }
-                                      },
-                                      concurrent_opts);
+                                        } }, concurrent_opts);
                                  });
                       });
              describe("write",
@@ -1992,8 +1972,7 @@ void zowex_ds_tests()
                                    // compete for the same RESERVE regardless of member. EXCLUSIVE+RET=USE means the
                                    // holder gets RC=0; concurrent requestors get RC=4 immediately. At least one write
                                    // must succeed, and every member that was written must contain coherent data.
-                                   it("should serialize concurrent BPAM writes to the same PDSE via RESERVE: even across different members",
-                                      [&]() -> void
+                                   it("should serialize concurrent BPAM writes to the same PDSE via RESERVE: even across different members", [&]() -> void
                                       {
                                         const std::string ds = get_random_ds();
                                         _ds.push_back(ds);
@@ -2036,15 +2015,12 @@ void zowex_ds_tests()
                                           ZDSReadOpts read_opts{.zds = &read_zds, .dsname = ds + "(MEM" + std::to_string(i) + ")"};
                                           ExpectWithContext(zds_read(read_opts, content), content).ToBe(0);
                                           Expect(content).ToContain("thread " + std::to_string(i) + " data");
-                                        }
-                                      },
-                                      concurrent_opts);
+                                        } }, concurrent_opts);
 
                                    // Same member = same ENQ rname. ENQ uses EXCLUSIVE+RET=USE: the holder gets RC=0,
                                    // concurrent requestors get RC=4 immediately (no wait). At least one write must
                                    // succeed, and the final content must come from exactly one write (no interleaving).
-                                   it("should serialize concurrent writes to the same PDSE member via exclusive ENQ",
-                                      [&]() -> void
+                                   it("should serialize concurrent writes to the same PDSE member via exclusive ENQ", [&]() -> void
                                       {
                                         const std::string ds = get_random_ds();
                                         _ds.push_back(ds);
@@ -2085,9 +2061,7 @@ void zowex_ds_tests()
                                         for (int i = 0; i < thread_count; ++i)
                                           if (content.find("thread " + std::to_string(i) + " data") != std::string::npos)
                                             ++matching_threads;
-                                        Expect(matching_threads).ToBe(1);
-                                      },
-                                      concurrent_opts);
+                                        Expect(matching_threads).ToBe(1); }, concurrent_opts);
                                  });
                       });
            });

--- a/native/c/test/zowex.ds.test.cpp
+++ b/native/c/test/zowex.ds.test.cpp
@@ -62,8 +62,9 @@ void zowex_ds_tests()
                        ExpectWithContext(rc, response).ToBe(0);
                        Expect(response).ToContain("Data set '" + ds + "' deleted"); // ds deleted
                      }
-                     catch (...)
+                     catch (const std::exception &deleteErr)
                      {
+                       TestLog("Failed to delete: " + ds + ", error: " + deleteErr.what() + ". Verifying with data-set list command");
                        try
                        {
                          std::string response;
@@ -72,9 +73,9 @@ void zowex_ds_tests()
                          ExpectWithContext(rc, response).ToBe(0);
                          Expect(response).Not().ToContain(ds);
                        }
-                       catch (...)
+                       catch (const std::exception &listCheckErr)
                        {
-                         TestLog("Failed to delete: " + ds);
+                         TestLog("Failed to delete: " + ds + ", error: " + listCheckErr.what());
                        }
                      }
                    }

--- a/native/c/test/zut.test.cpp
+++ b/native/c/test/zut.test.cpp
@@ -222,7 +222,7 @@ void zut_tests()
                            []() -> void
                            {
                              ZLOG_DEBUG("zut.test: it allocate sysout");
-                             std::string cmd = "ALLOC SYSOUT";
+                             std::string cmd = "ALLOC SYSIN";
                              unsigned int code = 0;
                              std::string dsname = "";
                              std::string resp = "";

--- a/native/c/test/zut.test.cpp
+++ b/native/c/test/zut.test.cpp
@@ -222,7 +222,7 @@ void zut_tests()
                            []() -> void
                            {
                              ZLOG_DEBUG("zut.test: it allocate sysout");
-                             std::string cmd = "ALLOC SYSIN";
+                             std::string cmd = "ALLOC SYSOUT";
                              unsigned int code = 0;
                              std::string dsname = "";
                              std::string resp = "";

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -4355,23 +4355,22 @@ int zds_idcams(const std::string &sysInData, std::string &output, std::string &e
     zut_loop_dynalloc(diag, free_dds);
     return RTNCD_FAILURE;
   }
-  error += "write to dataset succeeded\n";
 
   rc = ZUTIDCAM(sysinDdName.c_str(), sysprintDdName.c_str());
+  ZDS sysprintZds{};
+  ZDSReadOpts ropts{.zds = &sysprintZds, .ddname = sysprintDdName};
+  int sysprintReadRc = zds_read(ropts, output);
+  if (sysprintReadRc != 0)
+  {
+    error += "Failed to read from IDCAMS SYSPRINT DD '" + sysprintDdName + "'\n";
+  }
   if (rc != 0)
   {
     error += "IDCAMS returned nonzero RC: " + std::to_string(rc);
     zut_loop_dynalloc(diag, free_dds);
     return rc;
   }
-  ZDS sysprintZds{};
-  ZDSReadOpts ropts{.zds = &sysprintZds, .ddname = sysprintDdName};
-  rc = zds_read(ropts, output);
-  if (rc != 0)
-  {
-    error += "Failed to read from IDCAMS SYSPRINT DD '" + sysprintDdName + "'";
-  }
-  error += "Succeeded in reading output from  IDCAMS sysprint TODO remove";
+
   zut_loop_dynalloc(diag, free_dds);
   return rc;
 }

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -4313,3 +4313,40 @@ static int zds_write_member_bpam_streamed(ZDS *zds, const std::string &dsn, cons
   rc = zds_close_output_bpam(zds, ioc);
   return handle_truncation_result(zds, rc, truncation);
 }
+
+int zds_idcams(const std::string &sysInData, std::string &idcamsOutput, std::string &error)
+{
+  unsigned int bpxwdynCode = 0;
+  int rc = 0;
+  ZDIAG diag{};
+  std::string sysinDdName = "";
+  std::string bpxwdynResponse = "";
+
+  // Perform dynalloc
+  std::vector<std::string> dds;
+  dds.reserve(2);
+  dds.push_back("alloc dd(sysin)");
+  dds.push_back("alloc dd(sysprint)");
+
+  rc = zut_loop_dynalloc(diag, dds);
+  if (0 != rc)
+  {
+    error += "Error: allocation failed: " + std::string(diag.e_msg) + "\n";
+    zut_free_dynalloc_dds(diag, dds);
+    return RTNCD_FAILURE;
+  }
+
+  ZDS idcamsSysinZds{};
+  ZDSWriteOpts write_opts{.zds = &idcamsSysinZds, .ddname = "SYSIN"};
+  rc = zds_write(write_opts, sysInData);
+  if (rc != 0)
+  {
+    error += "failed to write IDCAMS commands to sysin\n";
+    zut_free_dynalloc_dds(diag, dds);
+    return RTNCD_FAILURE;
+  }
+
+  error += "write to dataset succeeded\n";
+  zut_free_dynalloc_dds(diag, dds);
+  return rc;
+}

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -12,6 +12,7 @@
 #ifndef _OPEN_SYS_ITOA_EXT
 #define _OPEN_SYS_ITOA_EXT
 #include "ztype.h"
+#include "zutm.h"
 #include <cctype>
 #endif
 #ifndef _POSIX_SOURCE
@@ -4314,39 +4315,50 @@ static int zds_write_member_bpam_streamed(ZDS *zds, const std::string &dsn, cons
   return handle_truncation_result(zds, rc, truncation);
 }
 
-int zds_idcams(const std::string &sysInData, std::string &idcamsOutput, std::string &error)
+int zds_idcams(const std::string &sysInData, std::string &output, std::string &error)
 {
   unsigned int bpxwdynCode = 0;
   int rc = 0;
   ZDIAG diag{};
   std::string sysinDdName = "";
+  std::string sysprintDdName = "";
   std::string bpxwdynResponse = "";
 
-  // Perform dynalloc
-  std::vector<std::string> dds;
-  dds.reserve(2);
-  dds.push_back("alloc dd(sysin)");
-  dds.push_back("alloc dd(sysprint)");
-
-  rc = zut_loop_dynalloc(diag, dds);
-  if (0 != rc)
+  // list of DDs to free later
+  std::vector<std::string> free_dds;
+  free_dds.reserve(2);
+  // Perform dynalloc for sysin and sysprint DDs
+  rc = zut_bpxwdyn_rtdd("alloc lrecl(80) recfm(f,b)", &bpxwdynCode, bpxwdynResponse, sysinDdName);
+  if (rc != 0)
   {
-    error += "Error: allocation failed: " + std::string(diag.e_msg) + "\n";
-    zut_free_dynalloc_dds(diag, dds);
+    error += "failed to allocate SYSIN dd for IDCAMS\n";
     return RTNCD_FAILURE;
   }
+  free_dds.push_back("free " + sysinDdName);
+
+  rc = zut_bpxwdyn_rtdd("alloc lrecl(80) recfm(f,b)", &bpxwdynCode, bpxwdynResponse, sysprintDdName);
+  if (rc != 0)
+  {
+    error += "failed to allocate SYSPRINT dd for IDCAMS\n";
+    zut_loop_dynalloc(diag, free_dds);
+    return RTNCD_FAILURE;
+  }
+  free_dds.push_back("free " + sysprintDdName);
 
   ZDS idcamsSysinZds{};
-  ZDSWriteOpts write_opts{.zds = &idcamsSysinZds, .ddname = "SYSIN"};
+  ZDSWriteOpts write_opts{.zds = &idcamsSysinZds, .ddname = sysinDdName};
   rc = zds_write(write_opts, sysInData);
   if (rc != 0)
   {
     error += "failed to write IDCAMS commands to sysin\n";
-    zut_free_dynalloc_dds(diag, dds);
+    zut_loop_dynalloc(diag, free_dds);
     return RTNCD_FAILURE;
   }
 
+  // todo build remap DD statements, add struct for parameters.
+  // rc = ZUTIDCAM();
+
   error += "write to dataset succeeded\n";
-  zut_free_dynalloc_dds(diag, dds);
+  zut_loop_dynalloc(diag, free_dds);
   return rc;
 }

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -4324,10 +4324,9 @@ int zds_idcams(const std::string &sysInData, std::string &output, std::string &e
   std::string sysinDdName = "";
   std::string sysprintDdName = "";
   std::string bpxwdynResponse = "";
-
-  // list of DDs to free later
   std::vector<std::string> free_dds;
   free_dds.reserve(2);
+
   // Perform dynalloc for sysin and sysprint DDs
   rc = zut_bpxwdyn_rtdd("alloc lrecl(80) recfm(f,b)", &bpxwdynCode, bpxwdynResponse, sysinDdName);
   if (rc != 0)

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -301,6 +301,7 @@ static int copy_sequential(ZDS *zds, const std::string &dsn1, const std::string 
                     "IEBGENER failed with RC=%d. SYSPRINT: %s",
                     rc, truncated_detail);
     }
+
     zut_free_dynalloc_dds(zds->diag, dds);
     return RTNCD_FAILURE;
   }
@@ -4345,8 +4346,8 @@ int zds_idcams(const std::string &sysInData, std::string &output, std::string &e
   }
   free_dds.push_back("free " + sysprintDdName);
 
-  ZDS idcamsSysinZds{};
-  ZDSWriteOpts write_opts{.zds = &idcamsSysinZds, .ddname = sysinDdName};
+  ZDS sysinZds{};
+  ZDSWriteOpts write_opts{.zds = &sysinZds, .ddname = sysinDdName};
   rc = zds_write(write_opts, sysInData);
   if (rc != 0)
   {
@@ -4354,11 +4355,23 @@ int zds_idcams(const std::string &sysInData, std::string &output, std::string &e
     zut_loop_dynalloc(diag, free_dds);
     return RTNCD_FAILURE;
   }
-
-  // todo build remap DD statements, add struct for parameters.
-  // rc = ZUTIDCAM();
-
   error += "write to dataset succeeded\n";
+
+  rc = ZUTIDCAM(sysinDdName.c_str(), sysprintDdName.c_str());
+  if (rc != 0)
+  {
+    error += "IDCAMS returned nonzero RC: " + std::to_string(rc);
+    zut_loop_dynalloc(diag, free_dds);
+    return rc;
+  }
+  ZDS sysprintZds{};
+  ZDSReadOpts ropts{.zds = &sysprintZds, .ddname = sysprintDdName};
+  rc = zds_read(ropts, output);
+  if (rc != 0)
+  {
+    error += "Failed to read from IDCAMS SYSPRINT DD '" + sysprintDdName + "'";
+  }
+  error += "Succeeded in reading output from  IDCAMS sysprint TODO remove";
   zut_loop_dynalloc(diag, free_dds);
   return rc;
 }

--- a/native/c/zds.hpp
+++ b/native/c/zds.hpp
@@ -362,10 +362,10 @@ int zds_read_streamed(const ZDSReadOpts &opts, const std::string &pipe, size_t *
  * @brief Invoke the IDCAMS program
  * https://www.ibm.com/docs/en/zos-basic-skills?topic=management-access-method-services-idcams-commands
  * @param sysInData string data to write to the SYSIN DD for IDCAMS. Consists of commands to pass to IDCAMS.
- * @param idcamsOutput output from the SYSPRINT DD of IDCAMS will be written here.
+ * @param output output from the SYSPRINT DD of IDCAMS will be written here.
  * @param error Reference to a string that receives a short error description on failure
  * @return Return code (0 for success, non-zero for error)
  */
-int zds_idcams(const std::string &sysInData, std::string &idcamsOutput, std::string &error);
+int zds_idcams(const std::string &sysInData, std::string &output, std::string &error);
 
 #endif

--- a/native/c/zds.hpp
+++ b/native/c/zds.hpp
@@ -358,4 +358,14 @@ int zdsReadDynalloc(const std::string &, const std::string &, const std::string 
  */
 int zds_read_streamed(const ZDSReadOpts &opts, const std::string &pipe, size_t *content_len, uint32_t *etag_checksum = nullptr);
 
+/**
+ * @brief Invoke the IDCAMS program
+ * https://www.ibm.com/docs/en/zos-basic-skills?topic=management-access-method-services-idcams-commands
+ * @param sysInData string data to write to the SYSIN DD for IDCAMS. Consists of commands to pass to IDCAMS.
+ * @param idcamsOutput output from the SYSPRINT DD of IDCAMS will be written here.
+ * @param error Reference to a string that receives a short error description on failure
+ * @return Return code (0 for success, non-zero for error)
+ */
+int zds_idcams(const std::string &sysInData, std::string &idcamsOutput, std::string &error);
+
 #endif

--- a/native/c/zds.hpp
+++ b/native/c/zds.hpp
@@ -359,7 +359,7 @@ int zdsReadDynalloc(const std::string &, const std::string &, const std::string 
 int zds_read_streamed(const ZDSReadOpts &opts, const std::string &pipe, size_t *content_len, uint32_t *etag_checksum = nullptr);
 
 /**
- * @brief Invoke the IDCAMS program
+ * @brief Invoke the IDCAMS program and receive its SYSPRINT output.
  * https://www.ibm.com/docs/en/zos-basic-skills?topic=management-access-method-services-idcams-commands
  * @param sysInData string data to write to the SYSIN DD for IDCAMS. Consists of commands to pass to IDCAMS.
  * @param output output from the SYSPRINT DD of IDCAMS will be written here.

--- a/native/c/zut.cpp
+++ b/native/c/zut.cpp
@@ -40,6 +40,8 @@
 #include <_Nascii.h>
 #include "csvapfaa.h"
 #include "iefjsqry.h"
+#include "zdstype.h"
+#include "zds.hpp"
 
 void zut_strip_final_newline(std::string &input)
 {

--- a/native/c/zut.cpp
+++ b/native/c/zut.cpp
@@ -40,8 +40,6 @@
 #include <_Nascii.h>
 #include "csvapfaa.h"
 #include "iefjsqry.h"
-#include "zdstype.h"
-#include "zds.hpp"
 
 void zut_strip_final_newline(std::string &input)
 {

--- a/native/c/zutm.c
+++ b/native/c/zutm.c
@@ -623,7 +623,7 @@ struct idcamsDdNameList
   char sysin[8];
   char sysprint[8];
 };
-typedef int (*IDCAMS)(void *PTR32, void *PTR32) ATTRIBUTE(amode31);
+typedef int (*IDCAMS)(unsigned int, unsigned int) ATTRIBUTE(amode31);
 #pragma prolog(ZUTIDCAM, " ZWEPROLG NEWDSA=(YES,8) ")
 #pragma epilog(ZUTIDCAM, " ZWEEPILG ")
 int ZUTIDCAM(const char *sysinDdName, const char *sysprintDdName)
@@ -631,22 +631,25 @@ int ZUTIDCAM(const char *sysinDdName, const char *sysprintDdName)
   int rc = 0;
 
   unsigned short options = 0;
-  struct idcamsDdNameList ddnameList = {0};
-  ddnameList.len = sizeof(ddnameList._unused);
+  struct idcamsDdNameList ddNameList = {0};
+  ddNameList.len = sizeof(ddNameList._unused) + sizeof(ddNameList.sysin) + sizeof(ddNameList.sysprint);
 
   // DD name replacements should be padded with blanks
-  memset(ddnameList.sysin, ' ', sizeof(ddnameList.sysin));
-  memset(ddnameList.sysprint, ' ', sizeof(ddnameList.sysprint));
-  memcpy(ddnameList.sysin, sysinDdName,
-         strlen(sysinDdName) > sizeof(ddnameList.sysin) ? sizeof(ddnameList.sysin) : strlen(sysinDdName));
-  memcpy(ddnameList.sysprint, sysprintDdName,
-         strlen(sysprintDdName) > sizeof(ddnameList.sysprint) ? sizeof(ddnameList.sysprint) : strlen(sysprintDdName));
+  memset(ddNameList.sysin, ' ', sizeof(ddNameList.sysin));
+  memset(ddNameList.sysprint, ' ', sizeof(ddNameList.sysprint));
+  memcpy(ddNameList.sysin, sysinDdName,
+         strlen(sysinDdName) > sizeof(ddNameList.sysin) ? sizeof(ddNameList.sysin) : strlen(sysinDdName));
+  memcpy(ddNameList.sysprint, sysprintDdName,
+         strlen(sysprintDdName) > sizeof(ddNameList.sysprint) ? sizeof(ddNameList.sysprint) : strlen(sysprintDdName));
 
   // IDCAMS must be entered in 31-bit mode. https://www.ibm.com/docs/en/zos/3.1.0?topic=commands-invoking-access-method-services-from-your-program
   IDCAMS idcams = (IDCAMS)load_module31("IDCAMS");
   // www.ibm.com/docs/en/zos/3.1.0?topic=instructions-load-call-macro
   // ddnameList is the current last entry so set the high order bit to indicate the last
-  rc = idcams(&options, (void *PTR32)((unsigned int)(uintptr_t)&ddnameList | 0x80000000U));
+  unsigned int parm_list[2];
+  parm_list[0] = (unsigned int)(uintptr_t)&options;
+  parm_list[1] = (unsigned int)(uintptr_t)&ddNameList | 0x80000000U;
+  rc = idcams(parm_list[0], parm_list[1]);
   delete_module("IDCAMS");
 
   return rc;

--- a/native/c/zutm.c
+++ b/native/c/zutm.c
@@ -590,3 +590,20 @@ int ZUTCVTD(const char *ptr, char *time)
   }
   return rc;
 }
+
+typedef int (*IDCAMS)(void *) ATTRIBUTE(amode31);
+#pragma prolog(ZUTIDCAM, " ZWEPROLG NEWDSA=(YES,4) ")
+#pragma epilog(ZUTIDCAM, " ZWEEPILG ")
+int ZUTIDCAM(const char *parms)
+{
+  int rc = 0;
+
+  PARMS p = {0};
+  p.len = sprintf(p.parms, "%.*s", (int)(sizeof(p.parms) - 1), parms);
+
+  IDCAMS idcams = (IDCAMS)load_module31("IDCAMS");
+  rc = idcams(&p);
+  delete_module("IDCAMS");
+
+  return rc;
+}

--- a/native/c/zutm.c
+++ b/native/c/zutm.c
@@ -624,7 +624,7 @@ struct idcamsDdNameList
   char sysprint[8];
 };
 typedef int (*IDCAMS)(unsigned int, unsigned int) ATTRIBUTE(amode31);
-#pragma prolog(ZUTIDCAM, " ZWEPROLG NEWDSA=(YES,8) ")
+#pragma prolog(ZUTIDCAM, " ZWEPROLG NEWDSA=(YES,4) ")
 #pragma epilog(ZUTIDCAM, " ZWEEPILG ")
 int ZUTIDCAM(const char *sysinDdName, const char *sysprintDdName)
 {

--- a/native/c/zutm.c
+++ b/native/c/zutm.c
@@ -616,18 +616,37 @@ int ZUTCVTD(const char *ptr, char *time)
   return rc;
 }
 
-typedef int (*IDCAMS)(void *) ATTRIBUTE(amode31);
-#pragma prolog(ZUTIDCAM, " ZWEPROLG NEWDSA=(YES,4) ")
+struct idcamsDdNameList
+{
+  unsigned short len;
+  char _unused[32];
+  char sysin[8];
+  char sysprint[8];
+};
+typedef int (*IDCAMS)(void *PTR32, void *PTR32) ATTRIBUTE(amode31);
+#pragma prolog(ZUTIDCAM, " ZWEPROLG NEWDSA=(YES,8) ")
 #pragma epilog(ZUTIDCAM, " ZWEEPILG ")
-int ZUTIDCAM(const char *parms)
+int ZUTIDCAM(const char *sysinDdName, const char *sysprintDdName)
 {
   int rc = 0;
 
-  PARMS p = {0};
-  p.len = sprintf(p.parms, "%.*s", (int)(sizeof(p.parms) - 1), parms);
+  unsigned short options = 0;
+  struct idcamsDdNameList ddnameList = {0};
+  ddnameList.len = sizeof(ddnameList._unused);
 
+  // DD name replacements should be padded with blanks
+  memset(ddnameList.sysin, ' ', sizeof(ddnameList.sysin));
+  memset(ddnameList.sysprint, ' ', sizeof(ddnameList.sysprint));
+  memcpy(ddnameList.sysin, sysinDdName,
+         strlen(sysinDdName) > sizeof(ddnameList.sysin) ? sizeof(ddnameList.sysin) : strlen(sysinDdName));
+  memcpy(ddnameList.sysprint, sysprintDdName,
+         strlen(sysprintDdName) > sizeof(ddnameList.sysprint) ? sizeof(ddnameList.sysprint) : strlen(sysprintDdName));
+
+  // IDCAMS must be entered in 31-bit mode. https://www.ibm.com/docs/en/zos/3.1.0?topic=commands-invoking-access-method-services-from-your-program
   IDCAMS idcams = (IDCAMS)load_module31("IDCAMS");
-  rc = idcams(&p);
+  // www.ibm.com/docs/en/zos/3.1.0?topic=instructions-load-call-macro
+  // ddnameList is the current last entry so set the high order bit to indicate the last
+  rc = idcams(&options, (void *PTR32)((unsigned int)(uintptr_t)&ddnameList | 0x80000000U));
   delete_module("IDCAMS");
 
   return rc;

--- a/native/c/zutm.c
+++ b/native/c/zutm.c
@@ -642,15 +642,16 @@ int ZUTIDCAM(const char *sysinDdName, const char *sysprintDdName)
   memcpy(ddNameList.sysprint, sysprintDdName,
          strlen(sysprintDdName) > sizeof(ddNameList.sysprint) ? sizeof(ddNameList.sysprint) : strlen(sysprintDdName));
 
+  char programName[8] = "IDCAMS";
   // IDCAMS must be entered in 31-bit mode. https://www.ibm.com/docs/en/zos/3.1.0?topic=commands-invoking-access-method-services-from-your-program
-  IDCAMS idcams = (IDCAMS)load_module31("IDCAMS");
+  IDCAMS idcams = (IDCAMS)load_module31(programName);
   // www.ibm.com/docs/en/zos/3.1.0?topic=instructions-load-call-macro
   // ddnameList is the current last entry so set the high order bit to indicate the last
   unsigned int parm_list[2];
   parm_list[0] = (unsigned int)(uintptr_t)&options;
   parm_list[1] = (unsigned int)(uintptr_t)&ddNameList | 0x80000000U;
   rc = idcams(parm_list[0], parm_list[1]);
-  delete_module("IDCAMS");
+  delete_module(programName);
 
   return rc;
 }

--- a/native/c/zutm.h
+++ b/native/c/zutm.h
@@ -153,7 +153,7 @@ extern "C"
   int ZUTEDSCT();
   int ZUTSYMBP(SYMBOL_DATA *);
   int ZUTSRCH(const char *);
-  int ZUTIDCAM(const char *);
+  int ZUTIDCAM(const char *, const char *);
   int ZUTRUN(ZDIAG *, const char *, const char *);
   void ZUTDBGMG(const char *);
   unsigned char ZUTMGKEY();

--- a/native/c/zutm.h
+++ b/native/c/zutm.h
@@ -153,6 +153,7 @@ extern "C"
   int ZUTEDSCT();
   int ZUTSYMBP(SYMBOL_DATA *);
   int ZUTSRCH(const char *);
+  int ZUTIDCAM(const char *);
   int ZUTRUN(ZDIAG *, const char *, const char *);
   void ZUTDBGMG(const char *);
   unsigned char ZUTMGKEY();

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Client code for "zowex-for-zowe-cli" are documented i
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes 
+
+- Added the `zssh files list alias` command to the CLI. [#1108](https://github.com/zowe/zowex/pull/1108)
+
 ## `0.8.0`
 
 - Added ESM (RACF or equivalent) certificate and key ring management to the `zssh system` command group over SSH: `zssh system keyring create|delete|list|list-rings|count` and `zssh system cert import|export|delete|show|connect|set-default|trust|rename|refresh`. [#1079](https://github.com/zowe/zowex/pull/1079)

--- a/packages/cli/src/list/List.definition.ts
+++ b/packages/cli/src/list/List.definition.ts
@@ -17,6 +17,7 @@ import { ListDataSetMembersDefinition } from "./data-set-members/DataSetMembers.
 import { ListJobsDefinition } from "./jobs/Jobs.definition";
 import { ListSpoolFilesDefinition } from "./spool-files/SpoolFiles.definition";
 import { ListUssFilesDefinition } from "./uss-files/UssFiles.definition";
+import { ListAliasDefinition } from "./alias/Alias.definition";
 
 const ListDefinition: ICommandDefinition = {
     name: "list",
@@ -25,6 +26,7 @@ const ListDefinition: ICommandDefinition = {
     description: "List data sets, data set members, uss files, jobs, spool files",
     type: "group",
     children: [
+        ListAliasDefinition,
         ListDataSetDefinition,
         ListDataSetMembersDefinition,
         ListUssFilesDefinition,

--- a/packages/cli/src/list/List.definition.ts
+++ b/packages/cli/src/list/List.definition.ts
@@ -12,12 +12,12 @@
 import type { ICommandDefinition } from "@zowe/imperative";
 import { SshSession } from "@zowe/zos-uss-for-zowe-sdk";
 import { Constants } from "../Constants";
+import { ListAliasDefinition } from "./alias/Alias.definition";
 import { ListDataSetDefinition } from "./data-set/DataSet.definition";
 import { ListDataSetMembersDefinition } from "./data-set-members/DataSetMembers.definition";
 import { ListJobsDefinition } from "./jobs/Jobs.definition";
 import { ListSpoolFilesDefinition } from "./spool-files/SpoolFiles.definition";
 import { ListUssFilesDefinition } from "./uss-files/UssFiles.definition";
-import { ListAliasDefinition } from "./alias/Alias.definition";
 
 const ListDefinition: ICommandDefinition = {
     name: "list",

--- a/packages/cli/src/list/alias/Alias.definition.ts
+++ b/packages/cli/src/list/alias/Alias.definition.ts
@@ -1,0 +1,39 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import type { ICommandDefinition } from "@zowe/imperative";
+
+export const ListAliasDefinition: ICommandDefinition = {
+    handler: `${__dirname}/Alias.handler`,
+    type: "command",
+    name: "alias",
+    aliases: ["a"],
+    summary: "Resolve a data set alias",
+    description:
+        "Resolve a data set alias to find the target data set it points to. " +
+        "Uses IDCAMS LISTCAT to look up the alias in the catalog and return the associated data set name.",
+    examples: [
+        {
+            description: `Resolve the alias "SHARE.ALIAS.NAME" to find its target data set`,
+            options: `"SHARE.ALIAS.NAME"`,
+        },
+    ],
+    positionals: [
+        {
+            name: "aliasName",
+            description: "The name of the data set alias that you want to resolve",
+            type: "string",
+            required: true,
+        },
+    ],
+    options: [],
+    profile: { optional: ["ssh"] },
+};

--- a/packages/cli/src/list/alias/Alias.handler.ts
+++ b/packages/cli/src/list/alias/Alias.handler.ts
@@ -1,0 +1,36 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { type IHandlerParameters, ImperativeError, TextUtils } from "@zowe/imperative";
+import type { ds, ZSshClient } from "@zowe/zowex-for-zowe-sdk";
+import { SshBaseHandler } from "../../SshBaseHandler";
+
+export default class ListAliasHandler extends SshBaseHandler {
+    public async processWithClient(params: IHandlerParameters, client: ZSshClient): Promise<ds.ResolveDsAliasResponse> {
+        let response: ds.ResolveDsAliasResponse;
+        try {
+            response = await client.ds.resolveDsAlias({
+                dsname: params.arguments.aliasName,
+            });
+        } catch (err) {
+            const errText = err.toString().replace("Error: ", "");
+            params.response.data.setExitCode(1);
+            params.response.console.errorHeader(TextUtils.chalk.red("Response from Service"));
+            params.response.console.error(errText);
+            params.response.data.setMessage(errText);
+            return { success: false, targetDsn: undefined };
+        }
+        const msg = `Alias '${params.arguments.aliasName}' resolved to data set '${response.targetDsn}'.`;
+        params.response.data.setMessage(msg);
+        params.response.console.log(msg);
+        return response;
+    }
+}

--- a/packages/cli/src/list/alias/Alias.handler.ts
+++ b/packages/cli/src/list/alias/Alias.handler.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { type IHandlerParameters, ImperativeError, TextUtils } from "@zowe/imperative";
+import { type IHandlerParameters, TextUtils } from "@zowe/imperative";
 import type { ds, ZSshClient } from "@zowe/zowex-for-zowe-sdk";
 import { SshBaseHandler } from "../../SshBaseHandler";
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Client code for "@zowe/zowex-for-zowe-sdk" are docume
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Recent Changes 
+
+- Added support for the `resolveDsAlias` RPC command. [#1108](https://github.com/zowe/zowex/pull/1108)
+
 ## `0.9.0`
 
 - Enable console commands through JSON-RPC. [#1112](https://github.com/zowe/zowex/pull/1110)

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes 
 
-- Added support for the `resolveDsAlias` RPC command. [#1108](https://github.com/zowe/zowex/pull/1108)
+- Added support for the `resolveDsAlias` RPC command which allows the caller to resolve data set aliases. [#1108](https://github.com/zowe/zowex/pull/1108)
 
 ## `0.9.0`
 

--- a/packages/sdk/src/RpcClientApi.ts
+++ b/packages/sdk/src/RpcClientApi.ts
@@ -84,6 +84,7 @@ export abstract class RpcClientApi implements IRpcClient {
         listDatasets: this.rpc<ds.ListDatasetsRequest, ds.ListDatasetsResponse>("listDatasets"),
         listDsMembers: this.rpc<ds.ListDsMembersRequest, ds.ListDsMembersResponse>("listDsMembers"),
         readDataset: this.rpc<ds.ReadDatasetRequest, ds.ReadDatasetResponse>("readDataset"),
+        resolveDsAlias: this.rpc<ds.ResolveDsAliasRequest, ds.ResolveDsAliasResponse>("resolveDsAlias"),
         restoreDataset: this.rpc<ds.RestoreDatasetRequest, ds.RestoreDatasetResponse>("restoreDataset"),
         writeDataset: this.rpc<ds.WriteDatasetRequest, ds.WriteDatasetResponse>("writeDataset"),
         renameDataset: this.rpc<ds.RenameDatasetRequest, ds.RenameDatasetResponse>("renameDataset"),

--- a/packages/sdk/src/ZSshConstants.ts
+++ b/packages/sdk/src/ZSshConstants.ts
@@ -10,4 +10,4 @@
  */
 
 // Generated via generateConstants.ts
-export const BUNDLED_SSH_SERVER_VERSION = "0.8.1";
+export const BUNDLED_SSH_SERVER_VERSION = "0.9.0";

--- a/packages/sdk/src/ZSshConstants.ts
+++ b/packages/sdk/src/ZSshConstants.ts
@@ -10,4 +10,4 @@
  */
 
 // Generated via generateConstants.ts
-export const BUNDLED_SSH_SERVER_VERSION = "0.8.0";
+export const BUNDLED_SSH_SERVER_VERSION = "0.8.1";

--- a/packages/sdk/src/doc/rpc/ds.ts
+++ b/packages/sdk/src/doc/rpc/ds.ts
@@ -139,6 +139,19 @@ export interface ListDsMembersResponse extends common.CommandResponse {
     returnedRows: number;
 }
 
+export interface ResolveDsAliasRequest extends common.CommandRequest<"resolveDsAlias"> {
+    /**
+     * Dataset name
+     */
+    dsname: string;
+}
+export interface ResolveDsAliasResponse extends common.CommandResponse {
+    /**
+     *  The original data set name pointed to by the alias.
+     */
+    targetDsn: string;
+}
+
 export interface ReadDatasetRequest extends common.CommandRequest<"readDataset">, common.WritableStreamRpc {
     /**
      * Desired encoding for the dataset (optional)

--- a/packages/sdk/tests/RpcClientApi.test.ts
+++ b/packages/sdk/tests/RpcClientApi.test.ts
@@ -109,6 +109,12 @@ describe("RpcClientApi", () => {
             fromName: "FROM.NAME",
             toName: "TO.NAME",
         });
+
+        await client.ds.resolveDsAlias({ dsname: "MY.ALIAS" });
+        expect(client.request).toHaveBeenCalledWith({
+            command: "resolveDsAlias",
+            dsname: "MY.ALIAS",
+        });
     });
 
     it("should route jobs commands correctly", async () => {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Add `zowex ds resolve-alias( or ra) my.alias.name `command
```

CHRIS@system  $ ./.zowe-server/zowex ds ra chris.goblin
Could not determine the target data set for the specified alias. Ensure the alias exists and is cataloged.
CHRIS@system  $ ./.zowe-server/zowex ds ra chris.test.jcl.alias
Alias 'CHRIS.TEST.JCL.ALIAS' resolved to data set 'CHRIS.PUBLIC.CNTL'
```

Replace batch jobs for IDCAMS in tests with `zds_idcams` utility calls 
Adds zowex CLI plugin command: 
```
$ zowe zowex list alias chris.test.jcl.alias
Alias 'chris.test.jcl.alias' resolved to data set 'CHRIS.PUBLIC.CNTL'.
```

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
